### PR TITLE
Add getUnixTime utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export {
   verifySignature,
 } from "./utils/crypto";
 
+export { getUnixTime } from "./utils/time";
+
 export {
   createEvent,
   createAddressableEvent,

--- a/src/nip01/event.ts
+++ b/src/nip01/event.ts
@@ -14,6 +14,7 @@ import { encrypt as encryptNIP04 } from "../nip04";
 import { sha256Hex } from "../utils/crypto";
 import { signEvent as signEventCrypto } from "../utils/crypto";
 import { isValidRelayUrl } from "../nip19";
+import { getUnixTime } from "../utils/time";
 
 export type UnsignedEvent = Omit<NostrEvent, "id" | "sig">;
 
@@ -155,7 +156,7 @@ export function createEvent(
 
   return {
     pubkey,
-    created_at: template.created_at || Math.floor(Date.now() / 1000),
+    created_at: template.created_at || getUnixTime(),
     kind: template.kind,
     tags: template.tags || [],
     content: template.content,
@@ -234,7 +235,7 @@ export function createTextNote(
 
   return {
     pubkey,
-    created_at: Math.floor(Date.now() / 1000),
+    created_at: getUnixTime(),
     kind: NostrKind.ShortNote,
     tags,
     content,
@@ -293,7 +294,7 @@ export async function createDirectMessage(
 
     return {
       pubkey,
-      created_at: Math.floor(Date.now() / 1000),
+      created_at: getUnixTime(),
       kind: NostrKind.DirectMessage,
       tags: [["p", recipientPubkey], ...tags],
       content: encryptedContent,
@@ -338,7 +339,7 @@ export function createMetadataEvent(
 
   return {
     pubkey,
-    created_at: Math.floor(Date.now() / 1000),
+    created_at: getUnixTime(),
     kind: NostrKind.Metadata,
     tags: [],
     content: JSON.stringify(metadata),
@@ -400,7 +401,7 @@ export function createAddressableEvent(
 
   return {
     pubkey,
-    created_at: Math.floor(Date.now() / 1000),
+    created_at: getUnixTime(),
     kind,
     tags,
     content,
@@ -548,7 +549,7 @@ export async function validateEvent(
 
   // 3. Validate timestamp drift if enabled
   if (maxTimestampDrift > 0) {
-    const now = Math.floor(Date.now() / 1000);
+    const now = getUnixTime();
     const drift = Math.abs(now - event.created_at);
 
     if (drift > maxTimestampDrift) {

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -13,6 +13,7 @@ import {
 } from "../types/nostr";
 import { RelayConnectionOptions } from "../types/protocol";
 import { NostrValidationError } from "./event";
+import { getUnixTime } from "../utils/time";
 
 export class Relay {
   private url: string;
@@ -815,7 +816,7 @@ export class Relay {
       }
 
       // Check reasonable timestamp (not more than 1 hour in the future and not too far in the past)
-      const now = Math.floor(Date.now() / 1000);
+      const now = getUnixTime();
       if (event.created_at > now + 3600) {
         return false; // Reject events with future timestamps
       }

--- a/src/nip02/index.ts
+++ b/src/nip02/index.ts
@@ -1,6 +1,7 @@
 // NIP-02 implementation will go here
 
 import { NostrEvent, ContactsEvent } from "../types/nostr";
+import { getUnixTime } from "../utils/time";
 // Assuming NostrEvent and NostrTag are defined in a central types file.
 // Adjust the import path if necessary.
 
@@ -72,7 +73,7 @@ export function createContactListEvent(
     kind: 3,
     tags,
     content: existingContent,
-    created_at: Math.floor(Date.now() / 1000),
+    created_at: getUnixTime(),
   };
 }
 

--- a/src/nip07/adapter.ts
+++ b/src/nip07/adapter.ts
@@ -1,6 +1,7 @@
 import { NostrEvent } from "../types/nostr";
 import { Nostr } from "../nip01/nostr";
 import * as nip07 from "./index";
+import { getUnixTime } from "../utils/time";
 
 /**
  * NIP-07 enabled Nostr client that uses browser extension for signing
@@ -87,7 +88,7 @@ export class Nip07Nostr extends Nostr {
 
     const event: Omit<NostrEvent, "id" | "pubkey" | "sig"> = {
       kind: 1,
-      created_at: Math.floor(Date.now() / 1000),
+      created_at: getUnixTime(),
       tags,
       content,
     };
@@ -140,7 +141,7 @@ export class Nip07Nostr extends Nostr {
 
       const event: Omit<NostrEvent, "id" | "pubkey" | "sig"> = {
         kind: 4,
-        created_at: Math.floor(Date.now() / 1000),
+        created_at: getUnixTime(),
         tags: updatedTags,
         content: encryptedContent,
       };

--- a/src/nip46/bunker.ts
+++ b/src/nip46/bunker.ts
@@ -3,6 +3,7 @@ import { encrypt as encryptNIP44, decrypt as decryptNIP44 } from "../nip44";
 import { encrypt as encryptNIP04, decrypt as decryptNIP04 } from "../nip04";
 import { NostrEvent, NostrFilter } from "../types/nostr";
 import { createSignedEvent } from "../nip01/event";
+import { getUnixTime } from "../utils/time";
 import {
   NIP46Method,
   NIP46Request,
@@ -723,7 +724,7 @@ export class NostrRemoteSignerBunker {
       await this.nostr.publishEvent({
         kind: 24133,
         pubkey: this.signerKeypair.publicKey,
-        created_at: Math.floor(Date.now() / 1000),
+        created_at: getUnixTime(),
         tags: [["p", clientPubkey]],
         content: encryptedContent,
         id: "",
@@ -780,7 +781,7 @@ export class NostrRemoteSignerBunker {
               ? [["nostrconnect_url", metadata.nostrconnect_url]]
               : []),
           ],
-          created_at: Math.floor(Date.now() / 1000),
+          created_at: getUnixTime(),
           pubkey: this.signerKeypair.publicKey,
         },
         this.signerKeypair.privateKey,

--- a/src/nip46/client.ts
+++ b/src/nip46/client.ts
@@ -1,5 +1,6 @@
 import { Nostr } from "../nip01/nostr";
 import { generateKeypair } from "../utils/crypto";
+import { getUnixTime } from "../utils/time";
 import { encrypt as encryptNIP44, decrypt as decryptNIP44 } from "../nip44";
 import { encrypt as encryptNIP04, decrypt as decryptNIP04 } from "../nip04";
 import { NostrEvent, NostrFilter } from "../types/nostr";
@@ -691,7 +692,7 @@ export class NostrRemoteSignerClient {
       const event = {
         kind: 24133,
         pubkey: this.clientKeypair.publicKey,
-        created_at: Math.floor(Date.now() / 1000),
+        created_at: getUnixTime(),
         tags: [["p", this.signerPubkey]],
         content: encryptedContent,
         id: "",

--- a/src/nip46/simple-bunker.ts
+++ b/src/nip46/simple-bunker.ts
@@ -13,6 +13,7 @@ import {
 } from "./types";
 import { Logger, LogLevel } from "./utils/logger";
 import { createSignedEvent, UnsignedEvent } from "../nip01/event";
+import { getUnixTime } from "../utils/time";
 
 // Helper functions for response creation
 export function createSuccessResponse(
@@ -584,7 +585,7 @@ export class SimpleNIP46Bunker {
       const eventData: UnsignedEvent = {
         kind: 24133,
         pubkey: this.signerKeys.publicKey,
-        created_at: Math.floor(Date.now() / 1000),
+        created_at: getUnixTime(),
         tags: [["p", clientPubkey]],
         content: encrypted,
       };

--- a/src/nip46/simple-client.ts
+++ b/src/nip46/simple-client.ts
@@ -1,6 +1,7 @@
 import { NostrEvent, NostrFilter } from "../types/nostr";
 import { Nostr } from "../nip01/nostr";
 import { generateKeypair } from "../utils/crypto";
+import { getUnixTime } from "../utils/time";
 import { encrypt as encryptNIP04, decrypt as decryptNIP04 } from "../nip04";
 import { createSignedEvent } from "../nip01/event";
 import { generateRequestId } from "./utils/request-response";
@@ -334,7 +335,7 @@ export class SimpleNIP46Client {
         const eventData: Omit<NostrEvent, "id" | "sig"> = {
           kind: 24133,
           pubkey: this.clientKeys.publicKey,
-          created_at: Math.floor(Date.now() / 1000),
+          created_at: getUnixTime(),
           tags: [["p", this.signerPubkey]],
           content: encrypted,
         };

--- a/src/nip47/service.ts
+++ b/src/nip47/service.ts
@@ -2,6 +2,7 @@ import { Nostr } from "../nip01/nostr";
 import { NostrEvent } from "../types/nostr";
 import { signEvent } from "../utils/crypto";
 import { getEventHash } from "../nip01/event";
+import { getUnixTime } from "../utils/time";
 import { createEvent, createSignedEvent } from "../nip01/event";
 import { encrypt as encryptNIP04, decrypt as decryptNIP04 } from "../nip04";
 import {
@@ -245,7 +246,7 @@ export class NostrWalletService {
       let expirationTimestamp: number | undefined;
       if (expirationTag && expirationTag.length > 1) {
         expirationTimestamp = parseInt(expirationTag[1], 10);
-        const now = Math.floor(Date.now() / 1000);
+        const now = getUnixTime();
         if (now > expirationTimestamp) {
           console.log(
             `Request ${event.id} has already expired (${expirationTimestamp} < ${now}).`,

--- a/src/nip57/client.ts
+++ b/src/nip57/client.ts
@@ -12,6 +12,7 @@
 import { NostrEvent, Filter } from "../types/nostr";
 import { Nostr } from "../nip01/nostr";
 import { createSignedEvent } from "../nip01/event";
+import { getUnixTime } from "../utils/time";
 import {
   createZapRequest,
   validateZapReceipt,
@@ -789,7 +790,7 @@ export class ZapClient {
           pubkey: options.anonymousZap
             ? "00000000000000000000000000000000000000000000000000000000000000"
             : senderPubkey || "",
-          created_at: Math.floor(Date.now() / 1000),
+          created_at: getUnixTime(),
         },
         privateKey,
       );

--- a/src/nip65/index.ts
+++ b/src/nip65/index.ts
@@ -1,5 +1,6 @@
 import { NostrEvent } from "../types/nostr";
 import { validateRelayUrl } from "../nip19/index";
+import { getUnixTime } from "../utils/time";
 
 /** Relay list entry describing read/write preferences */
 export interface RelayListEntry {
@@ -55,7 +56,7 @@ export function createRelayListEvent(
     kind: RELAY_LIST_KIND,
     tags,
     content,
-    created_at: Math.floor(Date.now() / 1000),
+    created_at: getUnixTime(),
   };
 }
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,3 @@
+export function getUnixTime(): number {
+  return Math.floor(Date.now() / 1000);
+}


### PR DESCRIPTION
## Summary
- introduce `getUnixTime` helper
- export `getUnixTime`
- use helper across modules to replace duplicated timestamp logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68430c7474f083308d30a2f43b02f92e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a utility function for obtaining the current Unix timestamp, now available for use.

- **Refactor**
  - Centralized all timestamp generation to use the new utility function, ensuring consistency across event creation and validation throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->