### PR TITLE
Fix README discrepancies

### DIFF
--- a/examples/nip04/README.md
+++ b/examples/nip04/README.md
@@ -6,9 +6,9 @@ This directory contains examples demonstrating how to use NIP-04 encrypted direc
 
 [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md) defines a protocol for encrypted direct messages in Nostr. It uses ECDH (Elliptic Curve Diffie-Hellman) to create a shared secret between sender and recipient, then encrypts the message with AES-256-CBC.
 
-**Implementation Details**:
-- Uses HMAC-SHA256 with the key "nip04" for shared secret derivation
-- Ensures compatibility with nip04 spec compliant nostr libraries and clients
+-**Implementation Details**:
+- Uses ECDH to derive a 32-byte shared secret
+- Ensures compatibility with NIP-04 compliant Nostr libraries and clients
 - Provides robust validation of message format and proper error handling
 
 **Note**: NIP-04 is considered less secure than NIP-44 and has been marked as "unrecommended" in favor of NIP-44. It's provided here for compatibility with older clients.
@@ -36,7 +36,7 @@ npm run example:nip04
 ## Key Concepts
 
 - **Shared Secret Generation**: Both parties can independently derive the same shared secret using ECDH
-- **Shared Secret Processing**: The X coordinate is extracted from the shared point and processed with HMAC-SHA256
+- **Shared Secret Processing**: The X coordinate is used directly as the encryption key
 - **Message Encryption/Decryption**: Using AES-256-CBC with the derived shared secret
 - **Key Exchange**: No direct key exchange is needed; only public keys are shared
 - **Cross-Platform Compatibility**: Uses Web Crypto API which works in both browsers and Node.js

--- a/examples/nip46/README.md
+++ b/examples/nip46/README.md
@@ -21,7 +21,7 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for diagrams and a visual explanation o
 A single comprehensive example that shows the core functionality:
 
 ```bash
-npm run example:nip46:unified
+npm run example:nip46
 ```
 
 Key features demonstrated:

