### PR TITLE
Fix tsconfig rootDir

### DIFF
--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../dist-examples",
-    "rootDir": "..",
+    "rootDir": "./",
     "baseUrl": "..",
     "paths": {
       "snstr": ["src"],

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,1 +1,7 @@
-../tsconfig.json
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../"
+  }
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "declaration": true,
     "outDir": "./dist",
-    "rootDir": "..",
+    "rootDir": "./",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -13,6 +13,6 @@
     "resolveJsonModule": true,
     "lib": ["es2020", "dom"]
   },
-  "include": ["./**/*.ts"],
+  "include": ["index.ts", "src/**/*.ts"],
   "exclude": ["node_modules", "dist", "coverage"]
-} 
+}


### PR DESCRIPTION
## Summary
- keep TypeScript compilation inside the repo by setting `rootDir` to `./`
- narrow compilation to only `src` and `index.ts`
- replace tests tsconfig symlink with file so Jest uses repo root

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6848f43ec2e48330a1deff7a965b996e