### PR TITLE
Handle purge interval cleanup

### DIFF
--- a/src/utils/ephemeral-relay.ts
+++ b/src/utils/ephemeral-relay.ts
@@ -44,6 +44,7 @@ export class NostrRelay {
   private _wss: WebSocketServer | null;
   private _cache: SignedEvent[];
   private _isClosing: boolean = false;
+  private _purgeTimer: NodeJS.Timeout | null = null;
 
   public conn: number;
 
@@ -99,7 +100,7 @@ export class NostrRelay {
             console.log(
               `[ relay ] purging events every ${this._purge} seconds`,
             );
-          setInterval(() => {
+          this._purgeTimer = setInterval(() => {
             this._cache = [];
           }, this._purge * 1000);
         }
@@ -128,6 +129,11 @@ export class NostrRelay {
 
       // Clear any listeners on the emitter
       this._emitter.removeAllListeners();
+
+      if (this._purgeTimer) {
+        clearInterval(this._purgeTimer);
+        this._purgeTimer = null;
+      }
 
       if (this._wss) {
         // Clean up clients first


### PR DESCRIPTION
## Summary
- store purge interval handle `_purgeTimer`
- clear interval in `close()` and reset handle

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840779b7ebc8330b483406b4192ffbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of background processes to ensure smoother shutdown of the relay server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->