### PR TITLE
Remove outdated NIP‑33 references

### DIFF
--- a/src/types/README.md
+++ b/src/types/README.md
@@ -140,7 +140,7 @@ function processEvent(event: NostrEvent) {
     console.log('This is a replaceable event');
   }
   
-  // Process parameterized replaceable events (NIP-33)
+  // Process addressable events (NIP-01 parameterized replaceable events)
   if (event.kind >= 30000 && event.kind < 40000) {
     const dTag = event.tags.find(tag => tag[0] === 'd')?.[1] || '';
     console.log(`Addressable event with d tag value: ${dTag}`);
@@ -455,9 +455,8 @@ declare module '../types/nostr' {
 
 The types in this directory implement these NIPs:
 
-- **[NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)**: Basic protocol flow and event format
+- **[NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)**: Basic protocol flow and event format, including parameterized replaceable events
 - **[NIP-11](https://github.com/nostr-protocol/nips/blob/master/11.md)**: Relay information document
 - **[NIP-16](https://github.com/nostr-protocol/nips/blob/master/16.md)**: Ephemeral events
-- **[NIP-33](https://github.com/nostr-protocol/nips/blob/master/33.md)**: Parameterized replaceable events
 - **[NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md)**: Authentication of clients to relays 
 - **[NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md)**: Search capability 

--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -50,7 +50,7 @@ export type NostrFilter = {
   "#e"?: string[];
   /** Filter by p tags (pubkey references) */
   "#p"?: string[];
-  /** Filter by a tags (address references NIP-33) */
+  /** Filter by a tags for addressable events (NIP-01) */
   "#a"?: string[];
   /** Filter by d tags (for replaceable events) */
   "#d"?: string[];
@@ -767,7 +767,7 @@ export type TagValues = {
   e: string[];
   /** Public key reference */
   p: string[];
-  /** Address (NIP-33) */
+  /** Address for parameterized replaceable events (NIP-01) */
   a: string[];
   /** Identifier (replaceable events) */
   d: string[];

--- a/tests/nip01/relay/filters.test.ts
+++ b/tests/nip01/relay/filters.test.ts
@@ -69,7 +69,7 @@ describe("Enhanced NostrFilter Types", () => {
         kinds: [NostrKind.ShortNote],
         "#e": ["event1", "event2"], // event references
         "#p": ["pubkey1", "pubkey2"], // pubkey references
-        "#a": ["address1", "address2"], // address references (NIP-33)
+        "#a": ["address1", "address2"], // address references for addressable events (NIP-01)
         "#d": ["d-tag1", "d-tag2"], // d-tag for replaceable events
         "#t": ["topic1", "topic2"], // topics/hashtags
         "#r": ["reference1", "reference2"], // references/URLs


### PR DESCRIPTION
## Summary
- drop references to NIP-33
- note that addressable events are part of NIP-01 now
- update filters test comments

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684110ecb0e083309d8636927d6dd1fe