### PR TITLE
Implement RelayPool abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ npm run example:nip01:event:ordering      # Event ordering demonstration
 npm run example:nip01:event:addressable   # Addressable events
 npm run example:nip01:event:replaceable   # Replaceable events
 npm run example:nip01:relay:connection    # Relay connection management
+npm run example:nip01:relay:pool         # RelayPool multi-relay demo
 npm run example:nip01:relay:filters       # Filter types
 npm run example:nip01:relay:reconnect     # Relay reconnection
 npm run example:nip01:validation          # NIP-01 validation flow
@@ -283,6 +284,7 @@ npm run example:nip01:event:ordering     # Event ordering demonstration
 npm run example:nip01:event:addressable  # Addressable events
 npm run example:nip01:event:replaceable  # Replaceable events
 npm run example:nip01:relay:connection   # Relay connection management
+npm run example:nip01:relay:pool        # RelayPool multi-relay demo
 npm run example:nip01:relay:filters      # Filter types
 npm run example:nip01:relay:reconnect    # Relay reconnection
 npm run example:nip01:validation         # NIP-01 validation flow

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ This directory contains example code demonstrating how to use the SNSTR library 
 
 All examples can be run using npm scripts. Here's how to use them:
 
-```bash
+````bash
 # Basic usage examples
 npm run example                # Basic usage with ephemeral relay
 npm run example:verbose        # Basic usage with verbose logging
@@ -21,6 +21,7 @@ npm run example:nip01:event:addressable    # Addressable events (kinds 30000-399
 npm run example:nip01:event:replaceable    # Replaceable events (kinds 0, 3, 10000-19999)
 npm run example:nip01:relay:connection     # Relay connection with timeout handling
 npm run example:nip01:relay:reconnect      # Relay reconnection with exponential backoff
+npm run example:nip01:relay:pool           # RelayPool multi-relay demo
 npm run example:nip01:relay:filters        # Filter type examples
 npm run example:nip01:validation           # NIP-01 validation flow
 
@@ -54,7 +55,7 @@ npm run example:nip19:tlv      # TLV entities (nprofile, nevent, naddr)
 npm run example:nip19:validation # Validation and error handling
 npm run example:nip19:security # Security features like relay URL validation and TLV entry limits
 npm run example:nip19:demo     # Interactive demo with various encoding/decoding operations
-```
+````
 
 ## NIP-07 Examples
 
@@ -153,6 +154,7 @@ npm run example:advanced      # Run nip46 and nip47:error-handling examples
   - `/relay` - Relay-related examples
     - `relay-connection.ts` - Connection management with error handling and timeout configuration
     - `relay-reconnect.ts` - Relay reconnection with exponential backoff strategies
+    - `relay-pool.ts` - Manage multiple relays with RelayPool
     - `filter-types.ts` - Filter type examples for event retrieval optimization
 - `/client` - Client-related examples
   - `validation-flow.ts` - NIP-01 validation flow for event verification

--- a/examples/nip01/README.md
+++ b/examples/nip01/README.md
@@ -27,6 +27,9 @@ npm run example:nip01:event:replaceable
 # Relay connection with timeout handling
 npm run example:nip01:relay:connection
 
+# RelayPool multi-relay demo
+npm run example:nip01:relay:pool
+
 # Filter types and subscription handling
 npm run example:nip01:relay:filters
 
@@ -44,14 +47,17 @@ npm run example:nip01:validation  # Located in examples/client/validation-flow.t
 ## Directory Structure
 
 - `/event` - Event-related examples
+
   - `event-ordering-demo.ts` - Demonstrates event ordering with timestamp and lexicographic ordering
   - `addressable-events.ts` - Shows how to work with addressable events (kinds 30000-39999)
   - `replaceable-events.ts` - Demonstrates replaceable events (kinds 0, 3, 10000-19999)
 
 - `/relay` - Relay-related examples
+
   - `relay-connection.ts` - Connection management with error handling and timeout configuration
   - `filter-types.ts` - Different filter types for subscription and event retrieval
   - `relay-reconnect.ts` - Relay reconnection with exponential backoff strategies
+  - `relay-pool.ts` - Manage multiple relays with RelayPool
 
 - Related examples in other directories:
   - `examples/client/validation-flow.ts` - NIP-01 event validation process
@@ -80,4 +86,4 @@ The examples in this directory demonstrate both basic and advanced usage pattern
 - Creating complex filter combinations
 - Handling event ordering with non-monotonic timestamps
 - Implementing proper reconnection backoff strategies
-- Managing subscription lifecycles 
+- Managing subscription lifecycles

