### PR TITLE
Fix example README commands

### DIFF
--- a/examples/nip44/README.md
+++ b/examples/nip44/README.md
@@ -64,7 +64,7 @@ npm run example:nip44
 npm run example:nip44:version-compat
 
 # Run the test vector verification
-npm run example:nip44:run-vectors
+npm run example:nip44:test-vector
 ```
 
 ## Key Concepts

--- a/examples/nip47/README.md
+++ b/examples/nip47/README.md
@@ -15,7 +15,7 @@ The [basic-client-service.ts](./basic-client-service.ts) demonstrates:
 Run it with:
 
 ```bash
-npm run example:nip47:basic
+npm run example:nip47:client-service
 ```
 
 ### Error Handling and Retry Example
@@ -30,7 +30,7 @@ The [error-handling-example.ts](./error-handling-example.ts) demonstrates:
 Run it with:
 
 ```bash
-npm run example:nip47:errors
+npm run example:nip47:error-handling
 ```
 
 ### Request Expiration Example
@@ -46,31 +46,6 @@ Run it with:
 npm run example:nip47:expiration
 ```
 
-### Notifications Example
-
-The [notifications-example.ts](./notifications-example.ts) demonstrates:
-- Setting up notification subscriptions
-- Handling payment received/sent notifications
-- Custom notification handling
-
-Run it with:
-
-```bash
-npm run example:nip47:notifications
-```
-
-### Custom Wallet Implementation
-
-The [custom-wallet-implementation.ts](./custom-wallet-implementation.ts) demonstrates:
-- Creating a custom wallet implementation
-- Connecting to an external Lightning node/wallet
-- Advanced configuration options
-
-Run it with:
-
-```bash
-npm run example:nip47:custom
-```
 
 ## What is NIP-47?
 


### PR DESCRIPTION
## Summary
- correct command for NIP‑44 test vectors
- update NIP‑47 README to match available scripts and remove references to missing examples

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68407bb0875c8330afdfe9f5b9383e65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated example run commands in the README files for NIP-44 and NIP-47.
  - Removed sections describing the Notifications Example and Custom Wallet Implementation Example from the NIP-47 README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->