### PR TITLE
Remove duplicate test callback types

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -4,8 +4,7 @@ import {
   Relay,
   RelayEvent,
   RelayEventCallbacks,
-  Subscription,
-  ParsedOkReason,
+  Subscription
 } from "../../src";
 import { NostrRelay } from "../../src/utils/ephemeral-relay";
 


### PR DESCRIPTION
## Summary
- deduplicate callback type definitions in test helpers by aliasing to library `RelayEventCallbacks`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684327c98e54833096d808d651b22f9b