--- a/examples/nip01/relay/relay-pool.ts
+++ b/examples/nip01/relay/relay-pool.ts
@@ -1,0 +1,77 @@
+/**
+ * Relay Pool Example
+ *
+ * This example demonstrates managing multiple relay connections using the
+ * RelayPool class. The pool simplifies publishing events to many relays and
+ * subscribing across them.
+ *
+ * Key concepts:
+ * - Creating a RelayPool with multiple relays
+ * - Publishing an event to all relays
+ * - Subscribing to events from every relay in the pool
+ *
+ * How to run:
+ * npm run example:nip01:relay:pool
+ */
+
+import { RelayPool } from "../../../src";
+import { createTextNote, createSignedEvent } from "../../../src/nip01/event";
+import { generateKeypair } from "../../../src/utils/crypto";
+import { NostrRelay } from "../../../src/utils/ephemeral-relay";
+import type { NostrEvent } from "../../../src/types/nostr";
+
+const USE_EPHEMERAL = process.env.USE_PUBLIC_RELAYS !== "true";
+const RELAY_PORTS = [3351, 3352];
+
+async function main() {
+  const relayUrls: string[] = [];
+  const ephemeralRelays: NostrRelay[] = [];
+
+  if (USE_EPHEMERAL) {
+    for (const port of RELAY_PORTS) {
+      const relay = new NostrRelay(port);
+      await relay.start();
+      ephemeralRelays.push(relay);
+      relayUrls.push(relay.url);
+    }
+    console.log(`Ephemeral relays running at ${relayUrls.join(", ")}`);
+  } else {
+    relayUrls.push("wss://relay.primal.net", "wss://relay.nostr.band");
+  }
+
+  const pool = new RelayPool(relayUrls);
+  const keys = await generateKeypair();
+  const unsigned = createTextNote("Hello from RelayPool", keys.privateKey);
+  const event = await createSignedEvent(unsigned, keys.privateKey);
+
+  console.log("Publishing event to relays...");
+  await Promise.all(pool.publish(relayUrls, event));
+
+  console.log("Subscribing for recent text notes...");
+  const received: Record<string, NostrEvent[]> = {};
+
+  const sub = await pool.subscribe(
+    relayUrls,
+    [{ kinds: [1], since: event.created_at - 60 }],
+    (ev, relay) => {
+      received[relay] = received[relay] || [];
+      received[relay].push(ev);
+      console.log(`Received from ${relay}: ${ev.content}`);
+    },
+    () => {
+      console.log("EOSE from all relays");
+    },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  sub.close();
+
+  if (USE_EPHEMERAL) {
+    ephemeralRelays.forEach((r) => r.close());
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "example:nip01:relay:connection": "ts-node examples/nip01/relay/relay-connection.ts",
     "example:nip01:relay:filters": "ts-node examples/nip01/relay/filter-types.ts",
     "example:nip01:relay:reconnect": "ts-node examples/nip01/relay/relay-reconnect.ts",
+    "example:nip01:relay:pool": "ts-node examples/nip01/relay/relay-pool.ts",
     "example:nip01:validation": "ts-node examples/client/validation-flow.ts",
     "// Example NIP": "-------------- Other NIP Examples --------------",
     "example:nip02": "ts-node examples/nip02/nip02-demo.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Export client classes
 export { Nostr } from "./nip01/nostr";
 export { Relay } from "./nip01/relay";
+export { RelayPool } from "./nip01/relayPool";
 
 // Export types from nip01/nostr.ts (Callback types)
 export type {

--- a/src/nip01/relayPool.ts
+++ b/src/nip01/relayPool.ts
@@ -1,0 +1,140 @@
+import { Relay } from "./relay";
+import {
+  NostrEvent,
+  Filter,
+  PublishOptions,
+  PublishResponse,
+} from "../types/nostr";
+import { RelayConnectionOptions } from "../types/protocol";
+
+export class RelayPool {
+  private relays: Map<string, Relay> = new Map();
+  private relayOptions?: RelayConnectionOptions;
+
+  constructor(relayUrls: string[] = [], options?: { relayOptions?: RelayConnectionOptions }) {
+    this.relayOptions = options?.relayOptions;
+    relayUrls.forEach((url) => this.addRelay(url));
+  }
+
+  public addRelay(url: string, options?: RelayConnectionOptions): Relay {
+    if (!url.startsWith("wss://") && !url.startsWith("ws://")) {
+      url = `wss://${url}`;
+    }
+    let relay = this.relays.get(url);
+    if (!relay) {
+      relay = new Relay(url, options || this.relayOptions);
+      this.relays.set(url, relay);
+    }
+    return relay;
+  }
+
+  public removeRelay(url: string): void {
+    if (!url.startsWith("wss://") && !url.startsWith("ws://")) {
+      url = `wss://${url}`;
+    }
+    const relay = this.relays.get(url);
+    if (relay) {
+      relay.disconnect();
+      this.relays.delete(url);
+    }
+  }
+
+  public async ensureRelay(url: string): Promise<Relay> {
+    const relay = this.addRelay(url);
+    await relay.connect();
+    return relay;
+  }
+
+  public close(relayUrls?: string[]): void {
+    if (relayUrls) {
+      relayUrls.forEach((url) => {
+        const relay = this.relays.get(url);
+        if (relay) relay.disconnect();
+      });
+    } else {
+      this.relays.forEach((relay) => relay.disconnect());
+    }
+  }
+
+  public publish(relays: string[], event: NostrEvent, options?: PublishOptions): Promise<PublishResponse>[] {
+    return relays.map(async (url) => {
+      const relay = await this.ensureRelay(url);
+      return relay.publish(event, options);
+    });
+  }
+
+  public async subscribe(
+    relays: string[],
+    filters: Filter[],
+    onEvent: (event: NostrEvent, relay: string) => void,
+    onEOSE?: () => void,
+  ): Promise<{ close: () => void }> {
+    const subscriptions: { relay: Relay; id: string }[] = [];
+    let eoseCount = 0;
+
+    const openPromises = Promise.all(
+      relays.map(async (url) => {
+        const relay = await this.ensureRelay(url);
+        const id = relay.subscribe(
+          filters,
+          (ev) => onEvent(ev, url),
+          () => {
+            eoseCount++;
+            if (eoseCount === relays.length && onEOSE) {
+              onEOSE();
+            }
+          },
+        );
+        subscriptions.push({ relay, id });
+      }),
+    );
+
+    return {
+      close: () => {
+        openPromises.then(() => {
+          subscriptions.forEach(({ relay, id }) => relay.unsubscribe(id));
+        });
+      },
+    };
+  }
+
+  public async querySync(
+    relays: string[],
+    filter: Filter,
+    options: { timeout?: number } = {},
+  ): Promise<NostrEvent[]> {
+    return new Promise(async (resolve) => {
+      const events: NostrEvent[] = [];
+      let timer: NodeJS.Timeout | null = null;
+
+      const sub = await this.subscribe(
+        relays,
+        [filter],
+        (ev) => events.push(ev),
+        () => {
+          if (timer) clearTimeout(timer);
+          sub.close();
+          resolve(events);
+        },
+      );
+
+      if (options.timeout && options.timeout > 0) {
+        timer = setTimeout(() => {
+          sub.close();
+          resolve(events);
+        }, options.timeout);
+      }
+    });
+  }
+
+  public async get(
+    relays: string[],
+    filter: Filter,
+    options: { timeout?: number } = {},
+  ): Promise<NostrEvent | null> {
+    const f = { ...filter, limit: 1 };
+    const events = await this.querySync(relays, f, options);
+    events.sort((a, b) => b.created_at - a.created_at);
+    return events[0] || null;
+  }
+}

--- a/tests/nip01/relayPool.test.ts
+++ b/tests/nip01/relayPool.test.ts
@@ -1,0 +1,65 @@
+import { RelayPool, NostrEvent } from "../../src";
+import { NostrRelay } from "../../src/utils/ephemeral-relay";
+import { generateKeypair } from "../../src/utils/crypto";
+import { createTextNote, createSignedEvent } from "../../src/nip01/event";
+
+const PORT1 = 4501;
+const PORT2 = 4502;
+
+describe("RelayPool", () => {
+  let relay1: NostrRelay;
+  let relay2: NostrRelay;
+
+  beforeAll(async () => {
+    relay1 = new NostrRelay(PORT1);
+    relay2 = new NostrRelay(PORT2);
+    await relay1.start();
+    await relay2.start();
+  });
+
+  afterAll(() => {
+    relay1.close();
+    relay2.close();
+  });
+
+  test("should publish events to multiple relays", async () => {
+    const pool = new RelayPool([relay1.url, relay2.url]);
+    const keys = await generateKeypair();
+    const unsigned = createTextNote("pool publish", keys.privateKey);
+    const event = await createSignedEvent(unsigned, keys.privateKey);
+
+    const results = await Promise.all(pool.publish([relay1.url, relay2.url], event));
+    expect(results).toHaveLength(2);
+    results.forEach((r) => expect(r.success).toBe(true));
+  });
+
+  test("should subscribe and receive events from all relays", async () => {
+    const pool = new RelayPool([relay1.url, relay2.url]);
+    const keys = await generateKeypair();
+
+    const received: Record<string, NostrEvent[]> = {
+      [relay1.url]: [],
+      [relay2.url]: [],
+    };
+
+    const sub = await pool.subscribe(
+      [relay1.url, relay2.url],
+      [{ kinds: [1] }],
+      (event, relay) => {
+        received[relay].push(event);
+      },
+    );
+
+    const ev1 = await createSignedEvent(createTextNote("from1", keys.privateKey), keys.privateKey);
+    const ev2 = await createSignedEvent(createTextNote("from2", keys.privateKey), keys.privateKey);
+
+    await Promise.all(pool.publish([relay1.url], ev1));
+    await Promise.all(pool.publish([relay2.url], ev2));
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    sub.close();
+
+    expect(received[relay1.url].length).toBeGreaterThan(0);
+    expect(received[relay2.url].length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- rename SimplePool to `RelayPool`
- export `RelayPool` from library index
- test multi-relay publishing and subscribing with `RelayPool`
- provide a `RelayPool` example and npm script
- document the new example in the README and examples guides

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845f957af40833080b5e4e254211da9