### PR TITLE
Fix and tidy npm test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "test:event:all": "jest tests/nip01/event",
     "test:nostr": "jest tests/nip01/nostr.test.ts",
     "test:relay": "jest tests/nip01/relay",
-    "test:relay:connection": "jest tests/nip01/relay/connection.test.ts",
-    "test:relay:filter": "jest tests/nip01/relay/filter.test.ts",
-    "test:relay:reconnect": "jest tests/nip01/relay/reconnect.test.ts",
-    "test:crypto:core": "jest tests/utils/crypto.test.ts",
+    "test:nip01:relay:connection": "jest tests/nip01/relay/relay.test.ts",
+    "test:nip01:relay:filter": "jest tests/nip01/relay/filters.test.ts",
+    "test:nip01:relay:reconnect": "jest tests/nip01/relay/relay-reconnect.test.ts",
+    "test:crypto:core": "jest tests/crypto.test.ts",
     
     "// Test NIP": "-------------- NIP-specific Tests --------------",
     "test:nip02": "jest tests/nip02",
@@ -54,7 +54,7 @@
     "// Test Groups": "-------------- Test Category Groups --------------",
     "test:all": "npm test",
     "test:core": "jest tests/nip01",
-    "test:crypto": "jest tests/utils/crypto.test.ts tests/nip04 tests/nip44",
+    "test:crypto": "jest tests/crypto.test.ts tests/nip04 tests/nip44",
     "test:identity": "jest tests/nip05 tests/nip07 tests/nip19",
     "test:protocols": "jest tests/nip46 tests/nip47 tests/nip57",
      


### PR DESCRIPTION
## Summary
- correct file paths for relay and crypto tests
- update grouped crypto script
- organize relay test scripts

## Testing
- `npm test`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6843032a93748330b75e7b76f3980604