--- a/src/nip01/README.md
+++ b/src/nip01/README.md
@@ -6,7 +6,7 @@ This directory contains the implementation of [NIP-01](https://github.com/nostr-
 
 NIP-01 is the foundational specification for Nostr, outlining the basic protocol flow, event format, relay communication, and subscription mechanism. This implementation provides a complete client and relay interface with comprehensive validation for Nostr events.
 
-## Key Components
+## Key Features
 
 - ✅ **Event Creation and Validation**: Full support for creating, signing, and validating Nostr events
 - ✅ **Relay Communication**: WebSocket-based connection management with automatic reconnection

--- a/src/nip02/README.md
+++ b/src/nip02/README.md
@@ -2,6 +2,12 @@
 
 This directory contains the implementation for NIP-02, which defines a format for users to publish their contact list (follows) as a Nostr event of kind 3. Each contact in the list can include the user's public key, a recommended relay URL, and a petname for that user.
 
+## Overview
+
+NIP-02 events allow users to share and update contact lists. This module
+provides helper functions for creating and parsing these events while
+supporting optional relay URLs and petnames for each contact.
+
 ## Key Features
 
 - Defines a `Contact` interface: `{ pubkey: string; relayUrl?: string; petname?: string; }`.

--- a/src/nip04/README.md
+++ b/src/nip04/README.md
@@ -81,7 +81,7 @@ Common validation errors include:
 - `'Invalid encrypted message: IV is not valid base64'`
 - `'Invalid IV length: expected 16 bytes, got X'`
 
-## Usage
+## Basic Usage
 
 ### Basic Encryption and Decryption
 

--- a/src/nip44/README.md
+++ b/src/nip44/README.md
@@ -1,4 +1,4 @@
-# NIP-44 Encryption Implementation
+# NIP-44: Encryption Implementation
 
 This is an implementation of [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md), which defines a new encryption scheme for Nostr direct messages.
 
@@ -14,7 +14,7 @@ NIP-44 replaces the older NIP-04 encryption with a more secure approach using Ch
 - Secure nonce handling with 32-byte nonces
 - **Full version compatibility** supporting decryption of v0, v1, and v2 messages
 
-## Usage
+## Basic Usage
 
 ```typescript
 import { 

--- a/src/nip46/README.md
+++ b/src/nip46/README.md
@@ -90,7 +90,7 @@ Permissions control what operations a client can perform. They are defined in th
 - `nip44_decrypt`: Allow NIP-44 decryption
 - `ping`: Allow ping functionality
 
-## Usage Examples
+## Basic Usage
 
 ### Simple Client Example
 

--- a/src/nip47/README.md
+++ b/src/nip47/README.md
@@ -10,7 +10,7 @@ Nostr Wallet Connect (NWC) provides a secure way for applications to interact wi
 2. **Service Implementation** - For wallet services that need to respond to client requests
 3. **Utility Functions** - For connection string generation and parsing
 
-## Key Components
+## Key Features
 
 - `NostrWalletConnectClient`: The client-side implementation, used by applications to connect to a remote wallet service.
 - `NostrWalletService`: The server-side implementation, used by wallet providers to implement the NWC protocol.

--- a/tests/nip04/README.md
+++ b/tests/nip04/README.md
@@ -5,7 +5,7 @@ This directory contains tests for the NIP-04 (Encrypted Direct Messages) impleme
 ## Test Coverage
 
 - ✅ Encryption/decryption functionality
-- ✅ Shared secret derivation (using HMAC-SHA256)
+- ✅ ECDH shared secret derivation
 - ✅ Format validation (`<ciphertext>?iv=<initialization_vector>`)
 - ✅ Cross-compatibility with other implementations
 - ✅ Error handling for invalid inputs
@@ -26,10 +26,10 @@ npx jest tests/nip04/encryption.test.ts
 
 ## Implementation Notes
 
-While NIP-04 is now considered "unrecommended" in favor of NIP-44, these tests ensure compatibility with existing clients and messages. The implementation includes specific compatibility with nip04 spec compliant libraries and clients by:
+While NIP-04 is now considered "unrecommended" in favor of NIP-44, these tests ensure compatibility with existing clients and messages. The implementation includes specific compatibility with NIP-04 compliant libraries and clients by:
 
-- Using HMAC-SHA256 with the key "nip04" for shared secret derivation
-- Following the same approach to key handling as nip04 spec compliant libraries and clients
+- Using ECDH to derive the shared secret
+- Following the same approach to key handling as NIP-04 compliant libraries and clients
 - Including specific compatibility test cases
 
 ## Security Considerations

--- a/tests/nip44/README.md
+++ b/tests/nip44/README.md
@@ -26,6 +26,7 @@ npx jest tests/nip44/nip44-vectors.test.ts
 - `nip44-compatibility.test.ts`: Tests for compatibility between platforms and implementations
 - `nip44-official-vectors.test.ts`: Tests using the official NIP-44 test vectors
 - `nip44-padding-hmac.test.ts`: Tests for message padding and HMAC authentication
+- `nip44-format-validation.test.ts`: Tests for validating public and private key formats
 - `nip44-vectors.test.ts`: Additional test vectors for comprehensive testing
 
 ## Test Vectors

--- a/tests/nip47/README.md
+++ b/tests/nip47/README.md
@@ -37,13 +37,13 @@ Recent improvements to error handling include:
 To run all NIP-47 tests:
 
 ```bash
-npm test -- tests/nip47
+npm run test:nip47
 ```
 
 To run a specific test file:
 
 ```bash
-npm test -- tests/nip47/error-handling.test.ts
+npx jest tests/nip47/error-handling.test.ts
 ```
 
 ## Related Code


### PR DESCRIPTION
## Summary
- correct NIP-04 example details to reflect ECDH usage
- update NIP-46 instructions for running unified example

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684111827af48330a7eb6817706e1920