### PR TITLE
Add NIP-10 thread utilities with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ SNSTR is a lightweight TypeScript library for interacting with the Nostr protoco
 - Browser extension integration via NIP-07
 - Remote signing capability via NIP-46
 - Lightning Zaps integration via NIP-57
+- Threaded conversations via NIP-10
 - Wallet connection via NIP-47
 - Relay list metadata via NIP-65
 - Built-in ephemeral relay for testing and development
@@ -51,6 +52,7 @@ SNSTR currently implements the following Nostr Implementation Possibilities (NIP
 - **NIP-05**: DNS identifier verification and relay discovery
 - **NIP-07**: Browser extension integration for key management
 - **NIP-09**: Event deletion requests for removing published events
+- **NIP-10**: Text notes and threading metadata
 - **NIP-11**: Relay Information Document for discovering relay capabilities
 - **NIP-19**: Bech32-encoded entities for human-readable identifiers
 - **NIP-44**: Improved encryption with ChaCha20 and HMAC-SHA256 authentication
@@ -128,6 +130,7 @@ The project is organized with detailed documentation for different components:
 - **[NIP-05](src/nip05/README.md)**: DNS identifier verification
 - **[NIP-07](src/nip07/README.md)**: Browser extension integration
 - **[NIP-09](src/nip09/README.md)**: Event deletion requests
+- **[NIP-10](src/nip10/README.md)**: Text notes and threads
 - **[NIP-11](src/nip11/README.md)**: Relay information document
 - **[NIP-19](src/nip19/README.md)**: Bech32-encoded entities
 - **[NIP-44](src/nip44/README.md)**: Versioned encryption

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:nip05": "jest tests/nip05",
     "test:nip07": "jest tests/nip07",
     "test:nip09": "jest tests/nip09",
+    "test:nip10": "jest tests/nip10",
     "test:nip11": "jest tests/nip11",
     "test:nip17": "jest tests/nip17",
     "test:nip19": "jest tests/nip19",

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,15 @@ export {
   isDeletionRequestForEvent,
 } from "./nip09";
 
+// Export NIP-10 utilities
+export {
+  createReplyTags,
+  createQuoteTag,
+  parseThreadReferences,
+  ThreadPointer,
+  ThreadReferences,
+} from "./nip10";
+
 // Export NIP-07 adapter
 export { Nip07Nostr } from "./nip07/adapter";
 
@@ -213,7 +222,15 @@ export {
 export { createSearchFilter } from "./nip50";
 
 // NIP-65: Relay List Metadata
-export { createRelayListEvent, parseRelayList, getReadRelays, getWriteRelays, RELAY_LIST_KIND, RelayListEntry, RelayListEvent } from "./nip65";
+export {
+  createRelayListEvent,
+  parseRelayList,
+  getReadRelays,
+  getWriteRelays,
+  RELAY_LIST_KIND,
+  RelayListEntry,
+  RelayListEvent,
+} from "./nip65";
 
 // NIP-66: Relay Discovery and Liveness Monitoring
 export {

--- a/src/nip10/README.md
+++ b/src/nip10/README.md
@@ -1,0 +1,34 @@
+# NIP-10: Text Notes and Threads
+
+Implementation of [NIP-10](https://github.com/nostr-protocol/nips/blob/master/10.md) which defines how `kind:1` text notes reference each other in threads.
+
+## Overview
+
+NIP‑10 introduces marked `e` tags for replies and `q` tags for quoting other events. Root and reply identifiers are carried in the tags and authors referenced should be included in `p` tags.
+
+## Key Features
+
+- Utilities to create marked `e` and `q` tags
+- Parsing of thread references from an event
+- Support for the deprecated positional `e` tag scheme
+
+## Basic Usage
+
+```typescript
+import { createReplyTags, createQuoteTag, parseThreadReferences } from 'snstr/nip10';
+
+const eTags = createReplyTags(
+  { id: rootId, relay: 'wss://relay.example.com' },
+  { id: replyId }
+);
+
+const quote = createQuoteTag({ id: quotedId });
+
+// later when inspecting an event
+const refs = parseThreadReferences(event);
+console.log(refs.root, refs.reply, refs.quotes);
+```
+
+## Implementation Details
+
+`parseThreadReferences` first looks for marked `e` tags (`"root"` and `"reply"`). If none are found it falls back to the positional scheme described in the NIP for backwards compatibility. Quote information is extracted from `q` tags.

--- a/src/nip10/index.ts
+++ b/src/nip10/index.ts
@@ -1,0 +1,103 @@
+/**
+ * NIP-10: Text Notes and Threads
+ *
+ * Utilities for working with thread references as defined in
+ * https://github.com/nostr-protocol/nips/blob/master/10.md
+ */
+
+import { NostrEvent } from "../types/nostr";
+
+/** Event pointer used in thread references */
+export interface ThreadPointer {
+  id: string;
+  relay?: string;
+  pubkey?: string;
+}
+
+/** Parsed thread references from an event */
+export interface ThreadReferences {
+  /** Root event of the thread */
+  root?: ThreadPointer;
+  /** Direct parent being replied to */
+  reply?: ThreadPointer;
+  /** Other mentioned events */
+  mentions: ThreadPointer[];
+  /** Quoted events using q tags */
+  quotes: ThreadPointer[];
+}
+
+/**
+ * Create marked "e" tags for a reply as defined in NIP-10.
+ * The tags are returned in the recommended order from root to reply.
+ */
+export function createReplyTags(
+  root: ThreadPointer,
+  reply?: ThreadPointer,
+): string[][] {
+  const tags: string[][] = [];
+
+  tags.push(["e", root.id, root.relay ?? "", "root", root.pubkey ?? ""]);
+
+  if (reply) {
+    tags.push(["e", reply.id, reply.relay ?? "", "reply", reply.pubkey ?? ""]);
+  }
+
+  return tags;
+}
+
+/** Create a "q" tag for quoting an event */
+export function createQuoteTag(pointer: ThreadPointer): string[] {
+  return ["q", pointer.id, pointer.relay ?? "", pointer.pubkey ?? ""];
+}
+
+/**
+ * Parse thread references (e and q tags) from an event. Handles both
+ * marked and deprecated positional e tags.
+ */
+export function parseThreadReferences(event: NostrEvent): ThreadReferences {
+  const eTags = event.tags.filter((t) => t[0] === "e");
+  const qTags = event.tags.filter((t) => t[0] === "q");
+
+  let root: ThreadPointer | undefined;
+  let reply: ThreadPointer | undefined;
+  const mentions: ThreadPointer[] = [];
+  const unmarked: ThreadPointer[] = [];
+
+  for (const tag of eTags) {
+    const [_, id, relay, marker, pubkey] = tag;
+    if (marker === "root") {
+      root = { id, relay: relay || undefined, pubkey };
+    } else if (marker === "reply") {
+      reply = { id, relay: relay || undefined, pubkey };
+    } else {
+      unmarked.push({ id, relay: relay || undefined, pubkey });
+    }
+  }
+
+  // Handle deprecated positional scheme if no marked tags were found
+  if (!root && !reply && unmarked.length > 0) {
+    if (unmarked.length === 1) {
+      reply = unmarked[0];
+    } else {
+      root = unmarked[0];
+      reply = unmarked[unmarked.length - 1];
+      mentions.push(...unmarked.slice(1, -1));
+    }
+  } else {
+    mentions.push(...unmarked);
+  }
+
+  const quotes: ThreadPointer[] = qTags.map((tag) => ({
+    id: tag[1],
+    relay: tag[2] || undefined,
+    pubkey: tag[3],
+  }));
+
+  return { root, reply, mentions, quotes };
+}
+
+export default {
+  createReplyTags,
+  createQuoteTag,
+  parseThreadReferences,
+};

--- a/tests/nip10/README.md
+++ b/tests/nip10/README.md
@@ -1,0 +1,19 @@
+# NIP-10 Tests
+
+This directory contains tests for the NIP‑10 thread utility functions.
+
+## Components Tested
+
+- Parsing of marked and positional `e` tags
+- Parsing of `q` tags
+- Creation helpers for reply and quote tags
+
+## Running the Tests
+
+```bash
+npm run test:nip10
+```
+
+## Test Files
+
+- `nip10.test.ts`: Unit tests for the NIP‑10 utilities

--- a/tests/nip10/nip10.test.ts
+++ b/tests/nip10/nip10.test.ts
@@ -1,0 +1,95 @@
+import {
+  createReplyTags,
+  createQuoteTag,
+  parseThreadReferences,
+} from "../../src/nip10";
+import { NostrEvent } from "../../src/types/nostr";
+
+describe("NIP-10 utilities", () => {
+  test("createReplyTags should build root and reply tags", () => {
+    const tags = createReplyTags(
+      { id: "root", relay: "wss://relay" },
+      { id: "reply" },
+    );
+    expect(tags).toEqual([
+      ["e", "root", "wss://relay", "root", ""],
+      ["e", "reply", "", "reply", ""],
+    ]);
+  });
+
+  test("createQuoteTag should build q tag", () => {
+    expect(createQuoteTag({ id: "abc" })).toEqual(["q", "abc", "", ""]);
+  });
+
+  test("parseThreadReferences handles marked tags", () => {
+    const event: NostrEvent = {
+      id: "1",
+      pubkey: "a",
+      created_at: 0,
+      kind: 1,
+      content: "",
+      tags: [
+        ["e", "root", "", "root", "pub1"],
+        ["e", "reply", "", "reply", "pub2"],
+        ["q", "quote", "relay"],
+      ],
+      sig: "sig",
+    };
+
+    const refs = parseThreadReferences(event);
+    expect(refs.root?.id).toBe("root");
+    expect(refs.reply?.id).toBe("reply");
+    expect(refs.quotes[0].id).toBe("quote");
+  });
+
+  test("parseThreadReferences handles positional scheme", () => {
+    const event: NostrEvent = {
+      id: "1",
+      pubkey: "a",
+      created_at: 0,
+      kind: 1,
+      content: "",
+      tags: [
+        ["e", "root"],
+        ["e", "mention"],
+        ["e", "reply"],
+      ],
+      sig: "sig",
+    };
+
+    const refs = parseThreadReferences(event);
+    expect(refs.root?.id).toBe("root");
+    expect(refs.reply?.id).toBe("reply");
+    expect(refs.mentions.map((m) => m.id)).toEqual(["mention"]);
+  });
+
+  test("createReplyTags should build only root tag when no reply", () => {
+    expect(createReplyTags({ id: "root" })).toEqual([
+      ["e", "root", "", "root", ""],
+    ]);
+  });
+
+  test("parseThreadReferences collects mentions with marked tags", () => {
+    const event: NostrEvent = {
+      id: "1",
+      pubkey: "pk",
+      created_at: 0,
+      kind: 1,
+      content: "",
+      tags: [
+        ["e", "root", "", "root"],
+        ["e", "reply", "", "reply"],
+        ["e", "mention"],
+        ["q", "quote", "wss://relay", "pub"],
+      ],
+      sig: "s",
+    };
+    const refs = parseThreadReferences(event);
+    expect(refs.mentions.map((m) => m.id)).toEqual(["mention"]);
+    expect(refs.quotes[0]).toEqual({
+      id: "quote",
+      relay: "wss://relay",
+      pubkey: "pub",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement helpers to create and parse NIP-10 thread tags
- document NIP-10 support in README and index exports
- add extensive NIP-10 unit tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run test:nip10`


------
https://chatgpt.com/codex/tasks/task_e_68424e1a12bc83308e4eea1fa4271b8a