### PR TITLE
Update NIP-07 comment

### DIFF
--- a/src/nip07/adapter.ts
+++ b/src/nip07/adapter.ts
@@ -165,7 +165,7 @@ export class Nip07Nostr extends Nostr {
       throw new Error("Event is not a direct message (kind 4)");
     }
 
-    // Return a Promise.then pattern that resolves synchronously
+    // Synchronous decryption isn't supported with NIP-07; an error will be thrown
     try {
       // In a direct message, we need to return a string, not a Promise
       // However, the NIP-07 extension functions are async


### PR DESCRIPTION
## Summary
- clarify that direct message decryption cannot be done synchronously using NIP-07

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840779e84b48330b3a429e8c2c3f028