### PR TITLE
Fix README import paths

### DIFF
--- a/src/nip01/README.md
+++ b/src/nip01/README.md
@@ -19,7 +19,7 @@ NIP-01 is the foundational specification for Nostr, outlining the basic protocol
 ### Creating and Publishing Events
 
 ```typescript
-import { Nostr } from '../nip01/nostr';
+import { Nostr } from 'snstr';
 
 // Initialize client with relays
 const client = new Nostr(['wss://relay.nostr.band']);
@@ -40,7 +40,7 @@ console.log(`Published event with ID: ${event.id}`);
 ### Subscribing to Events
 
 ```typescript
-import { Nostr, RelayEvent } from '../nip01/nostr';
+import { Nostr, RelayEvent } from 'snstr';
 
 const client = new Nostr(['wss://relay.nostr.band']);
 
@@ -67,7 +67,8 @@ client.unsubscribe(subIds);
 ### Working with Events Directly
 
 ```typescript
-import { createEvent, validateEvent } from '../nip01/event';
+import { createEvent } from 'snstr';
+import { validateEvent } from 'snstr/nip01/event';
 
 // Create an event
 const event = createEvent({
@@ -120,7 +121,7 @@ The relay connection includes:
 ### Custom Event Handlers
 
 ```typescript
-import { Nostr, RelayEvent } from '../nip01/nostr';
+import { Nostr, RelayEvent } from 'snstr';
 
 const client = new Nostr(['wss://relay.nostr.band']);
 
