### PR TITLE
Add NIP-65 relay list support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ SNSTR is a lightweight TypeScript library for interacting with the Nostr protoco
 - Remote signing capability via NIP-46
 - Lightning Zaps integration via NIP-57
 - Wallet connection via NIP-47
+- Relay list metadata via NIP-65
 - Built-in ephemeral relay for testing and development
 
 ## Supported NIPs
@@ -56,6 +57,7 @@ SNSTR currently implements the following Nostr Implementation Possibilities (NIP
 - **NIP-46**: Remote signing (bunker) support for secure key management
 - **NIP-57**: Lightning Zaps protocol for Bitcoin payments via Lightning
 - **NIP-47**: Nostr Wallet Connect for secure wallet communication
+- **NIP-65**: Relay List metadata for read/write relay preferences
 
 For detailed information on each implementation, see the corresponding directories in the `src/` directory (e.g., `src/nip01/`, `src/nip04/`, etc.).
 
@@ -166,6 +168,7 @@ npm run example:nip44  # Versioned encryption
 npm run example:nip17  # Gift wrapped direct messages
 npm run example:nip46  # Remote signing protocol
 npm run example:nip57  # Lightning Zaps
+npm run example:nip65  # Relay list metadata
 ```
 
 For a full list of examples and detailed descriptions, see the [examples README](./examples/README.md).
@@ -249,6 +252,7 @@ npm run test:nip17         # NIP-17 (Direct Messages)
 npm run test:nip46         # NIP-46 (Remote Signing)
 npm run test:nip47         # NIP-47 (Wallet Connect)
 npm run test:nip57         # NIP-57 (Lightning Zaps)
+npm run test:nip65         # NIP-65 (Relay List Metadata)
 ```
 
 ### Example Scripts
@@ -293,6 +297,7 @@ npm run example:nip17      # Gift wrapped direct messages (NIP-17)
 npm run example:nip46      # Remote signing protocol (NIP-46)
 npm run example:nip47      # Wallet connect (NIP-47)
 npm run example:nip57      # Lightning zaps (NIP-57)
+npm run example:nip65      # Relay list metadata (NIP-65)
 ```
 
 ### Code Quality Scripts

--- a/examples/README.md
+++ b/examples/README.md
@@ -104,6 +104,14 @@ npm run example:nip57:lnurl    # LNURL server simulation
 npm run example:nip57:validation # Invoice validation example
 ```
 
+## NIP-65 Examples
+
+For [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) (Relay List Metadata):
+
+```bash
+npm run example:nip65          # Relay list metadata demo
+```
+
 ## Example Categories
 
 You can also run example groups:

--- a/examples/nip65/README.md
+++ b/examples/nip65/README.md
@@ -1,0 +1,9 @@
+# NIP-65 Example
+
+This example demonstrates how to create and parse relay list metadata events as defined in [NIP‑65](https://github.com/nostr-protocol/nips/blob/master/65.md).
+
+Run with:
+
+```bash
+npm run example:nip65
+```

--- a/examples/nip65/nip65-demo.ts
+++ b/examples/nip65/nip65-demo.ts
@@ -1,0 +1,35 @@
+import {
+  createRelayListEvent,
+  parseRelayList,
+  getReadRelays,
+  getWriteRelays,
+  RelayListEvent,
+} from "../../src/nip65";
+import { generateKeypair } from "../../src/utils/crypto";
+import { createSignedEvent } from "../../src/nip01/event";
+
+async function main() {
+  const keys = await generateKeypair();
+
+  const template = createRelayListEvent([
+    { url: "wss://relay1.example.com", read: true, write: true },
+    { url: "wss://read.example.com", read: true, write: false },
+    { url: "wss://write.example.com", read: false, write: true },
+  ]);
+
+  const unsigned = { ...template, pubkey: keys.publicKey };
+  const event = (await createSignedEvent(
+    unsigned,
+    keys.privateKey,
+  )) as RelayListEvent;
+
+  console.log("Relay list event", event);
+  const entries = parseRelayList(event);
+  console.log("Read relays:", getReadRelays(entries));
+  console.log("Write relays:", getWriteRelays(entries));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:nip46": "jest tests/nip46",
     "test:nip47": "jest tests/nip47",
     "test:nip57": "jest tests/nip57",
+    "test:nip65": "jest tests/nip65",
     "test:nip17": "jest tests/nip17",
 
     "// Test Groups": "-------------- Test Category Groups --------------",
@@ -104,6 +105,7 @@
     "example:nip47:error-handling": "ts-node examples/nip47/error-handling-example.ts",
     "example:nip47:expiration": "ts-node examples/nip47/request-expiration-example.ts",
     "example:nip57": "ts-node examples/nip57/basic-example.ts",
+    "example:nip65": "ts-node examples/nip65/nip65-demo.ts",
     "example:nip57:client": "ts-node examples/nip57/zap-client-example.ts",
     "example:nip57:lnurl": "ts-node examples/nip57/lnurl-server-simulation.ts",
     "example:nip57:validation": "ts-node examples/nip57/invoice-validation-example.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,3 +208,6 @@ export {
   NIP47ConnectionOptions,
   TransactionType,
 } from "./nip47";
+
+// NIP-65: Relay List Metadata
+export { createRelayListEvent, parseRelayList, getReadRelays, getWriteRelays, RELAY_LIST_KIND, RelayListEntry, RelayListEvent } from "./nip65";

--- a/src/nip19/index.ts
+++ b/src/nip19/index.ts
@@ -32,7 +32,7 @@ const MAX_TLV_ENTRIES = 20; // Max number of TLV entries to prevent DoS (reduced
  * Relay URLs must start with wss:// or ws:// and contain a valid hostname
  * No credentials are allowed in URLs
  */
-function validateRelayUrl(url: string): boolean {
+export function validateRelayUrl(url: string): boolean {
   try {
     if (!url.startsWith("wss://") && !url.startsWith("ws://")) {
       return false;

--- a/src/nip65/README.md
+++ b/src/nip65/README.md
@@ -1,0 +1,59 @@
+# NIP-65: Relay List Metadata
+
+This module implements [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md), which defines a replaceable event of kind `10002` for advertising the relays a user typically **reads** from and **writes** to.
+
+## Overview
+
+NIP‑65 events contain `r` tags with relay URLs.  Each tag may optionally include a `read` or `write` marker.  If the marker is omitted the relay is used for both reading and writing.
+
+```jsonc
+{
+  "kind": 10002,
+  "tags": [
+    ["r", "wss://relay.example.com"],            // read & write
+    ["r", "wss://read.example.com", "read"],    // read only
+    ["r", "wss://write.example.com", "write"]   // write only
+  ],
+  "content": ""
+}
+```
+
+## API
+
+### `createRelayListEvent(relays, content?)`
+Returns an unsigned event template ready to be signed.  Relay entries are specified using:
+
+```ts
+interface RelayListEntry {
+  url: string;   // relay URL
+  read: boolean; // read capability
+  write: boolean;// write capability
+}
+```
+
+### `parseRelayList(event)`
+Parses a signed or unsigned relay list event and returns an array of `RelayListEntry` objects.
+
+### `getReadRelays(input)` / `getWriteRelays(input)`
+Convenience helpers that extract just the relay URLs intended for reading or writing.  `input` can be either a `RelayListEvent` or the array returned by `parseRelayList`.
+
+## Usage Example
+
+```ts
+import { createRelayListEvent, parseRelayList, getReadRelays } from "snstr/nip65";
+import { createSignedEvent } from "snstr/nip01/event";
+import { generateKeypair } from "snstr/utils/crypto";
+
+(async () => {
+  const keys = await generateKeypair();
+  const template = createRelayListEvent([
+    { url: "wss://relay1.example.com", read: true, write: true },
+    { url: "wss://relay2.example.com", write: true, read: false },
+  ]);
+  const unsigned = { ...template, pubkey: keys.publicKey };
+  const event = await createSignedEvent(unsigned, keys.privateKey);
+
+  const entries = parseRelayList(event);
+  console.log("read relays", getReadRelays(entries));
+})();
+```

--- a/src/nip65/index.ts
+++ b/src/nip65/index.ts
@@ -1,4 +1,5 @@
 import { NostrEvent } from "../types/nostr";
+import { validateRelayUrl } from "../nip19/index";
 
 /** Relay list entry describing read/write preferences */
 export interface RelayListEntry {
@@ -30,8 +31,15 @@ export function createRelayListEvent(
   const tags: string[][] = [];
 
   for (const r of relays) {
-    // skip entries without a URL
-    if (!r.url) continue;
+    // skip entries with missing or invalid URL
+    if (!r.url || !validateRelayUrl(r.url)) {
+      if (!r.url) {
+        console.warn("Skipping relay entry with missing URL", r);
+      } else {
+        console.warn(`Skipping relay entry with invalid URL: ${r.url}`, r);
+      }
+      continue;
+    }
     let marker: string | undefined;
     const read = r.read !== false; // default to true if undefined
     const write = r.write !== false;

--- a/src/nip65/index.ts
+++ b/src/nip65/index.ts
@@ -1,0 +1,83 @@
+import { NostrEvent } from "../types/nostr";
+
+/** Relay list entry describing read/write preferences */
+export interface RelayListEntry {
+  /** Relay URL */
+  url: string;
+  /** Whether the user reads from this relay */
+  read: boolean;
+  /** Whether the user writes to this relay */
+  write: boolean;
+}
+
+/** Kind constant for NIP-65 relay list metadata */
+export const RELAY_LIST_KIND = 10002;
+
+export interface RelayListEvent extends NostrEvent {
+  kind: typeof RELAY_LIST_KIND;
+}
+
+/**
+ * Create an unsigned relay list event (kind 10002) according to NIP-65.
+ *
+ * @param relays Array of relay list entries
+ * @param content Optional content field (usually empty)
+ */
+export function createRelayListEvent(
+  relays: RelayListEntry[],
+  content = "",
+): Omit<RelayListEvent, "id" | "sig" | "pubkey"> {
+  const tags: string[][] = [];
+
+  for (const r of relays) {
+    // skip entries without a URL
+    if (!r.url) continue;
+    let marker: string | undefined;
+    const read = r.read !== false; // default to true if undefined
+    const write = r.write !== false;
+
+    if (read && !write) marker = "read";
+    else if (write && !read) marker = "write";
+
+    if (marker) tags.push(["r", r.url, marker]);
+    else if (read || write) tags.push(["r", r.url]);
+  }
+
+  return {
+    kind: RELAY_LIST_KIND,
+    tags,
+    content,
+    created_at: Math.floor(Date.now() / 1000),
+  };
+}
+
+/**
+ * Parse relay list entries from a NIP-65 event.
+ */
+export function parseRelayList(event: RelayListEvent): RelayListEntry[] {
+  if (event.kind !== RELAY_LIST_KIND) {
+    throw new Error("Invalid relay list event kind");
+  }
+  const result: RelayListEntry[] = [];
+  for (const tag of event.tags) {
+    if (tag[0] === "r" && tag[1]) {
+      const marker = tag[2];
+      if (marker === "read") result.push({ url: tag[1], read: true, write: false });
+      else if (marker === "write") result.push({ url: tag[1], read: false, write: true });
+      else result.push({ url: tag[1], read: true, write: true });
+    }
+  }
+  return result;
+}
+
+/** Get relay URLs marked for writing */
+export function getWriteRelays(input: RelayListEntry[] | RelayListEvent): string[] {
+  const entries = Array.isArray(input) ? input : parseRelayList(input);
+  return entries.filter((e) => e.write).map((e) => e.url);
+}
+
+/** Get relay URLs marked for reading */
+export function getReadRelays(input: RelayListEntry[] | RelayListEvent): string[] {
+  const entries = Array.isArray(input) ? input : parseRelayList(input);
+  return entries.filter((e) => e.read).map((e) => e.url);
+}

--- a/src/nip65/index.ts
+++ b/src/nip65/index.ts
@@ -41,8 +41,8 @@ export function createRelayListEvent(
       continue;
     }
     let marker: string | undefined;
-    const read = r.read !== false; // default to true if undefined
-    const write = r.write !== false;
+    const read = r.read ?? true;  // default to true if undefined
+    const write = r.write ?? true; // default to true if undefined
 
     if (read && !write) marker = "read";
     else if (write && !read) marker = "write";

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,6 +48,8 @@ Tests are organized into directories by NIP number, with subdirectories for spec
     - `error-handling.test.ts` - Error handling tests
   - `/nip57` - Tests for NIP-57 (Lightning Zaps)
     - `zap.test.ts` - Zap functionality tests
+  - `/nip65` - Tests for NIP-65 (Relay List Metadata)
+    - `nip65.test.ts` - Relay list parsing and creation
 
 - **Other Directories**:
   - `/types` - Type definitions and helpers for testing
@@ -78,6 +80,7 @@ npm run test:nip44       # Run NIP-44 tests
 npm run test:nip46       # Run NIP-46 tests
 npm run test:nip47       # Run NIP-47 tests
 npm run test:nip57       # Run NIP-57 tests
+npm run test:nip65       # Run NIP-65 tests
 ```
 
 For NIP-01 components specifically:

--- a/tests/nip65/README.md
+++ b/tests/nip65/README.md
@@ -1,0 +1,3 @@
+# NIP-65 Tests
+
+This directory contains unit tests for the Relay List Metadata implementation.

--- a/tests/nip65/nip65.test.ts
+++ b/tests/nip65/nip65.test.ts
@@ -1,0 +1,36 @@
+import { createRelayListEvent, parseRelayList, getReadRelays, getWriteRelays, RelayListEvent } from "../../src/nip65";
+import { generateKeypair } from "../../src/utils/crypto";
+import { createSignedEvent } from "../../src/nip01/event";
+
+describe("NIP-65", () => {
+  test("createRelayListEvent builds correct tags", () => {
+    const template = createRelayListEvent([
+      { url: "wss://a", read: true, write: true },
+      { url: "wss://b", read: false, write: true },
+      { url: "wss://c", read: true, write: false },
+    ]);
+
+    expect(template.kind).toBe(10002);
+    expect(template.tags).toEqual([
+      ["r", "wss://a"],
+      ["r", "wss://b", "write"],
+      ["r", "wss://c", "read"],
+    ]);
+  });
+
+  test("parseRelayList and helper getters", async () => {
+    const entries = [
+      { url: "wss://a", read: true, write: true },
+      { url: "wss://b", read: false, write: true },
+      { url: "wss://c", read: true, write: false },
+    ];
+    const keys = await generateKeypair();
+    const unsigned = { ...createRelayListEvent(entries), pubkey: keys.publicKey };
+    const event = (await createSignedEvent(unsigned, keys.privateKey)) as RelayListEvent;
+
+    const parsed = parseRelayList(event);
+    expect(parsed).toEqual(entries);
+    expect(getWriteRelays(parsed)).toEqual(["wss://a", "wss://b"]);
+    expect(getReadRelays(parsed)).toEqual(["wss://a", "wss://c"]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement NIP‑65 relay list metadata with helpers
- add example and tests for NIP‑65
- document NIP‑65 usage and scripts
- export new helpers from main package
- fix example types

## Testing
- `npm run lint`
- `npm run build`
- `npx jest tests/nip65/nip65.test.ts`
- `npm run example:nip65`


------
https://chatgpt.com/codex/tasks/task_e_6841b23adbdc8330bdb423f9d73094d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for NIP-65 (Relay List Metadata), allowing creation, parsing, and extraction of relay list events with read/write preferences.
  - Added utility functions to easily obtain read and write relay URLs from relay list events.

- **Documentation**
  - Updated and added documentation to cover NIP-65 features, usage examples, and test instructions.

- **Tests**
  - Added comprehensive unit tests for NIP-65 relay list event creation, parsing, and relay extraction.

- **Chores**
  - Integrated new npm scripts for running NIP-65 examples and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->