### PR TITLE
Add NIP-66 relay discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ SNSTR currently implements the following Nostr Implementation Possibilities (NIP
 - **NIP-46**: Remote signing (bunker) support for secure key management
 - **NIP-57**: Lightning Zaps protocol for Bitcoin payments via Lightning
 - **NIP-47**: Nostr Wallet Connect for secure wallet communication
+- **NIP-66**: Relay discovery and liveness monitoring
 
 For detailed information on each implementation, see the corresponding directories in the `src/` directory (e.g., `src/nip01/`, `src/nip04/`, etc.).
 

--- a/examples/nip66/nip66-demo.ts
+++ b/examples/nip66/nip66-demo.ts
@@ -1,0 +1,42 @@
+import {
+  createRelayDiscoveryEvent,
+  createRelayMonitorAnnouncement,
+  parseRelayDiscoveryEvent,
+  RELAY_DISCOVERY_KIND,
+  RELAY_MONITOR_KIND,
+} from '../../src/nip66';
+import { generateKeypair } from '../../src/utils/crypto';
+import { createSignedEvent } from '../../src/nip01/event';
+
+async function main() {
+  const keys = await generateKeypair();
+
+  const discovery = createRelayDiscoveryEvent(
+    {
+      relay: 'wss://relay.example.com',
+      network: 'clearnet',
+      supportedNips: [1, 11],
+      rttOpen: 123,
+    },
+    keys.publicKey,
+  );
+
+  const signedDiscovery = await createSignedEvent(discovery, keys.privateKey);
+  console.log('Discovery kind:', signedDiscovery.kind === RELAY_DISCOVERY_KIND);
+
+  const parsed = parseRelayDiscoveryEvent(signedDiscovery);
+  console.log('Relay URL:', parsed?.relay);
+
+  const announce = createRelayMonitorAnnouncement(
+    {
+      frequency: 3600,
+      checks: ['ws', 'nip11'],
+    },
+    keys.publicKey,
+  );
+
+  const signedAnnounce = await createSignedEvent(announce, keys.privateKey);
+  console.log('Announcement kind:', signedAnnounce.kind === RELAY_MONITOR_KIND);
+}
+
+main().catch((e) => console.error(e));

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:nip46": "jest tests/nip46",
     "test:nip47": "jest tests/nip47",
     "test:nip57": "jest tests/nip57",
+    "test:nip66": "jest tests/nip66",
     "test:nip17": "jest tests/nip17",
 
     "// Test Groups": "-------------- Test Category Groups --------------",
@@ -107,6 +108,7 @@
     "example:nip57:client": "ts-node examples/nip57/zap-client-example.ts",
     "example:nip57:lnurl": "ts-node examples/nip57/lnurl-server-simulation.ts",
     "example:nip57:validation": "ts-node examples/nip57/invoice-validation-example.ts",
+    "example:nip66": "ts-node examples/nip66/nip66-demo.ts",
     
     "// Example Groups": "-------------- Example Category Groups --------------",
     "example:all": "npm run example",

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,3 +208,13 @@ export {
   NIP47ConnectionOptions,
   TransactionType,
 } from "./nip47";
+
+// NIP-66: Relay Discovery and Liveness Monitoring
+export {
+  RELAY_DISCOVERY_KIND,
+  RELAY_MONITOR_KIND,
+  createRelayDiscoveryEvent,
+  parseRelayDiscoveryEvent,
+  createRelayMonitorAnnouncement,
+  parseRelayMonitorAnnouncement,
+} from "./nip66";

--- a/src/nip66/README.md
+++ b/src/nip66/README.md
@@ -1,0 +1,66 @@
+# NIP-66: Relay Discovery and Liveness Monitoring
+
+This module implements [NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md),
+which defines two event kinds used for announcing relay liveness and monitor
+capabilities.
+
+## Overview
+
+NIP-66 introduces:
+
+- **Relay Discovery (kind `30166`)** – an addressable event published by a
+  monitor when a relay is online.
+- **Relay Monitor Announcement (kind `10166`)** – a replaceable event describing
+  a monitor and the frequency it publishes discovery events.
+
+The implementation provides helpers for creating and parsing these events.
+
+## Key Features
+
+- 📡 Create relay discovery events with relevant tags
+- 📈 Announce monitoring frequency and timeouts
+- 🔍 Parse events into easy to use structures
+
+## Basic Usage
+
+```typescript
+import {
+  createRelayDiscoveryEvent,
+  createRelayMonitorAnnouncement,
+  RELAY_DISCOVERY_KIND,
+  RELAY_MONITOR_KIND,
+  parseRelayDiscoveryEvent,
+} from 'snstr';
+import { signEvent } from 'snstr';
+
+const keys = await generateKeypair();
+
+const discovery = createRelayDiscoveryEvent(
+  {
+    relay: 'wss://relay.example.com',
+    network: 'clearnet',
+    supportedNips: [1, 11],
+    rttOpen: 150,
+  },
+  keys.publicKey,
+);
+
+const signed = await signEvent(discovery, keys.privateKey);
+console.log(signed.kind === RELAY_DISCOVERY_KIND); // true
+
+const parsed = parseRelayDiscoveryEvent(signed);
+console.log(parsed.relay); // 'wss://relay.example.com'
+```
+
+## Implementation Details
+
+The helper functions follow the specification closely. Optional tags such as
+`n`, `T`, `N`, `R`, `t`, `k`, `g` and `rtt-*` are included only when values are
+provided. Content may include the relay's NIP‑11 document or any custom string.
+Parsing functions return structured objects for easier consumption by clients.
+
+## Security Considerations
+
+Clients should validate discovery events originate from trusted monitors and
+handle potentially bogus data gracefully. Always fall back to direct relay
+connections if no valid NIP‑66 information is found.

--- a/src/nip66/index.ts
+++ b/src/nip66/index.ts
@@ -1,0 +1,223 @@
+/**
+ * NIP-66: Relay Discovery and Liveness Monitoring
+ *
+ * Implements utilities for creating and parsing relay discovery events
+ * (kind 30166) and relay monitor announcement events (kind 10166).
+ *
+ * @see https://github.com/nostr-protocol/nips/blob/master/66.md
+ */
+
+import { NostrEvent } from "../types/nostr";
+import { UnsignedEvent } from "../nip01/event";
+import { createEvent } from "../nip01/event";
+
+import {
+  RelayDiscoveryEventOptions,
+  ParsedRelayDiscoveryEvent,
+  RelayMonitorAnnouncementOptions,
+  ParsedRelayMonitorAnnouncement,
+} from "./types";
+
+export * from "./types";
+
+/** Constant for relay discovery event kind */
+export const RELAY_DISCOVERY_KIND = 30166;
+/** Constant for monitor announcement kind */
+export const RELAY_MONITOR_KIND = 10166;
+
+/**
+ * Create a relay discovery event (kind 30166)
+ */
+export function createRelayDiscoveryEvent(
+  options: RelayDiscoveryEventOptions,
+  pubkey: string,
+): UnsignedEvent {
+  const tags: string[][] = [["d", options.relay]];
+
+  if (options.network) tags.push(["n", options.network]);
+  if (options.relayType) tags.push(["T", options.relayType]);
+  if (options.supportedNips) {
+    for (const nip of options.supportedNips) {
+      tags.push(["N", nip.toString()]);
+    }
+  }
+  if (options.requirements) {
+    for (const req of options.requirements) {
+      tags.push(["R", req]);
+    }
+  }
+  if (options.topics) {
+    for (const t of options.topics) {
+      tags.push(["t", t]);
+    }
+  }
+  if (options.kinds) {
+    for (const k of options.kinds) {
+      tags.push(["k", k.toString()]);
+    }
+  }
+  if (options.geohash) tags.push(["g", options.geohash]);
+  if (options.rttOpen !== undefined) {
+    tags.push(["rtt-open", options.rttOpen.toString()]);
+  }
+  if (options.rttRead !== undefined) {
+    tags.push(["rtt-read", options.rttRead.toString()]);
+  }
+  if (options.rttWrite !== undefined) {
+    tags.push(["rtt-write", options.rttWrite.toString()]);
+  }
+  for (const extra of options.additionalTags || []) {
+    tags.push(extra);
+  }
+
+  const content =
+    typeof options.content === "object"
+      ? JSON.stringify(options.content)
+      : options.content || "{}";
+
+  return createEvent({ kind: RELAY_DISCOVERY_KIND, content, tags }, pubkey);
+}
+
+/**
+ * Parse a relay discovery event into a structured object
+ */
+export function parseRelayDiscoveryEvent(
+  event: NostrEvent,
+): ParsedRelayDiscoveryEvent | null {
+  if (event.kind !== RELAY_DISCOVERY_KIND) return null;
+  const data: ParsedRelayDiscoveryEvent = {
+    relay: "",
+    supportedNips: [],
+    requirements: [],
+    topics: [],
+    kinds: [],
+  };
+
+  for (const tag of event.tags) {
+    switch (tag[0]) {
+      case "d":
+        data.relay = tag[1];
+        break;
+      case "n":
+        data.network = tag[1];
+        break;
+      case "T":
+        data.relayType = tag[1];
+        break;
+      case "N":
+        data.supportedNips.push(tag[1]);
+        break;
+      case "R":
+        data.requirements.push(tag[1]);
+        break;
+      case "t":
+        data.topics.push(tag[1]);
+        break;
+      case "k":
+        data.kinds.push(tag[1]);
+        break;
+      case "g":
+        data.geohash = tag[1];
+        break;
+      case "rtt-open":
+        data.rttOpen = parseInt(tag[1], 10);
+        break;
+      case "rtt-read":
+        data.rttRead = parseInt(tag[1], 10);
+        break;
+      case "rtt-write":
+        data.rttWrite = parseInt(tag[1], 10);
+        break;
+    }
+  }
+
+  try {
+    if (event.content) {
+      data.content = JSON.parse(event.content);
+    }
+  } catch {
+    data.content = event.content;
+  }
+
+  return data;
+}
+
+/**
+ * Create a relay monitor announcement event (kind 10166)
+ */
+export function createRelayMonitorAnnouncement(
+  options: RelayMonitorAnnouncementOptions,
+  pubkey: string,
+): UnsignedEvent {
+  const tags: string[][] = [["frequency", options.frequency.toString()]];
+
+  if (options.timeouts) {
+    for (const t of options.timeouts) {
+      const tag = ["timeout", t.value.toString()];
+      if (t.test) tag.push(t.test);
+      tags.push(tag);
+    }
+  }
+
+  if (options.checks) {
+    for (const c of options.checks) {
+      tags.push(["c", c]);
+    }
+  }
+
+  if (options.geohash) tags.push(["g", options.geohash]);
+  for (const extra of options.additionalTags || []) {
+    tags.push(extra);
+  }
+
+  const content = options.content || "";
+
+  return createEvent({ kind: RELAY_MONITOR_KIND, content, tags }, pubkey);
+}
+
+/**
+ * Parse a relay monitor announcement event
+ */
+export function parseRelayMonitorAnnouncement(
+  event: NostrEvent,
+): ParsedRelayMonitorAnnouncement | null {
+  if (event.kind !== RELAY_MONITOR_KIND) return null;
+
+  const data: ParsedRelayMonitorAnnouncement = {
+    frequency: 0,
+    timeouts: [],
+    checks: [],
+  };
+
+  for (const tag of event.tags) {
+    switch (tag[0]) {
+      case "frequency":
+        data.frequency = parseInt(tag[1], 10);
+        break;
+      case "timeout":
+        data.timeouts.push({
+          value: parseInt(tag[1], 10),
+          test: tag[2],
+        });
+        break;
+      case "c":
+        data.checks.push(tag[1]);
+        break;
+      case "g":
+        data.geohash = tag[1];
+        break;
+    }
+  }
+
+  data.content = event.content || "";
+  return data;
+}
+
+export default {
+  RELAY_DISCOVERY_KIND,
+  RELAY_MONITOR_KIND,
+  createRelayDiscoveryEvent,
+  parseRelayDiscoveryEvent,
+  createRelayMonitorAnnouncement,
+  parseRelayMonitorAnnouncement,
+};

--- a/src/nip66/types.ts
+++ b/src/nip66/types.ts
@@ -1,0 +1,52 @@
+export interface RelayDiscoveryEventOptions {
+  relay: string;
+  content?: string | Record<string, unknown>;
+  network?: string;
+  relayType?: string;
+  supportedNips?: (number | string)[];
+  requirements?: string[];
+  topics?: string[];
+  kinds?: (number | string)[];
+  geohash?: string;
+  rttOpen?: number;
+  rttRead?: number;
+  rttWrite?: number;
+  additionalTags?: string[][];
+}
+
+export interface ParsedRelayDiscoveryEvent {
+  relay: string;
+  network?: string;
+  relayType?: string;
+  supportedNips: string[];
+  requirements: string[];
+  topics: string[];
+  kinds: string[];
+  geohash?: string;
+  rttOpen?: number;
+  rttRead?: number;
+  rttWrite?: number;
+  content?: unknown;
+}
+
+export interface TimeoutDefinition {
+  value: number;
+  test?: string;
+}
+
+export interface RelayMonitorAnnouncementOptions {
+  frequency: number;
+  timeouts?: TimeoutDefinition[];
+  checks?: string[];
+  geohash?: string;
+  content?: string;
+  additionalTags?: string[][];
+}
+
+export interface ParsedRelayMonitorAnnouncement {
+  frequency: number;
+  timeouts: TimeoutDefinition[];
+  checks: string[];
+  geohash?: string;
+  content?: string;
+}

--- a/tests/nip66/README.md
+++ b/tests/nip66/README.md
@@ -1,0 +1,15 @@
+# NIP-66 Tests
+
+This directory contains tests for the NIP-66 implementation.
+
+## Components Tested
+
+- ✅ Creation of relay discovery events (kind 30166)
+- ✅ Creation of relay monitor announcement events (kind 10166)
+- ✅ Parsing of discovery events into structured data
+
+## Running the Tests
+
+```bash
+npm run test:nip66
+```

--- a/tests/nip66/nip66.test.ts
+++ b/tests/nip66/nip66.test.ts
@@ -1,0 +1,55 @@
+import {
+  createRelayDiscoveryEvent,
+  parseRelayDiscoveryEvent,
+  createRelayMonitorAnnouncement,
+  RELAY_DISCOVERY_KIND,
+  RELAY_MONITOR_KIND,
+} from "../../src/nip66";
+
+/**
+ * Tests for NIP-66 relay discovery utilities
+ */
+
+describe("NIP-66", () => {
+  test("createRelayDiscoveryEvent should create proper event", () => {
+    const event = createRelayDiscoveryEvent(
+      { relay: "wss://relay.example.com", rttOpen: 100 },
+      "pubkey",
+    );
+    expect(event.kind).toBe(RELAY_DISCOVERY_KIND);
+    expect(event.tags).toContainEqual(["d", "wss://relay.example.com"]);
+    expect(event.tags).toContainEqual(["rtt-open", "100"]);
+  });
+
+  test("parseRelayDiscoveryEvent should parse tags", () => {
+    const event = createRelayDiscoveryEvent(
+      {
+        relay: "wss://relay.example.com",
+        network: "clearnet",
+        supportedNips: [1],
+      },
+      "pubkey",
+    );
+
+    const parsed = parseRelayDiscoveryEvent({
+      ...event,
+      id: "1",
+      sig: "sig",
+      pubkey: "pubkey",
+    });
+
+    expect(parsed?.relay).toBe("wss://relay.example.com");
+    expect(parsed?.network).toBe("clearnet");
+    expect(parsed?.supportedNips).toContain("1");
+  });
+
+  test("createRelayMonitorAnnouncement should create announcement", () => {
+    const event = createRelayMonitorAnnouncement(
+      { frequency: 3600, checks: ["ws"] },
+      "pubkey",
+    );
+    expect(event.kind).toBe(RELAY_MONITOR_KIND);
+    expect(event.tags).toContainEqual(["frequency", "3600"]);
+    expect(event.tags).toContainEqual(["c", "ws"]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement NIP-66 relay discovery and monitor announcement events
- export utilities in the main module
- add example usage and documentation
- provide unit tests
- document new supported NIP
- fix example imports and event signing

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:nip66`


------
https://chatgpt.com/codex/tasks/task_e_6841b268a1b083308bd0f43d5e88ae3d