### PR TITLE
Implement NIP-50 search filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ SNSTR currently implements the following Nostr Implementation Possibilities (NIP
 - **NIP-46**: Remote signing (bunker) support for secure key management
 - **NIP-57**: Lightning Zaps protocol for Bitcoin payments via Lightning
 - **NIP-47**: Nostr Wallet Connect for secure wallet communication
+- **NIP-50**: Search capability via `search` subscription filters
 
 For detailed information on each implementation, see the corresponding directories in the `src/` directory (e.g., `src/nip01/`, `src/nip04/`, etc.).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -104,6 +104,12 @@ npm run example:nip57:lnurl    # LNURL server simulation
 npm run example:nip57:validation # Invoice validation example
 ```
 
+For [NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md) (Search capability):
+
+```bash
+npm run example:nip50          # Basic search filter example
+```
+
 ## Example Categories
 
 You can also run example groups:
@@ -176,6 +182,8 @@ npm run example:advanced      # Run nip46 and nip47:error-handling examples
   - `zap-client-example.ts` - Zap client example for sending zaps
   - `lnurl-server-simulation.ts` - LNURL server simulation for zap endpoints
   - `invoice-validation-example.ts` - Invoice validation example for zap verification
+- `/nip50` - [NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md) (Search capability)
+  - `search-demo.ts` - Basic search filter usage
 
 ## Building Examples
 

--- a/examples/nip50/README.md
+++ b/examples/nip50/README.md
@@ -1,0 +1,11 @@
+# NIP-50 Example
+
+This example demonstrates how to use the search filter introduced in [NIP‑50](https://github.com/nostr-protocol/nips/blob/master/50.md).
+
+The script starts an ephemeral relay, publishes a few notes and then queries them using a search term.
+
+Run with:
+
+```bash
+npm run example:nip50
+```

--- a/examples/nip50/search-demo.ts
+++ b/examples/nip50/search-demo.ts
@@ -1,0 +1,61 @@
+import { Nostr } from "../../src/nip01/nostr";
+import { generateKeypair } from "../../src/utils/crypto";
+import { createSignedEvent } from "../../src/nip01/event";
+import { NostrRelay } from "../../src/utils/ephemeral-relay";
+import { createSearchFilter } from "../../src/nip50";
+
+async function main() {
+  const relay = new NostrRelay(4080);
+  await relay.start();
+  console.log(`Ephemeral relay running at ${relay.url}`);
+
+  const client = new Nostr([relay.url]);
+  await client.connectToRelays();
+
+  const keys = await generateKeypair();
+  client.setPrivateKey(keys.privateKey);
+
+  const note1 = await createSignedEvent(
+    {
+      pubkey: keys.publicKey,
+      kind: 1,
+      content: "I love building nostr apps!",
+      tags: [],
+      created_at: Math.floor(Date.now() / 1000),
+    },
+    keys.privateKey,
+  );
+
+  const note2 = await createSignedEvent(
+    {
+      pubkey: keys.publicKey,
+      kind: 1,
+      content: "Another event about something else",
+      tags: [],
+      created_at: Math.floor(Date.now() / 1000),
+    },
+    keys.privateKey,
+  );
+
+  await client.publishEvent(note1);
+  await client.publishEvent(note2);
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  console.log("Searching for 'nostr'");
+  await new Promise<void>((resolve) => {
+    const subId = client.subscribe(
+      [createSearchFilter("nostr")],
+      (event) => console.log("Found", event.content),
+      () => {
+        client.unsubscribe(subId);
+        resolve();
+      },
+    );
+  });
+
+  client.disconnectFromRelays();
+  await relay.close();
+}
+
+main().catch((e) => console.error(e));

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:nip46": "jest tests/nip46",
     "test:nip47": "jest tests/nip47",
     "test:nip57": "jest tests/nip57",
+    "test:nip50": "jest tests/nip50",
     "test:nip17": "jest tests/nip17",
 
     "// Test Groups": "-------------- Test Category Groups --------------",
@@ -107,6 +108,7 @@
     "example:nip57:client": "ts-node examples/nip57/zap-client-example.ts",
     "example:nip57:lnurl": "ts-node examples/nip57/lnurl-server-simulation.ts",
     "example:nip57:validation": "ts-node examples/nip57/invoice-validation-example.ts",
+    "example:nip50": "ts-node examples/nip50/search-demo.ts",
     
     "// Example Groups": "-------------- Example Category Groups --------------",
     "example:all": "npm run example",

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,3 +208,6 @@ export {
   NIP47ConnectionOptions,
   TransactionType,
 } from "./nip47";
+
+// NIP-50 search utilities
+export { createSearchFilter } from "./nip50";

--- a/src/nip50/README.md
+++ b/src/nip50/README.md
@@ -1,0 +1,33 @@
+# NIP-50: Search Capability
+
+This module implements the basics of [NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md). The specification introduces a `search` field for subscription filters allowing full text queries.
+
+## Overview
+
+Relays that support NIP-50 interpret the `search` string and return matching events. The search algorithm is implementation specific. This library provides a helper to build search filters and the ephemeral relay supports simple substring matching.
+
+## Key Features
+
+- 🔍 **Search Filters** – create filters containing a `search` query
+- 🤖 **Ephemeral Relay Support** – the in‑memory relay can respond to search filters for testing
+- 📄 **Type Safety** – `NostrFilter` includes an optional `search` property
+
+## Basic Usage
+
+```typescript
+import { Nostr } from 'snstr';
+import { createSearchFilter } from 'snstr/nip50';
+
+const client = new Nostr(['wss://relay.example.com']);
+await client.connectToRelays();
+
+// Subscribe using a search query
+client.subscribe(
+  [createSearchFilter('nostr apps', { kinds: [1], limit: 20 })],
+  (event) => console.log('Found event', event.id)
+);
+```
+
+## Implementation Details
+
+The included ephemeral relay performs a very naïve search by checking if the query appears in the event content or any tag values. Real relays are expected to implement more advanced search and ranking algorithms.

--- a/src/nip50/index.ts
+++ b/src/nip50/index.ts
@@ -1,0 +1,24 @@
+/**
+ * NIP-50: Search Capability
+ *
+ * Provides helper utilities for creating search filters as defined in
+ * https://github.com/nostr-protocol/nips/blob/master/50.md
+ */
+
+import { Filter } from "../types/nostr";
+
+/**
+ * Create a NIP-50 search filter.
+ *
+ * @param query - Human readable search query string
+ * @param other - Optional additional filter fields
+ * @returns Filter including the search term
+ */
+export function createSearchFilter(
+  query: string,
+  other: Partial<Filter> = {},
+): Filter {
+  return { ...other, search: query } as Filter;
+}
+
+export default { createSearchFilter };

--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -80,6 +80,11 @@ export type NostrFilter = {
   until?: number;
   /** Maximum number of events to return */
   limit?: number;
+  /**
+   * Full text search query string as defined in NIP-50.
+   * Relays interpret this to return events matching the query.
+   */
+  search?: string;
 };
 
 /**

--- a/src/utils/ephemeral-relay.ts
+++ b/src/utils/ephemeral-relay.ts
@@ -742,7 +742,7 @@ class ClientSession {
 /* ================ [ Methods ] ================ */
 
 function match_filter(event: SignedEvent, filter: EventFilter = {}): boolean {
-  const { authors, ids, kinds, since, until, ...rest } = filter;
+  const { authors, ids, kinds, since, until, search, ...rest } = filter;
 
   // Extract all tag filters from rest
   const tag_filters: string[][] = Object.entries(rest)
@@ -759,6 +759,14 @@ function match_filter(event: SignedEvent, filter: EventFilter = {}): boolean {
     return false;
   } else if (kinds !== undefined && !kinds.includes(event.kind)) {
     return false;
+  } else if (search !== undefined && search.length > 0) {
+    const query = search.toLowerCase();
+    const contentMatch = event.content.toLowerCase().includes(query);
+    const tagMatch = event.tags.some((tag) =>
+      tag.some((v) => v.toLowerCase().includes(query)),
+    );
+    if (!contentMatch && !tagMatch) return false;
+    return tag_filters.length > 0 ? match_tags(tag_filters, event.tags) : true;
   } else if (tag_filters.length > 0) {
     return match_tags(tag_filters, event.tags);
   } else {

--- a/tests/nip50/README.md
+++ b/tests/nip50/README.md
@@ -1,0 +1,5 @@
+# NIP-50 Tests
+
+This directory contains tests for the search capability described in NIP‑50.
+
+The tests verify that the `search` filter works with the provided ephemeral relay implementation.

--- a/tests/nip50/search.test.ts
+++ b/tests/nip50/search.test.ts
@@ -1,0 +1,109 @@
+import { Nostr } from "../../src/nip01/nostr";
+import { createSignedEvent } from "../../src/nip01/event";
+import { generateKeypair } from "../../src/utils/crypto";
+import { NostrRelay } from "../../src/utils/ephemeral-relay";
+import { createSearchFilter } from "../../src/nip50";
+import { Filter, NostrEvent } from "../../src/types/nostr";
+
+const PORT = 4099;
+
+describe("NIP-50 Search Filter", () => {
+  let relay: NostrRelay;
+  let client: Nostr;
+  let keys: { privateKey: string; publicKey: string };
+
+  beforeAll(async () => {
+    relay = new NostrRelay(PORT);
+    await relay.start();
+
+    client = new Nostr([relay.url]);
+    await client.connectToRelays();
+
+    keys = await generateKeypair();
+    client.setPrivateKey(keys.privateKey);
+  });
+
+  afterAll(async () => {
+    client.disconnectFromRelays();
+    await relay.close();
+  });
+
+  test("search field should be usable in Filter type", () => {
+    const filter: Filter = { search: "nostr" };
+    expect(filter.search).toBe("nostr");
+  });
+
+  test("should return events matching search query", async () => {
+    const event1 = await createSignedEvent(
+      {
+        pubkey: keys.publicKey,
+        kind: 1,
+        content: "hello nostr world",
+        tags: [],
+        created_at: Math.floor(Date.now() / 1000),
+      },
+      keys.privateKey,
+    );
+
+    const event2 = await createSignedEvent(
+      {
+        pubkey: keys.publicKey,
+        kind: 1,
+        content: "another note",
+        tags: [],
+        created_at: Math.floor(Date.now() / 1000),
+      },
+      keys.privateKey,
+    );
+
+    await client.publishEvent(event1);
+    await client.publishEvent(event2);
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const events: NostrEvent[] = [];
+    await new Promise<void>((resolve) => {
+      const subId = client.subscribe(
+        [createSearchFilter("nostr")],
+        (ev) => events.push(ev),
+        () => {
+          client.unsubscribe(subId);
+          resolve();
+        },
+      );
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].id).toBe(event1.id);
+  });
+
+  test("search should be case insensitive", async () => {
+    const event = await createSignedEvent(
+      {
+        pubkey: keys.publicKey,
+        kind: 1,
+        content: "Case Insensitive Search", // Contains 'search'
+        tags: [],
+        created_at: Math.floor(Date.now() / 1000),
+      },
+      keys.privateKey,
+    );
+
+    await client.publishEvent(event);
+    await new Promise((r) => setTimeout(r, 20));
+
+    const events: NostrEvent[] = [];
+    await new Promise<void>((resolve) => {
+      const subId = client.subscribe(
+        [createSearchFilter("search")],
+        (ev) => events.push(ev),
+        () => {
+          client.unsubscribe(subId);
+          resolve();
+        },
+      );
+    });
+
+    expect(events.some((e) => e.id === event.id)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add NIP‑50 module with helper and documentation
- update types to include `search` field
- extend ephemeral relay to handle search queries
- provide example usage and docs
- add tests for search filter
- list NIP‑50 in main README and examples README
- wire up scripts for running tests and examples
- address lint warnings

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841b2c151ac8330a27f697ace919cc7