### PR TITLE
initial fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- NIP-01: normalize relay teardown by replacing socket lifecycle handlers with no-op callbacks during disconnect/cleanup to avoid listener-type crashes in strict WebSocket implementations (including some polyfills) that can propagate as CLI failures.
+
 ## [0.3.1] - 2026-02-09
 
 ### Fixed

--- a/src/nip01/README.md
+++ b/src/nip01/README.md
@@ -145,6 +145,7 @@ The relay connection includes:
 2. Connection pooling for efficient relay communication
 3. Message queue for handling offline scenarios
 4. Proper subscription management across reconnects
+5. Safe teardown paths for non-standard WebSocket implementations (e.g., polyfills) by replacing lifecycle callbacks with no-op functions during disconnect
 
 ### RelayPool Management
 

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -229,7 +229,7 @@ export class Relay {
 
           // Only reject the promise if we're still waiting to connect
           if (!wasConnected && this.connectionPromise) {
-            detachHandlers();
+            this.detachSocketHandlers(socket);
             this.connectionPromise = null;
             // Invalidate this attempt so any late socket events are ignored.
             // Auto-reconnect is handled in the catch() block below.

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -51,6 +51,7 @@ const WS_READY_STATE = {
 } as const;
 
 export class Relay {
+  private static readonly noopSocketHandler: BivariantHandler<unknown> = () => {};
   private url: string;
   private ws: WebSocketLike | null = null;
   private connected = false;
@@ -166,17 +167,6 @@ export class Relay {
           throw new Error("WebSocket implementation unavailable");
         }
 
-        const detachHandlers = () => {
-          try {
-            socket.onopen = null;
-            socket.onclose = null;
-            socket.onerror = null;
-            socket.onmessage = null;
-          } catch {
-            // Ignore failures (some implementations may not allow reassignment).
-          }
-        };
-
         // Set up connection timeout
         const timeoutId = setTimeout(() => {
           if (attemptId !== this.connectionAttempt) return;
@@ -188,7 +178,7 @@ export class Relay {
               new Error("connection timeout"),
             );
             try {
-              detachHandlers();
+              this.detachSocketHandlers(socket);
               const nodeWs = this.ws as unknown as {
                 readyState?: number;
                 close?: () => void;
@@ -260,7 +250,7 @@ export class Relay {
 
           // Only reject the promise if we haven't connected yet
           if (!this.connected && this.connectionPromise) {
-            detachHandlers();
+            this.detachSocketHandlers(socket);
             this.connectionPromise = null;
             // Invalidate this attempt so any late socket events are ignored.
             // Auto-reconnect is handled in the catch() block below.
@@ -352,14 +342,7 @@ export class Relay {
 
     try {
       // Detach handlers first so any late socket events don't fire callbacks after teardown.
-      try {
-        this.ws.onopen = null;
-        this.ws.onclose = null;
-        this.ws.onerror = null;
-        this.ws.onmessage = null;
-      } catch {
-        // Ignore failures (some implementations may not allow reassignment).
-      }
+      this.detachSocketHandlers(this.ws);
 
       // Clear all subscriptions to prevent further processing
       this.subscriptions.clear();
@@ -421,6 +404,23 @@ export class Relay {
       this.ws = null;
       this.connected = false;
       this.triggerEvent(RelayEvent.Disconnect, this.url);
+    }
+  }
+
+  private detachSocketHandlers(socket: WebSocketLike | null): void {
+    if (!socket) {
+      return;
+    }
+
+    try {
+      // Keep handlers callable for implementations that dispatch socket callbacks without type checks.
+      socket.onopen = Relay.noopSocketHandler as BivariantHandler<OpenEventLike>;
+      socket.onclose = Relay.noopSocketHandler as BivariantHandler<CloseEventLike>;
+      socket.onerror = Relay.noopSocketHandler as BivariantHandler<ErrorEventLike>;
+      socket.onmessage =
+        Relay.noopSocketHandler as BivariantHandler<MessageEventLike>;
+    } catch {
+      // Ignore failures (some implementations may not allow reassignment).
     }
   }
 

--- a/tests/nip01/relay/websocket-implementation.test.ts
+++ b/tests/nip01/relay/websocket-implementation.test.ts
@@ -126,6 +126,8 @@ describe("useWebSocketImplementation", () => {
     originalGlobalWebSocket = globalThis.WebSocket;
 
     MockWebSocket.instances.length = 0;
+    StrictDispatchWebSocket.instances.length = 0;
+    StrictDispatchWebSocket.lifecycle = "open";
     useWebSocketImplementation(MockWebSocket as unknown as typeof WebSocket);
   });
 
@@ -156,7 +158,6 @@ describe("useWebSocketImplementation", () => {
       capturedErrors.push(error);
     };
 
-    StrictDispatchWebSocket.instances.length = 0;
     useWebSocketImplementation(
       StrictDispatchWebSocket as unknown as typeof WebSocket,
     );
@@ -188,7 +189,6 @@ describe("useWebSocketImplementation", () => {
       capturedErrors.push(error);
     };
 
-    StrictDispatchWebSocket.instances.length = 0;
     StrictDispatchWebSocket.lifecycle = "close";
     useWebSocketImplementation(
       StrictDispatchWebSocket as unknown as typeof WebSocket,
@@ -222,7 +222,6 @@ describe("useWebSocketImplementation", () => {
       capturedErrors.push(error);
     };
 
-    StrictDispatchWebSocket.instances.length = 0;
     StrictDispatchWebSocket.lifecycle = "error";
     useWebSocketImplementation(
       StrictDispatchWebSocket as unknown as typeof WebSocket,
@@ -256,7 +255,6 @@ describe("useWebSocketImplementation", () => {
       capturedErrors.push(error);
     };
 
-    StrictDispatchWebSocket.instances.length = 0;
     StrictDispatchWebSocket.lifecycle = "hang";
     useWebSocketImplementation(
       StrictDispatchWebSocket as unknown as typeof WebSocket,

--- a/tests/nip01/relay/websocket-implementation.test.ts
+++ b/tests/nip01/relay/websocket-implementation.test.ts
@@ -84,11 +84,13 @@ class StrictDispatchWebSocket {
   close() {
     const listener = this._onclose;
     queueMicrotask(() => {
-      listener({
-        type: "close",
-        code: 1000,
-        reason: "Strict polyfill cleanup",
-      });
+      if (listener) {
+        listener({
+          type: "close",
+          code: 1000,
+          reason: "Strict polyfill cleanup",
+        });
+      }
     });
     this.readyState = StrictDispatchWebSocket.CLOSED;
   }

--- a/tests/nip01/relay/websocket-implementation.test.ts
+++ b/tests/nip01/relay/websocket-implementation.test.ts
@@ -29,6 +29,76 @@ class MockWebSocket {
   static CLOSED = 3;
 }
 
+class StrictDispatchWebSocket {
+  static instances: StrictDispatchWebSocket[] = [];
+  readyState = StrictDispatchWebSocket.CONNECTING;
+  private _onopen: (() => void) | null = null;
+  private _onclose:
+    | ((event: { type: string; code?: number; reason?: string }) => void)
+    | null = null;
+  private _onerror: ((error: unknown) => void) | null = null;
+  private _onmessage: ((msg: { data: string }) => void) | null = null;
+
+  constructor(public url: string) {
+    StrictDispatchWebSocket.instances.push(this);
+    setTimeout(() => {
+      this.readyState = StrictDispatchWebSocket.OPEN;
+      this._onopen?.();
+    }, 0);
+  }
+
+  get onopen() {
+    return this._onopen;
+  }
+  set onopen(handler: (() => void) | null) {
+    this._onopen = handler;
+  }
+
+  get onclose() {
+    return this._onclose;
+  }
+  set onclose(
+    handler:
+      | ((event: { type: string; code?: number; reason?: string }) => void)
+      | null,
+  ) {
+    this._onclose = handler;
+  }
+
+  get onerror() {
+    return this._onerror;
+  }
+  set onerror(handler: ((error: unknown) => void) | null) {
+    this._onerror = handler;
+  }
+
+  get onmessage() {
+    return this._onmessage;
+  }
+  set onmessage(handler: ((msg: { data: string }) => void) | null) {
+    this._onmessage = handler;
+  }
+
+  send(_data: string) {}
+
+  close() {
+    const listener = this._onclose;
+    queueMicrotask(() => {
+      listener({
+        type: "close",
+        code: 1000,
+        reason: "Strict polyfill cleanup",
+      });
+    });
+    this.readyState = StrictDispatchWebSocket.CLOSED;
+  }
+
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+}
+
 describe("useWebSocketImplementation", () => {
   let originalGlobalWebSocket: typeof WebSocket | undefined;
 
@@ -59,5 +129,37 @@ describe("useWebSocketImplementation", () => {
     expect(MockWebSocket.instances.length).toBe(1);
     expect(MockWebSocket.instances[0].url).toBe("wss://example.com");
     relay.disconnect();
+  });
+
+  test("Relay.disconnect should detach socket handlers safely for strict dispatchers", async () => {
+    const capturedErrors: unknown[] = [];
+    const handleUncaught = (error: unknown) => {
+      capturedErrors.push(error);
+    };
+
+    StrictDispatchWebSocket.instances.length = 0;
+    useWebSocketImplementation(
+      StrictDispatchWebSocket as unknown as typeof WebSocket,
+    );
+    const relay = new Relay("wss://example.com");
+
+    const connected = await relay.connect();
+    expect(connected).toBe(true);
+    expect(StrictDispatchWebSocket.instances.length).toBe(1);
+
+    const socket = StrictDispatchWebSocket.instances[0];
+    process.once("uncaughtException", handleUncaught);
+    try {
+      relay.disconnect();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(typeof socket.onopen).toBe("function");
+      expect(typeof socket.onclose).toBe("function");
+      expect(typeof socket.onerror).toBe("function");
+      expect(typeof socket.onmessage).toBe("function");
+      expect(capturedErrors).toHaveLength(0);
+    } finally {
+      process.removeListener("uncaughtException", handleUncaught);
+      relay.disconnect();
+    }
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes during relay disconnect for strict WebSocket implementations and polyfills by normalizing teardown so socket handlers are replaced with safe no-op callbacks.

* **Documentation**
  * Clarified relay WebSocket guidance to recommend safe teardown paths for non-standard implementations and fixed minor formatting.

* **Tests**
  * Added tests validating safe handler detachment across pre-connect and post-connect disconnect scenarios without uncaught exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches relay connection/teardown paths; behavior changes are localized but could affect disconnect/reconnect edge cases across runtimes and WebSocket implementations.
> 
> **Overview**
> Prevents relay teardown crashes with strict/non-standard WebSocket implementations by replacing `null` socket lifecycle handlers with no-op functions during disconnect and early connection-failure cleanup.
> 
> Adds regression tests using a strict WebSocket mock to ensure `Relay.disconnect()` (and pre-connect close/error/timeout paths) does not trigger uncaught exceptions, and updates NIP-01 docs/changelog to document the safer teardown behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 067deb9b29596ee7e9ce4a87d2479343439afa90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->