@@ -145,7 +146,7 @@ client.on(RelayEvent.Notice, (relay, message) => {
 ### Custom Filters
 
 ```typescript
-import { Nostr } from '../nip01/nostr';
+import { Nostr } from 'snstr';
 
 const client = new Nostr(['wss://relay.nostr.band']);
 await client.connectToRelays();

--- a/src/nip02/README.md
+++ b/src/nip02/README.md
@@ -23,7 +23,7 @@ import {
   parseContactsFromEvent,
   Contact,
 } from './index';
-import { NostrEvent /*, signEvent */ } from '../types/nostr'; // Assuming signEvent and NostrEvent types
+import { NostrEvent /*, signEvent */ } from 'snstr'; // Assuming signEvent and NostrEvent types
 
 // Example: Creating a contact list event
 const myContacts: Contact[] = [

--- a/src/nip10/README.md
+++ b/src/nip10/README.md
@@ -15,7 +15,7 @@ NIP‑10 introduces marked `e` tags for replies and `q` tags for quoting other e
 ## Basic Usage
 
 ```typescript
-import { createReplyTags, createQuoteTag, parseThreadReferences } from 'snstr/nip10';
+import { createReplyTags, createQuoteTag, parseThreadReferences } from 'snstr';
 
 const eTags = createReplyTags(
   { id: rootId, relay: 'wss://relay.example.com' },

--- a/src/nip11/README.md
+++ b/src/nip11/README.md
@@ -18,7 +18,7 @@ NIP-11 defines a standard way for relays to publish information about their capa
 ### Fetching Relay Information
 
 ```typescript
-import { fetchRelayInformation } from 'snstr/nip11';
+import { fetchRelayInformation } from 'snstr';
 
 async function getRelayInfo() {
   const relayInfo = await fetchRelayInformation('wss://relay.example.com');
@@ -78,7 +78,7 @@ Here's an example of what the relay information JSON structure might look like:
 ### Checking for NIP Support
 
 ```typescript
-import { relaySupportsNIPs } from 'snstr/nip11';
+import { relaySupportsNIPs } from 'snstr';
 
 async function checkRelayCompatibility() {
   // Check if relay supports NIP-01, NIP-02, and NIP-04
@@ -95,7 +95,7 @@ async function checkRelayCompatibility() {
 ### Getting Payment Information
 
 ```typescript
-import { getRelayPaymentInfo, relayRequiresPayment } from 'snstr/nip11';
+import { getRelayPaymentInfo, relayRequiresPayment } from 'snstr';
 
 async function checkPaymentRequirements() {
   const requiresPayment = await relayRequiresPayment('wss://relay.example.com');
@@ -112,7 +112,7 @@ async function checkPaymentRequirements() {
 ### Working with Fee Schedules
 
 ```typescript
-import { fetchRelayInformation, RelayFees } from 'snstr/nip11';
+import { fetchRelayInformation, RelayFees } from 'snstr';
 
 async function checkRelayFees() {
   const relayInfo = await fetchRelayInformation('wss://relay.example.com');

--- a/src/nip17/README.md
+++ b/src/nip17/README.md
@@ -13,8 +13,11 @@ This module implements a basic version of [NIP-17](https://github.com/nostr-prot
 ## Basic Usage
 
 ```typescript
-import { createDirectMessage, decryptDirectMessage } from 'snstr/nip17';
-import { generateKeypair } from 'snstr';
+import {
+  createDirectMessage,
+  decryptDirectMessage,
+  generateKeypair,
+} from 'snstr';
 
 const alice = await generateKeypair();
 const bob = await generateKeypair();

--- a/src/nip21/README.md
+++ b/src/nip21/README.md
@@ -15,8 +15,11 @@ NIP‑21 defines a simple URI scheme `nostr:`. The path component is any NIP‑1
 ## Basic Usage
 
 ```typescript
-import { encodePublicKey } from "snstr";
-import { encodeNostrURI, decodeNostrURI } from "snstr/nip21";
+import {
+  encodePublicKey,
+  encodeNostrURI,
+  decodeNostrURI,
+} from "snstr";
 
 const npub = encodePublicKey(
   "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",

--- a/src/nip50/README.md
+++ b/src/nip50/README.md
@@ -15,8 +15,7 @@ Relays that support NIP-50 interpret the `search` string and return matching eve
 ## Basic Usage
 
 ```typescript
-import { Nostr } from 'snstr';
-import { createSearchFilter } from 'snstr/nip50';
+import { Nostr, createSearchFilter } from 'snstr';
 
 const client = new Nostr(['wss://relay.example.com']);
 await client.connectToRelays();

--- a/src/nip57/README.md
+++ b/src/nip57/README.md
@@ -27,7 +27,7 @@ The protocol supports both standard zaps (signed by the sender) and anonymous za
 The library provides an in-memory relay implementation for testing and development:
 
 ```typescript
-import { NostrRelay } from 'snstr/utils/ephemeral-relay';
+import { NostrRelay } from '../utils/ephemeral-relay';
 
 // Create an ephemeral relay on port 3000
 // Optional: purge events every 60 seconds

--- a/src/nip65/README.md
+++ b/src/nip65/README.md
@@ -40,9 +40,13 @@ Convenience helpers that extract just the relay URLs intended for reading or wri
 ## Usage Example
 
 ```ts
-import { createRelayListEvent, parseRelayList, getReadRelays } from "snstr/nip65";
+import {
+  createRelayListEvent,
+  parseRelayList,
+  getReadRelays,
+} from "snstr";
 import { createSignedEvent } from "snstr/nip01/event";
-import { generateKeypair } from "snstr/utils/crypto";
+import { generateKeypair } from "snstr";
 
 (async () => {
   const keys = await generateKeypair();

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -56,7 +56,7 @@ import {
   RelayDebugOptions,
   MetricsCollectorOptions,
   WebSocketReadyState 
-} from '../types/nostr';
+} from 'snstr';
 
 // Configure advanced reconnection strategy
 const reconnectionStrategy: ReconnectionStrategy = {
@@ -117,7 +117,7 @@ if ((relay as any).ws.readyState === WebSocketReadyState.OPEN) {
 ### Handling NostrEvents with NostrKind
 
 ```typescript
-import { NostrEvent, NostrKind } from '../types/nostr';
+import { NostrEvent, NostrKind } from 'snstr';
 
 function processEvent(event: NostrEvent) {
   console.log(`Event kind: ${event.kind}, from: ${event.pubkey.slice(0, 8)}...`);
@@ -151,7 +151,7 @@ function processEvent(event: NostrEvent) {
 ### Creating Filters
 
 ```typescript
-import { Filter, NostrKind } from '../types/nostr';
+import { Filter, NostrKind } from 'snstr';
 
 // Query recent text notes from specific authors
 const textNotesFilter: Filter = {
@@ -179,8 +179,7 @@ const customTagFilter: Filter = {
 ### Subscribing to Events
 
 ```typescript
-import { Filter, SubscriptionOptions } from '../types/nostr';
-import { Relay } from '../nip01/relay';
+import { Filter, SubscriptionOptions, Relay } from 'snstr';
 
 async function subscribeWithOptions(relay: Relay) {
   // Connect to the relay
@@ -224,8 +223,7 @@ async function subscribeWithOptions(relay: Relay) {
 ### Using Publish Options and Responses
 
 ```typescript
-import { NostrEvent, PublishOptions, PublishResponse } from '../types/nostr';
-import { Relay } from '../nip01/relay';
+import { NostrEvent, PublishOptions, PublishResponse, Relay } from 'snstr';
 
 async function publishWithOptions(relay: Relay, event: NostrEvent) {
   // With default options (waits for acknowledgment)
@@ -251,7 +249,7 @@ async function publishWithOptions(relay: Relay, event: NostrEvent) {
 ### Working with Relay Capabilities
 
 ```typescript
-import { RelayCapabilities, RelayInfo } from '../types/nostr';
+import { RelayCapabilities, RelayInfo } from 'snstr';
 
 // Parse relay information document
 function parseRelayCapabilities(info: RelayInfo): RelayCapabilities {
@@ -302,8 +300,7 @@ function adaptToRelayCapabilities(capabilities: RelayCapabilities) {
 ### Working with Relay Groups
 
 ```typescript
-import { RelayGroup, RelayStatus, NostrEvent } from '../types/nostr';
-import { Relay } from '../nip01/relay';
+import { RelayGroup, RelayStatus, NostrEvent, Relay } from 'snstr';
 
 async function useRelayGroups() {
   // Define a relay group
@@ -361,7 +358,7 @@ async function useRelayGroups() {
 ### Using the Message Statistics
 
 ```typescript
-import { RelayMessageStats } from '../types/nostr';
+import { RelayMessageStats } from 'snstr';
 
 // Initialize message stats for a relay
 function createMessageStats(): RelayMessageStats {
@@ -436,10 +433,10 @@ To extend the existing types with additional NIPs, you can use TypeScript's decl
 
 ```typescript
 // Example: Adding custom event kind to NostrKind enum
-import { NostrKind } from '../types/nostr';
+import { NostrKind } from 'snstr';
 
 // Extend the enum
-declare module '../types/nostr' {
+declare module 'snstr' {
   export enum NostrKind {
     // Add custom event kinds
     LongFormArticle = 30023,


### PR DESCRIPTION
## Summary
- correct import paths in NIP README files so they match public exports
- adjust remaining docs to use root-level imports

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849891db94c8330baef6848ea3101df