### PR TITLE
feat: add nip42 auth and relay-scoped APIs

### DIFF
--- a/FLOTILLA_BRANCH_CHECKLIST.md
+++ b/FLOTILLA_BRANCH_CHECKLIST.md
@@ -6,16 +6,16 @@ This file tracks the three feature branches for the `snstr` work needed to suppo
 
 Scope: authentication and relay-scoped data primitives that the other branches depend on.
 
-- [ ] Fix NIP-42 typing so relay AUTH challenges are represented correctly.
-- [ ] Add a dedicated `src/nip42/` module.
-- [ ] Add auth event builders and validators.
-- [ ] Add relay authentication send flow on `Relay`.
-- [ ] Add relay authentication entry points on `Nostr`.
-- [ ] Add relay-scoped subscribe/fetch helpers that preserve relay provenance.
-- [ ] Add relay-specific replaceable/addressable query helpers.
-- [ ] Add tests for NIP-42 challenge handling and auth publishing.
-- [ ] Add tests for relay-scoped event/query APIs.
-- [ ] Export the new APIs from `src/index.ts`.
+- [x] Fix NIP-42 typing so relay AUTH challenges are represented correctly.
+- [x] Add a dedicated `src/nip42/` module.
+- [x] Add auth event builders and validators.
+- [x] Add relay authentication send flow on `Relay`.
+- [x] Add relay authentication entry points on `Nostr`.
+- [x] Add relay-scoped subscribe/fetch helpers that preserve relay provenance.
+- [x] Add relay-specific replaceable/addressable query helpers.
+- [x] Add tests for NIP-42 challenge handling and auth publishing.
+- [x] Add tests for relay-scoped event/query APIs.
+- [x] Export the new APIs from `src/index.ts`.
 - [ ] Add README/example coverage for the new foundation APIs.
 
 ## Branch 2: `codex/flotilla-groups-nip29`
@@ -54,7 +54,7 @@ Scope: admin/moderation and higher-level ergonomics used by a Flotilla-like clie
 ## Shared Completion Checks
 
 - [ ] `npm test`
-- [ ] `npm run build`
-- [ ] `npm run lint`
+- [x] `npm run build`
+- [x] `npm run lint`
 - [ ] Public exports and docs stay aligned with implementation.
 - [ ] New examples reflect the intended Flotilla-facing usage.

--- a/src/entries/index.web.ts
+++ b/src/entries/index.web.ts
@@ -43,6 +43,17 @@ export {
   getEventHash,
 } from "../nip01/event";
 
+// Export NIP-42 utilities
+export {
+  AUTH_EVENT_KIND,
+  createAuthEventTemplate,
+  createSignedAuthEvent,
+  isAuthEvent,
+  validateAuthEvent,
+  parseAuthRequiredReason,
+} from "../nip42";
+export type { NIP42ValidationOptions } from "../nip42";
+
 // Export NIP-02 utilities
 export {
   createContactListEvent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,17 @@ export {
   getEventHash,
 } from "./nip01/event";
 
+// Export NIP-42 utilities
+export {
+  AUTH_EVENT_KIND,
+  createAuthEventTemplate,
+  createSignedAuthEvent,
+  isAuthEvent,
+  validateAuthEvent,
+  parseAuthRequiredReason,
+} from "./nip42";
+export type { NIP42ValidationOptions } from "./nip42";
+
 // Export NIP-02 utilities
 export {
   createContactListEvent,

--- a/src/nip01/nostr.ts
+++ b/src/nip01/nostr.ts
@@ -541,23 +541,7 @@ export class Nostr {
     tags: string[][] = [],
     options?: { timeout?: number },
   ): Promise<NostrEvent | null> {
-    // Rate limiting check
-    const rateLimitCheck = checkRateLimit(
-      this.publishRateLimit,
-      this.RATE_LIMITS.PUBLISH.limit,
-      this.RATE_LIMITS.PUBLISH.windowMs,
-    );
-
-    if (!rateLimitCheck.allowed) {
-      throw new SecurityValidationError(
-        `Publish rate limit exceeded. Try again in ${Math.ceil((rateLimitCheck.retryAfter || 0) / 1000)} seconds`,
-        "RATE_LIMIT_EXCEEDED",
-        "publish",
-      );
-    }
-
-    // Update rate limit state (increment count)
-    this.publishRateLimit.count++;
+    this.enforcePublishRateLimit();
 
     if (!this.privateKey || !this.publicKey) {
       throw new Error("Private key is not set");
@@ -739,21 +723,36 @@ export class Nostr {
     try {
       const validatedFilters = validateFilters(filters);
       const subscriptionIds: string[] = [];
+      const relaySubscriptions: Array<{
+        relay: Relay;
+        subscriptionId: string;
+      }> = [];
 
       this.relays.forEach((relay, url) => {
-        const subscriptionRef = { id: "" };
-        subscriptionRef.id = relay.subscribe(
-          validatedFilters,
-          (event) =>
-            onEvent({
-              event,
-              relay: url,
-              subscriptionId: subscriptionRef.id,
-            }),
-          onEOSE ? () => onEOSE(url, subscriptionRef.id) : undefined,
-          options,
-        );
-        subscriptionIds.push(subscriptionRef.id);
+        try {
+          const subscriptionRef = { id: "" };
+          subscriptionRef.id = relay.subscribe(
+            validatedFilters,
+            (event) =>
+              onEvent({
+                event,
+                relay: url,
+                subscriptionId: subscriptionRef.id,
+              }),
+            onEOSE ? () => onEOSE(url, subscriptionRef.id) : undefined,
+            options,
+          );
+          subscriptionIds.push(subscriptionRef.id);
+          relaySubscriptions.push({
+            relay,
+            subscriptionId: subscriptionRef.id,
+          });
+        } catch (error) {
+          relaySubscriptions.forEach(({ relay: activeRelay, subscriptionId }) =>
+            activeRelay.unsubscribe(subscriptionId),
+          );
+          throw error;
+        }
       });
 
       return subscriptionIds;
@@ -1229,6 +1228,8 @@ export class Nostr {
     auth: NostrEvent | string,
     options: PublishOptions & { createdAt?: number } = {},
   ): Promise<PublishResponse> {
+    this.enforcePublishRateLimit();
+
     const relay = this.getRelayByUrl(relayUrl);
     const { createdAt, ...publishOptions } = options;
 
@@ -1237,10 +1238,7 @@ export class Nostr {
         ? await this.createSignedAuthEventForRelay(relayUrl, auth, createdAt)
         : auth;
 
-    return relay.authenticate(authEvent, {
-      waitForAck: false,
-      ...publishOptions,
-    });
+    return relay.authenticate(authEvent, publishOptions);
   }
 
   private async createSignedAuthEventForRelay(
@@ -1270,5 +1268,23 @@ export class Nostr {
     }
 
     return relay;
+  }
+
+  private enforcePublishRateLimit(): void {
+    const rateLimitCheck = checkRateLimit(
+      this.publishRateLimit,
+      this.RATE_LIMITS.PUBLISH.limit,
+      this.RATE_LIMITS.PUBLISH.windowMs,
+    );
+
+    if (!rateLimitCheck.allowed) {
+      throw new SecurityValidationError(
+        `Publish rate limit exceeded. Try again in ${Math.ceil((rateLimitCheck.retryAfter || 0) / 1000)} seconds`,
+        "RATE_LIMIT_EXCEEDED",
+        "publish",
+      );
+    }
+
+    this.publishRateLimit.count++;
   }
 }

--- a/src/nip01/nostr.ts
+++ b/src/nip01/nostr.ts
@@ -2,12 +2,16 @@ import { Relay } from "./relay";
 import {
   NostrEvent,
   Filter,
+  RelayReceivedEvent,
   RelayEvent,
   ParsedOkReason,
+  PublishOptions,
+  PublishResponse,
   SubscriptionOptions,
 } from "../types/nostr";
 import { getPublicKey, generateKeypair } from "../utils/crypto";
 import { isValidRelayUrl } from "../nip19";
+import { createSignedAuthEvent } from "../nip42";
 import {
   createSignedEvent,
   createTextNote,
@@ -84,7 +88,7 @@ export type NostrClosedCallback = (
 ) => void;
 export type NostrAuthCallback = (
   relay: string,
-  challengeEvent: NostrEvent,
+  challenge: string,
 ) => void;
 
 export type NostrEventCallback =
@@ -105,7 +109,7 @@ type RelayOkHandler = (
   details: ParsedOkReason,
 ) => void;
 type RelayClosedHandler = (subscriptionId: string, message: string) => void;
-type RelayAuthHandler = (challengeEvent: NostrEvent) => void;
+type RelayAuthHandler = (challenge: string) => void;
 
 type RelayEventHandler =
   | RelayConnectHandler
@@ -243,8 +247,8 @@ export class Nostr {
           );
         };
       case RelayEvent.Auth:
-        return (challengeEvent: NostrEvent) => {
-          (originalCallback as NostrAuthCallback)(relayUrl, challengeEvent);
+        return (challenge: string) => {
+          (originalCallback as NostrAuthCallback)(relayUrl, challenge);
         };
       default:
         // Should not happen if RelayEvent enum is comprehensive
@@ -699,6 +703,20 @@ export class Nostr {
     onEOSE?: () => void,
     options: SubscriptionOptions = {},
   ): string[] {
+    return this.subscribeDetailed(
+      filters,
+      ({ event, relay }) => onEvent(event, relay),
+      onEOSE ? () => onEOSE() : undefined,
+      options,
+    );
+  }
+
+  public subscribeDetailed(
+    filters: Filter[],
+    onEvent: (receivedEvent: RelayReceivedEvent) => void,
+    onEOSE?: (relay: string, subscriptionId: string) => void,
+    options: SubscriptionOptions = {},
+  ): string[] {
     // Rate limiting check
     const rateLimitCheck = checkRateLimit(
       this.subscribeRateLimit,
@@ -723,13 +741,19 @@ export class Nostr {
       const subscriptionIds: string[] = [];
 
       this.relays.forEach((relay, url) => {
-        const id = relay.subscribe(
+        let relaySubscriptionId = "";
+        relaySubscriptionId = relay.subscribe(
           validatedFilters,
-          (event) => onEvent(event, url),
-          onEOSE,
+          (event) =>
+            onEvent({
+              event,
+              relay: url,
+              subscriptionId: relaySubscriptionId,
+            }),
+          onEOSE ? () => onEOSE(url, relaySubscriptionId) : undefined,
           options,
         );
-        subscriptionIds.push(id);
+        subscriptionIds.push(relaySubscriptionId);
       });
 
       return subscriptionIds;
@@ -768,6 +792,20 @@ export class Nostr {
     filters: Filter[],
     options: { maxWait?: number; signal?: AbortSignal } = {},
   ): Promise<NostrEvent[]> {
+    const detailedEvents = await this.fetchManyDetailed(filters, options);
+    const eventsMap = new Map<string, NostrEvent>();
+
+    for (const { event } of detailedEvents) {
+      eventsMap.set(event.id, event);
+    }
+
+    return Array.from(eventsMap.values());
+  }
+
+  public async fetchManyDetailed(
+    filters: Filter[],
+    options: { maxWait?: number; signal?: AbortSignal } = {},
+  ): Promise<RelayReceivedEvent[]> {
     // Rate limiting check
     const rateLimitCheck = checkRateLimit(
       this.fetchRateLimit,
@@ -796,14 +834,17 @@ export class Nostr {
         : 5000;
 
       return new Promise((resolve, reject) => {
-        const eventsMap = new Map<string, NostrEvent>();
+        const eventsMap = new Map<string, RelayReceivedEvent>();
         let eoseCount = 0;
         let isCleanedUp = false;
 
-        const subIds = this.subscribe(
+        const subIds = this.subscribeDetailed(
           validatedFilters,
-          (event) => {
-            eventsMap.set(event.id, event);
+          (receivedEvent) => {
+            eventsMap.set(
+              `${receivedEvent.relay}:${receivedEvent.event.id}`,
+              receivedEvent,
+            );
           },
           () => {
             eoseCount++;
@@ -868,6 +909,25 @@ export class Nostr {
     }
   }
 
+  public async fetchOneDetailed(
+    filters: Filter[],
+    options?: { maxWait?: number; signal?: AbortSignal },
+  ): Promise<RelayReceivedEvent | null> {
+    const limitedFilters = filters.map((f) => ({ ...f, limit: 1 }));
+    const events = await this.fetchManyDetailed(limitedFilters, options);
+
+    if (events.length === 0) return null;
+
+    events.sort((a, b) => {
+      if (a.event.created_at !== b.event.created_at) {
+        return b.event.created_at - a.event.created_at;
+      }
+      return a.event.id.localeCompare(b.event.id);
+    });
+
+    return events[0];
+  }
+
   /**
    * Retrieve the newest single event matching the filters from all relays.
    *
@@ -922,7 +982,7 @@ export class Nostr {
   ): void;
   public on(
     event: RelayEvent.Auth,
-    callback: (relay: string, challengeEvent: NostrEvent) => void,
+    callback: (relay: string, challenge: string) => void,
   ): void;
   public on(event: RelayEvent, callback: unknown): void {
     if (typeof callback !== "function") {
@@ -1129,5 +1189,85 @@ export class Nostr {
     }
 
     return Array.from(eventsMap.values());
+  }
+
+  public getLatestReplaceableEventFromRelay(
+    relayUrl: string,
+    pubkey: string,
+    kind: number,
+  ): NostrEvent | null {
+    const relay = this.getRelayByUrl(relayUrl);
+    return relay.getLatestReplaceableEvent(pubkey, kind) || null;
+  }
+
+  public getLatestAddressableEventFromRelay(
+    relayUrl: string,
+    kind: number,
+    pubkey: string,
+    dTagValue: string = "",
+  ): NostrEvent | null {
+    const relay = this.getRelayByUrl(relayUrl);
+    return relay.getLatestAddressableEvent(kind, pubkey, dTagValue) || null;
+  }
+
+  public getAddressableEventsByPubkeyFromRelay(
+    relayUrl: string,
+    pubkey: string,
+  ): NostrEvent[] {
+    return this.getRelayByUrl(relayUrl).getAddressableEventsByPubkey(pubkey);
+  }
+
+  public getAddressableEventsByKindFromRelay(
+    relayUrl: string,
+    kind: number,
+  ): NostrEvent[] {
+    return this.getRelayByUrl(relayUrl).getAddressableEventsByKind(kind);
+  }
+
+  public async authenticateRelay(
+    relayUrl: string,
+    auth: NostrEvent | string,
+    options: PublishOptions & { createdAt?: number } = {},
+  ): Promise<PublishResponse> {
+    const relay = this.getRelayByUrl(relayUrl);
+    const { createdAt, ...publishOptions } = options;
+
+    const authEvent =
+      typeof auth === "string"
+        ? await this.createSignedAuthEventForRelay(relayUrl, auth, createdAt)
+        : auth;
+
+    return relay.authenticate(authEvent, {
+      waitForAck: false,
+      ...publishOptions,
+    });
+  }
+
+  private async createSignedAuthEventForRelay(
+    relayUrl: string,
+    challenge: string,
+    createdAt?: number,
+  ): Promise<NostrEvent> {
+    if (!this.privateKey) {
+      throw new Error("Private key is not set");
+    }
+
+    return createSignedAuthEvent(
+      challenge,
+      relayUrl,
+      this.privateKey,
+      createdAt,
+    );
+  }
+
+  private getRelayByUrl(relayUrl: string): Relay {
+    const normalizedUrl = this.normalizeRelayUrl(relayUrl);
+    const relay = this.relays.get(normalizedUrl);
+
+    if (!relay) {
+      throw new Error(`Relay not found: ${normalizedUrl}`);
+    }
+
+    return relay;
   }
 }

--- a/src/nip01/nostr.ts
+++ b/src/nip01/nostr.ts
@@ -741,19 +741,19 @@ export class Nostr {
       const subscriptionIds: string[] = [];
 
       this.relays.forEach((relay, url) => {
-        let relaySubscriptionId = "";
-        relaySubscriptionId = relay.subscribe(
+        const subscriptionRef = { id: "" };
+        subscriptionRef.id = relay.subscribe(
           validatedFilters,
           (event) =>
             onEvent({
               event,
               relay: url,
-              subscriptionId: relaySubscriptionId,
+              subscriptionId: subscriptionRef.id,
             }),
-          onEOSE ? () => onEOSE(url, relaySubscriptionId) : undefined,
+          onEOSE ? () => onEOSE(url, subscriptionRef.id) : undefined,
           options,
         );
-        subscriptionIds.push(relaySubscriptionId);
+        subscriptionIds.push(subscriptionRef.id);
       });
 
       return subscriptionIds;
@@ -1261,7 +1261,8 @@ export class Nostr {
   }
 
   private getRelayByUrl(relayUrl: string): Relay {
-    const normalizedUrl = this.normalizeRelayUrl(relayUrl);
+    const preprocessedUrl = this.preprocessRelayUrl(relayUrl);
+    const normalizedUrl = this.normalizeRelayUrl(preprocessedUrl);
     const relay = this.relays.get(normalizedUrl);
 
     if (!relay) {

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -585,6 +585,25 @@ export class Relay {
     event: NostrEvent,
     options: PublishOptions = {},
   ): Promise<PublishResponse> {
+    return this.sendClientMessage(["EVENT", event], options, event.id);
+  }
+
+  public async authenticate(
+    authEvent: NostrEvent,
+    options: PublishOptions = {},
+  ): Promise<PublishResponse> {
+    return this.sendClientMessage(
+      ["AUTH", authEvent],
+      { waitForAck: false, ...options },
+      authEvent.id,
+    );
+  }
+
+  private async sendClientMessage(
+    message: unknown[],
+    options: PublishOptions = {},
+    ackEventId?: string,
+  ): Promise<PublishResponse> {
     if (!this.connected) {
       try {
         const connected = await this.connect();
@@ -615,16 +634,12 @@ export class Relay {
     }
 
     try {
-      // First send the event
-      const message = JSON.stringify(["EVENT", event]);
-      this.ws.send(message);
+      this.ws.send(JSON.stringify(message));
 
-      // If we don't need to wait for acknowledgment, return immediately
-      if (options.waitForAck === false) {
+      if (options.waitForAck === false || !ackEventId) {
         return { success: true, relay: this.url };
       }
 
-      // Return a Promise that will resolve when we get the OK response for this event
       return new Promise<PublishResponse>((resolve) => {
         const timeout = options.timeout ?? 10000;
         let timeoutId: NodeJS.Timeout | null = null;
@@ -635,7 +650,7 @@ export class Relay {
           success: boolean,
           details: ParsedOkReason,
         ) => {
-          if (eventId === event.id) {
+          if (eventId === ackEventId) {
             cleanup();
             resolve({
               success,
@@ -688,7 +703,7 @@ export class Relay {
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "unknown error";
-      console.error(`Error publishing event to ${this.url}:`, errorMessage);
+      console.error(`Error sending message to ${this.url}:`, errorMessage);
       return {
         success: false,
         reason: `error: ${errorMessage}`,
@@ -896,17 +911,15 @@ export class Relay {
         break;
       }
       case "AUTH": {
-        const [challengeEvent] = rest;
-        // Check if the challenge is a proper NostrEvent
-        if (this.isNostrEvent(challengeEvent)) {
-          this.triggerEvent(RelayEvent.Auth, challengeEvent);
+        const [challenge] = rest;
+        if (typeof challenge === "string") {
+          this.triggerEvent(RelayEvent.Auth, challenge);
         } else {
-          // If it's not a proper event, log an error
           this.triggerEvent(
             RelayEvent.Error,
             this.url,
             new Error(
-              `Invalid AUTH challenge: ${JSON.stringify(challengeEvent)}`,
+              `Invalid AUTH challenge: ${JSON.stringify(challenge)}`,
             ),
           );
         }
@@ -1180,7 +1193,7 @@ export class Relay {
   ): void;
   private triggerEvent(
     event: RelayEvent.Auth,
-    challengeEvent: NostrEvent,
+    challenge: string,
   ): void;
   private triggerEvent(event: RelayEvent, ...args: unknown[]): void {
     const callbacks = this.eventHandlers[event];

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -43,6 +43,12 @@ type WebSocketLike = {
   terminate?: () => void;
 };
 
+type ClientMessage =
+  | ["EVENT", NostrEvent]
+  | ["AUTH", NostrEvent]
+  | ["REQ", string, ...Filter[]]
+  | ["CLOSE", string];
+
 const WS_READY_STATE = {
   CONNECTING: 0,
   OPEN: 1,
@@ -600,7 +606,7 @@ export class Relay {
   }
 
   private async sendClientMessage(
-    message: unknown[],
+    message: ClientMessage,
     options: PublishOptions = {},
     ackEventId?: string,
   ): Promise<PublishResponse> {

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -600,7 +600,7 @@ export class Relay {
   ): Promise<PublishResponse> {
     return this.sendClientMessage(
       ["AUTH", authEvent],
-      { waitForAck: false, ...options },
+      { waitForAck: true, ...options },
       authEvent.id,
     );
   }
@@ -640,9 +640,8 @@ export class Relay {
     }
 
     try {
-      this.ws.send(JSON.stringify(message));
-
       if (options.waitForAck === false || !ackEventId) {
+        this.ws.send(JSON.stringify(message));
         return { success: true, relay: this.url };
       }
 
@@ -650,7 +649,26 @@ export class Relay {
         const timeout = options.timeout ?? 10000;
         let timeoutId: NodeJS.Timeout | null = null;
 
-        // Create unique handler function for this specific publish operation
+        const extractErrorEventId = (error: unknown): string | undefined => {
+          if (
+            error &&
+            typeof error === "object" &&
+            "details" in error &&
+            error.details &&
+            typeof error.details === "object" &&
+            "eventId" in error.details &&
+            typeof error.details.eventId === "string"
+          ) {
+            return error.details.eventId;
+          }
+
+          if (error instanceof Error && ackEventId && error.message.includes(ackEventId)) {
+            return ackEventId;
+          }
+
+          return undefined;
+        };
+
         const handleOk = (
           eventId: string,
           success: boolean,
@@ -667,8 +685,11 @@ export class Relay {
           }
         };
 
-        // Setup error handler in case of WebSocket errors during publishing
         const handleError = (_: string, error: unknown) => {
+          if (extractErrorEventId(error) !== ackEventId) {
+            return;
+          }
+
           cleanup();
           const errorMsg =
             error instanceof Error ? error.message : "unknown error";
@@ -679,13 +700,11 @@ export class Relay {
           });
         };
 
-        // Setup disconnect handler in case connection drops during wait
         const handleDisconnect = () => {
           cleanup();
           resolve({ success: false, reason: "disconnected", relay: this.url });
         };
 
-        // Helper to clean up all handlers and timeout
         const cleanup = () => {
           this.off(RelayEvent.OK, handleOk);
           this.off(RelayEvent.Error, handleError);
@@ -694,17 +713,28 @@ export class Relay {
           timeoutId = null;
         };
 
-        // Register the event handlers
         this.on(RelayEvent.OK, handleOk);
         this.on(RelayEvent.Error, handleError);
         this.on(RelayEvent.Disconnect, handleDisconnect);
 
-        // Set timeout to avoid hanging indefinitely
         timeoutId = setTimeout(() => {
           cleanup();
           resolve({ success: false, reason: "timeout", relay: this.url });
         }, timeout);
         maybeUnref(timeoutId);
+
+        try {
+          this.ws!.send(JSON.stringify(message));
+        } catch (error) {
+          cleanup();
+          const errorMsg =
+            error instanceof Error ? error.message : "unknown error";
+          resolve({
+            success: false,
+            reason: `error: ${errorMsg}`,
+            relay: this.url,
+          });
+        }
       });
     } catch (error) {
       const errorMessage =

--- a/src/nip42/index.ts
+++ b/src/nip42/index.ts
@@ -2,6 +2,7 @@ import { createSignedEvent, validateEvent } from "../nip01/event";
 import { EventTemplate, NIP20Prefix, NostrEvent } from "../types/nostr";
 import { getPublicKey } from "../utils/crypto";
 import { normalizeRelayUrl } from "../utils/relayUrl";
+import { sanitizeString, SECURITY_LIMITS } from "../utils/security-validator";
 
 export const AUTH_EVENT_KIND = 22242;
 
@@ -25,14 +26,21 @@ export function createAuthEventTemplate(
     throw new Error("Challenge must be a non-empty string");
   }
 
-  const normalizedRelay = normalizeRelayUrl(relayUrl);
+  const validatedChallenge = sanitizeString(
+    challenge,
+    SECURITY_LIMITS.MAX_TAG_ELEMENT_SIZE,
+  );
+  const normalizedRelay = sanitizeString(
+    normalizeRelayUrl(relayUrl),
+    SECURITY_LIMITS.MAX_TAG_ELEMENT_SIZE,
+  );
 
   return {
     kind: AUTH_EVENT_KIND,
     content: "",
     tags: [
       ["relay", normalizedRelay],
-      ["challenge", challenge],
+      ["challenge", validatedChallenge],
     ],
     ...(created_at !== undefined ? { created_at } : {}),
   };

--- a/src/nip42/index.ts
+++ b/src/nip42/index.ts
@@ -1,0 +1,115 @@
+import { createSignedEvent, validateEvent } from "../nip01/event";
+import { EventTemplate, NIP20Prefix, NostrEvent } from "../types/nostr";
+import { getPublicKey } from "../utils/crypto";
+import { normalizeRelayUrl } from "../utils/relayUrl";
+
+export const AUTH_EVENT_KIND = 22242;
+
+export interface NIP42ValidationOptions {
+  challenge?: string;
+  relayUrl?: string;
+  maxTimestampDrift?: number;
+  validateSignatures?: boolean;
+}
+
+function getTagValue(tags: string[][], tagName: string): string | undefined {
+  return tags.find((tag) => tag[0] === tagName)?.[1];
+}
+
+export function createAuthEventTemplate(
+  challenge: string,
+  relayUrl: string,
+  created_at?: number,
+): EventTemplate {
+  if (!challenge || typeof challenge !== "string") {
+    throw new Error("Challenge must be a non-empty string");
+  }
+
+  const normalizedRelay = normalizeRelayUrl(relayUrl);
+
+  return {
+    kind: AUTH_EVENT_KIND,
+    content: "",
+    tags: [
+      ["relay", normalizedRelay],
+      ["challenge", challenge],
+    ],
+    ...(created_at !== undefined ? { created_at } : {}),
+  };
+}
+
+export async function createSignedAuthEvent(
+  challenge: string,
+  relayUrl: string,
+  privateKey: string,
+  created_at?: number,
+): Promise<NostrEvent> {
+  const template = createAuthEventTemplate(challenge, relayUrl, created_at);
+  return createSignedEvent(
+    {
+      pubkey: getPublicKey(privateKey),
+      kind: template.kind,
+      tags: template.tags ?? [],
+      content: template.content,
+      created_at:
+        template.created_at ?? Math.floor(Date.now() / 1000),
+    },
+    privateKey,
+  );
+}
+
+export function isAuthEvent(event: NostrEvent): boolean {
+  if (event.kind !== AUTH_EVENT_KIND || event.content !== "") {
+    return false;
+  }
+
+  return Boolean(
+    getTagValue(event.tags, "relay") && getTagValue(event.tags, "challenge"),
+  );
+}
+
+export async function validateAuthEvent(
+  event: NostrEvent,
+  options: NIP42ValidationOptions = {},
+): Promise<boolean> {
+  if (!isAuthEvent(event)) {
+    throw new Error("Invalid NIP-42 auth event structure");
+  }
+
+  await validateEvent(event, {
+    maxTimestampDrift: options.maxTimestampDrift ?? 600,
+    validateSignatures: options.validateSignatures ?? true,
+  });
+
+  const relayTag = getTagValue(event.tags, "relay");
+  const challengeTag = getTagValue(event.tags, "challenge");
+
+  if (!relayTag || !challengeTag) {
+    throw new Error("Auth event must include relay and challenge tags");
+  }
+
+  if (options.relayUrl) {
+    const normalizedExpectedRelay = normalizeRelayUrl(options.relayUrl);
+    const normalizedRelayTag = normalizeRelayUrl(relayTag);
+    if (normalizedRelayTag !== normalizedExpectedRelay) {
+      throw new Error("Auth event relay tag does not match expected relay");
+    }
+  }
+
+  if (
+    options.challenge !== undefined &&
+    challengeTag !== options.challenge
+  ) {
+    throw new Error("Auth event challenge tag does not match expected challenge");
+  }
+
+  return true;
+}
+
+export function parseAuthRequiredReason(reason: string): string | undefined {
+  if (!reason.startsWith(NIP20Prefix.AuthRequired)) {
+    return undefined;
+  }
+
+  return reason.slice(NIP20Prefix.AuthRequired.length).trim();
+}

--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -761,7 +761,10 @@ export interface RelayInterface {
     onEose?: () => void,
   ): string;
   unsubscribe(subscriptionId: string): void;
-  publish(event: NostrEvent): Promise<PublishResponse>;
+  publish(
+    event: NostrEvent,
+    options?: PublishOptions,
+  ): Promise<PublishResponse>;
   authenticate(
     authEvent: NostrEvent,
     options?: PublishOptions,

--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -117,6 +117,15 @@ export type Subscription = {
   eoseTimer?: ReturnType<typeof setTimeout>;
 };
 
+export interface RelayReceivedEvent {
+  /** The event delivered by the relay */
+  event: NostrEvent;
+  /** The relay URL that delivered the event */
+  relay: string;
+  /** The relay-local subscription identifier */
+  subscriptionId: string;
+}
+
 /**
  * Relay event types as specified in NIP-01
  */
@@ -151,7 +160,7 @@ export type RelayEventCallbacks = {
     details: ParsedOkReason,
   ) => void;
   [RelayEvent.Closed]: (subscriptionId: string, message: string) => void;
-  [RelayEvent.Auth]: (challengeEvent: NostrEvent) => void;
+  [RelayEvent.Auth]: (challenge: string) => void;
 };
 
 /**
@@ -753,6 +762,10 @@ export interface RelayInterface {
   ): string;
   unsubscribe(subscriptionId: string): void;
   publish(event: NostrEvent): Promise<PublishResponse>;
+  authenticate(
+    authEvent: NostrEvent,
+    options?: PublishOptions,
+  ): Promise<PublishResponse>;
 }
 
 /**

--- a/tests/nip01/nostr.test.ts
+++ b/tests/nip01/nostr.test.ts
@@ -178,51 +178,91 @@ describe("Nostr Client", () => {
     });
 
     test("should fetch events with relay provenance preserved", async () => {
+      const secondRelay = await createEphemeralRelay();
+      client.addRelay(secondRelay.url);
       await client.generateKeys();
       await client.connectToRelays();
 
-      const note = await client.publishTextNote("relay-aware fetch");
-      expect(note).toBeDefined();
+      try {
+        const note = await client.publishTextNote("relay-aware fetch");
+        expect(note).toBeDefined();
 
-      const events = await client.fetchManyDetailed(
-        [{ ids: [note!.id] }],
-        { maxWait: 500 },
-      );
+        const events = await client.fetchManyDetailed(
+          [{ ids: [note!.id] }],
+          { maxWait: 500 },
+        );
 
-      expect(events).toHaveLength(1);
-      expect(events[0].relay).toBe(ephemeralRelay.url);
-      expect(events[0].event.id).toBe(note!.id);
+        expect(events).toHaveLength(2);
+        expect(events.map((event) => event.event.id)).toEqual([
+          note!.id,
+          note!.id,
+        ]);
+        expect(new Set(events.map((event) => event.relay))).toEqual(
+          new Set([ephemeralRelay.url, secondRelay.url]),
+        );
+      } finally {
+        await secondRelay.close();
+      }
     });
 
     test("should subscribe with relay provenance preserved", async () => {
+      const secondRelay = await createEphemeralRelay();
+      client.addRelay(secondRelay.url);
       await client.generateKeys();
       await client.connectToRelays();
 
-      const note = await client.publishTextNote("relay-aware subscribe");
-      expect(note).toBeDefined();
+      try {
+        const note = await client.publishTextNote("relay-aware subscribe");
+        expect(note).toBeDefined();
 
-      const received = await new Promise<RelayReceivedEvent>((resolve, reject) => {
-        let subscriptionIds: string[] = [];
-        const timeout = setTimeout(() => {
-          client.unsubscribe(subscriptionIds);
-          reject(new Error("Timed out waiting for detailed subscription event"));
-        }, 1000);
+        const received = await new Promise<RelayReceivedEvent[]>(
+          (resolve, reject) => {
+            let subscriptionIds: string[] = [];
+            const receivedEvents: RelayReceivedEvent[] = [];
+            const timeout = setTimeout(() => {
+              client.unsubscribe(subscriptionIds);
+              reject(
+                new Error("Timed out waiting for detailed subscription events"),
+              );
+            }, 1000);
 
-        subscriptionIds = client.subscribeDetailed(
-          [{ ids: [note!.id] }],
-          (relayEvent) => {
-            clearTimeout(timeout);
-            client.unsubscribe(subscriptionIds);
-            resolve(relayEvent);
+            subscriptionIds = client.subscribeDetailed(
+              [{ ids: [note!.id] }],
+              (relayEvent) => {
+                receivedEvents.push(relayEvent);
+
+                if (receivedEvents.length === 2) {
+                  clearTimeout(timeout);
+                  client.unsubscribe(subscriptionIds);
+                  resolve(receivedEvents);
+                }
+              },
+              undefined,
+              { autoClose: true, eoseTimeout: 500 },
+            );
           },
-          undefined,
-          { autoClose: true, eoseTimeout: 500 },
         );
-      });
 
-      expect(received.relay).toBe(ephemeralRelay.url);
-      expect(received.event.id).toBe(note!.id);
-      expect(received.subscriptionId).toBeTruthy();
+        expect(received).toHaveLength(2);
+        expect(new Set(received.map((event) => event.relay))).toEqual(
+          new Set([ephemeralRelay.url, secondRelay.url]),
+        );
+        expect(received.map((event) => event.event.id)).toEqual([
+          note!.id,
+          note!.id,
+        ]);
+
+        const subscriptionIdsByRelay = new Map(
+          received.map((event) => [event.relay, event.subscriptionId]),
+        );
+        expect(subscriptionIdsByRelay.get(ephemeralRelay.url)).toBeTruthy();
+        expect(subscriptionIdsByRelay.get(secondRelay.url)).toBeTruthy();
+        expect(
+          subscriptionIdsByRelay.get(ephemeralRelay.url),
+        ).not.toEqual(subscriptionIdsByRelay.get(secondRelay.url));
+      } finally {
+        await secondRelay.close();
+      }
     });
   });
 
@@ -1095,6 +1135,30 @@ describe("Nostr client", () => {
           ["challenge", "challenge-789"],
         ]),
       );
+    });
+
+    it("should reject authenticateRelay for unknown relays", async () => {
+      const nostr = new Nostr();
+      const keys = await generateKeypair();
+
+      getNostrInternals(nostr).privateKey = keys.privateKey;
+      getNostrInternals(nostr).publicKey = keys.publicKey;
+
+      await expect(
+        nostr.authenticateRelay("wss://mock-relay1.com", "challenge-789"),
+      ).rejects.toThrow("Relay not found");
+    });
+
+    it("should reject authenticateRelay when the private key is missing", async () => {
+      const nostr = new Nostr();
+      const relay = new MockRelay("wss://mock-relay1.com");
+
+      getNostrInternals(nostr).relays.set("wss://mock-relay1.com", relay);
+
+      await expect(
+        nostr.authenticateRelay("wss://mock-relay1.com", "challenge-789"),
+      ).rejects.toThrow("Private key is not set");
+      expect(relay.authenticateCalls).toHaveLength(0);
     });
   });
 });

--- a/tests/nip01/nostr.test.ts
+++ b/tests/nip01/nostr.test.ts
@@ -1,4 +1,11 @@
-import { Nostr, NostrEvent, Filter, RelayEvent, Relay } from "../../src";
+import {
+  Nostr,
+  NostrEvent,
+  Filter,
+  RelayEvent,
+  Relay,
+  RelayReceivedEvent,
+} from "../../src";
 import { NostrRelay } from "../../src/utils/ephemeral-relay";
 import { generateKeypair } from "../../src/utils/crypto";
 import { encrypt as encryptNIP04 } from "../../src/nip04";
@@ -80,6 +87,18 @@ describe("Nostr Client", () => {
       expect(connectCount).toBe(1);
     });
 
+    test("should surface relay auth challenges as strings", () => {
+      let challenge = "";
+      client.on(RelayEvent.Auth, (_relayUrl, nextChallenge) => {
+        challenge = nextChallenge;
+      });
+
+      const relay = Array.from(getNostrInternals(client).relays.values())[0];
+      asTestRelay(relay as Relay).handleMessage(["AUTH", "relay-challenge"]);
+
+      expect(challenge).toBe("relay-challenge");
+    });
+
     test("should disconnect from relays", async () => {
       await client.connectToRelays();
 
@@ -156,6 +175,54 @@ describe("Nostr Client", () => {
       await expect(
         client.publishTextNote("This should fail"),
       ).rejects.toThrow();
+    });
+
+    test("should fetch events with relay provenance preserved", async () => {
+      await client.generateKeys();
+      await client.connectToRelays();
+
+      const note = await client.publishTextNote("relay-aware fetch");
+      expect(note).toBeDefined();
+
+      const events = await client.fetchManyDetailed(
+        [{ ids: [note!.id] }],
+        { maxWait: 500 },
+      );
+
+      expect(events).toHaveLength(1);
+      expect(events[0].relay).toBe(ephemeralRelay.url);
+      expect(events[0].event.id).toBe(note!.id);
+    });
+
+    test("should subscribe with relay provenance preserved", async () => {
+      await client.generateKeys();
+      await client.connectToRelays();
+
+      const note = await client.publishTextNote("relay-aware subscribe");
+      expect(note).toBeDefined();
+
+      const received = await new Promise<RelayReceivedEvent>((resolve, reject) => {
+        let subscriptionIds: string[] = [];
+        const timeout = setTimeout(() => {
+          client.unsubscribe(subscriptionIds);
+          reject(new Error("Timed out waiting for detailed subscription event"));
+        }, 1000);
+
+        subscriptionIds = client.subscribeDetailed(
+          [{ ids: [note!.id] }],
+          (relayEvent) => {
+            clearTimeout(timeout);
+            client.unsubscribe(subscriptionIds);
+            resolve(relayEvent);
+          },
+          undefined,
+          { autoClose: true, eoseTimeout: 500 },
+        );
+      });
+
+      expect(received.relay).toBe(ephemeralRelay.url);
+      expect(received.event.id).toBe(note!.id);
+      expect(received.subscriptionId).toBeTruthy();
     });
   });
 
@@ -780,6 +847,8 @@ describe("Nostr client", () => {
   // Mock relay for testing
   class MockRelay {
     public publishResults: { success: boolean; reason?: string }[] = [];
+    public authResults: { success: boolean; reason?: string }[] = [];
+    public authenticateCalls: NostrEvent[] = [];
     public readonly url: string;
     public connected = true;
     private connectionTimeout = 10000;
@@ -793,6 +862,7 @@ describe("Nostr client", () => {
       this.publishResults = publishResults.length
         ? publishResults
         : [{ success: true }];
+      this.authResults = [{ success: true }];
       if (options.connectionTimeout !== undefined) {
         this.connectionTimeout = options.connectionTimeout;
       }
@@ -810,6 +880,16 @@ describe("Nostr client", () => {
       return this.publishResults.length > 1
         ? this.publishResults.shift()!
         : this.publishResults[0];
+    }
+
+    public async authenticate(
+      authEvent: NostrEvent,
+      _options: { timeout?: number; waitForAck?: boolean } = {},
+    ): Promise<{ success: boolean; reason?: string }> {
+      this.authenticateCalls.push(authEvent);
+      return this.authResults.length > 1
+        ? this.authResults.shift()!
+        : this.authResults[0];
     }
 
     disconnect(): void {
@@ -986,6 +1066,34 @@ describe("Nostr client", () => {
       );
       expect(result.relayResults.get("wss://mock-relay3.com")?.success).toBe(
         true,
+      );
+    });
+  });
+
+  describe("authenticateRelay", () => {
+    it("should create and send a signed auth event from a challenge", async () => {
+      const nostr = new Nostr();
+      const relay = new MockRelay("wss://mock-relay1.com");
+      const keys = await generateKeypair();
+
+      getNostrInternals(nostr).relays.set("wss://mock-relay1.com", relay);
+      getNostrInternals(nostr).privateKey = keys.privateKey;
+      getNostrInternals(nostr).publicKey = keys.publicKey;
+
+      const result = await nostr.authenticateRelay(
+        "wss://mock-relay1.com",
+        "challenge-789",
+      );
+
+      expect(result.success).toBe(true);
+      expect(relay.authenticateCalls).toHaveLength(1);
+      expect(relay.authenticateCalls[0].kind).toBe(22242);
+      expect(relay.authenticateCalls[0].content).toBe("");
+      expect(relay.authenticateCalls[0].tags).toEqual(
+        expect.arrayContaining([
+          ["relay", "wss://mock-relay1.com"],
+          ["challenge", "challenge-789"],
+        ]),
       );
     });
   });

--- a/tests/nip01/nostr.test.ts
+++ b/tests/nip01/nostr.test.ts
@@ -1160,6 +1160,60 @@ describe("Nostr client", () => {
       ).rejects.toThrow("Private key is not set");
       expect(relay.authenticateCalls).toHaveLength(0);
     });
+
+    it("should enforce publish rate limits for authenticateRelay", async () => {
+      const nostr = new Nostr([], {
+        rateLimits: {
+          publish: { limit: 1, windowMs: 60000 },
+        },
+      });
+      const relay = new MockRelay("wss://mock-relay1.com");
+      const keys = await generateKeypair();
+
+      getNostrInternals(nostr).relays.set("wss://mock-relay1.com", relay);
+      getNostrInternals(nostr).privateKey = keys.privateKey;
+      getNostrInternals(nostr).publicKey = keys.publicKey;
+
+      await expect(
+        nostr.authenticateRelay("wss://mock-relay1.com", "challenge-1"),
+      ).resolves.toMatchObject({ success: true });
+
+      await expect(
+        nostr.authenticateRelay("wss://mock-relay1.com", "challenge-2"),
+      ).rejects.toThrow(/Publish rate limit exceeded/);
+      expect(relay.authenticateCalls).toHaveLength(1);
+    });
+  });
+});
+
+describe("Detailed subscription cleanup", () => {
+  it("should unsubscribe earlier relays when a later detailed subscribe fails", () => {
+    const nostr = new Nostr();
+    const firstRelay = {
+      subscribe: jest.fn().mockReturnValue("sub-1"),
+      unsubscribe: jest.fn(),
+    };
+    const secondRelay = {
+      subscribe: jest.fn(() => {
+        throw new Error("subscribe failed");
+      }),
+      unsubscribe: jest.fn(),
+    };
+
+    getNostrInternals(nostr).relays.set(
+      "wss://mock-relay1.com",
+      firstRelay as unknown as Relay,
+    );
+    getNostrInternals(nostr).relays.set(
+      "wss://mock-relay2.com",
+      secondRelay as unknown as Relay,
+    );
+
+    expect(() =>
+      nostr.subscribeDetailed([{ kinds: [1], limit: 1 }], () => {}),
+    ).toThrow(/subscribe failed/);
+    expect(firstRelay.unsubscribe).toHaveBeenCalledWith("sub-1");
+    expect(secondRelay.unsubscribe).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/nip01/relay/relay.test.ts
+++ b/tests/nip01/relay/relay.test.ts
@@ -184,6 +184,16 @@ describe("Relay", () => {
         relay.on(RelayEvent.Error, () => {});
       }).not.toThrow();
     });
+
+    test("should surface AUTH challenges as strings", () => {
+      const relay = new Relay(ephemeralRelay.url);
+      const authHandler = jest.fn();
+
+      relay.on(RelayEvent.Auth, authHandler);
+      asTestRelay(relay).handleMessage(["AUTH", "challenge-123"]);
+
+      expect(authHandler).toHaveBeenCalledWith("challenge-123");
+    });
   });
 
   describe("Publishing Events", () => {
@@ -298,6 +308,44 @@ describe("Relay", () => {
 
       // Restore the original implementation
       relay.on = originalOn;
+    });
+
+    test("should send AUTH events to the relay", async () => {
+      const authRelay = new Relay(ephemeralRelay.url);
+      const send = jest.fn();
+      const relayInternals = asTestRelay(authRelay);
+
+      relayInternals.connected = true;
+      relayInternals.ws = {
+        readyState: 1,
+        onopen: null,
+        onclose: null,
+        onerror: null,
+        onmessage: null,
+        send,
+        close: jest.fn(),
+      } as unknown as WebSocket;
+
+      const authEvent: NostrEvent = {
+        id: "auth-event-id",
+        pubkey: "f".repeat(64),
+        created_at: Math.floor(Date.now() / 1000),
+        kind: 22242,
+        tags: [
+          ["relay", ephemeralRelay.url],
+          ["challenge", "challenge-abc"],
+        ],
+        content: "",
+        sig: "a".repeat(128),
+      };
+
+      const result = await authRelay.authenticate(authEvent);
+
+      expect(send).toHaveBeenCalledWith(JSON.stringify(["AUTH", authEvent]));
+      expect(result).toEqual({
+        success: true,
+        relay: ephemeralRelay.url,
+      });
     });
 
     test("should resolve with timeout reason after timeout with no OK response", async () => {

--- a/tests/nip01/relay/relay.test.ts
+++ b/tests/nip01/relay/relay.test.ts
@@ -328,7 +328,96 @@ describe("Relay", () => {
       relay.on = originalOn;
     });
 
-    test("should send AUTH events to the relay", async () => {
+    test("should send AUTH events to the relay and wait for OK by default", async () => {
+      const authRelay = new Relay(ephemeralRelay.url);
+      const relayInternals = asTestRelay(authRelay);
+
+      relayInternals.connected = true;
+      relayInternals.ws = {
+        readyState: 1,
+        onopen: null,
+        onclose: null,
+        onerror: null,
+        onmessage: null,
+        send: jest.fn((payload: string) => {
+          expect(payload).toBe(JSON.stringify(["AUTH", authEvent]));
+          relayInternals.handleMessage(["OK", authEvent.id, true, "accepted"]);
+        }),
+        close: jest.fn(),
+      } as unknown as WebSocket;
+
+      const authEvent: NostrEvent = {
+        id: "auth-event-id",
+        pubkey: "f".repeat(64),
+        created_at: Math.floor(Date.now() / 1000),
+        kind: 22242,
+        tags: [
+          ["relay", ephemeralRelay.url],
+          ["challenge", "challenge-abc"],
+        ],
+        content: "",
+        sig: "a".repeat(128),
+      };
+
+      const result = await authRelay.authenticate(authEvent);
+
+      expect(result).toEqual({
+        success: true,
+        reason: "accepted",
+        parsedReason: {
+          rawMessage: "accepted",
+          message: "accepted",
+        },
+        relay: ephemeralRelay.url,
+      });
+    });
+
+    test("should ignore unrelated relay errors while waiting for OK", async () => {
+      const callbacks = new Map<RelayEvent, AnyRelayCallback>();
+      const originalOn = relay.on;
+      relay.on = jest.fn((event: RelayEvent, callback: AnyRelayCallback) => {
+        callbacks.set(event, callback);
+        return originalOn.call(relay, event, callback);
+      });
+
+      const event: NostrEvent = {
+        id: "test-event-id-unrelated-error",
+        pubkey: "test-pubkey",
+        created_at: Math.floor(Date.now() / 1000),
+        kind: 1,
+        tags: [],
+        content: "Test event content",
+        sig: "test-signature",
+      };
+
+      const publishPromise = relay.publish(event);
+
+      const errorCallback = callbacks.get(RelayEvent.Error) as (
+        relayUrl: string,
+        error: unknown,
+      ) => void;
+      const okCallback = callbacks.get(RelayEvent.OK) as RelayOkCallback;
+
+      errorCallback(ephemeralRelay.url, new Error("unrelated relay error"));
+      okCallback(event.id, true, {
+        rawMessage: "accepted",
+        message: "accepted",
+      });
+
+      await expect(publishPromise).resolves.toEqual({
+        success: true,
+        reason: "accepted",
+        parsedReason: {
+          rawMessage: "accepted",
+          message: "accepted",
+        },
+        relay: ephemeralRelay.url,
+      });
+
+      relay.on = originalOn;
+    });
+
+    test("should support waitForAck false for AUTH events", async () => {
       const authRelay = new Relay(ephemeralRelay.url);
       const send = jest.fn();
       const relayInternals = asTestRelay(authRelay);
@@ -357,7 +446,9 @@ describe("Relay", () => {
         sig: "a".repeat(128),
       };
 
-      const result = await authRelay.authenticate(authEvent);
+      const result = await authRelay.authenticate(authEvent, {
+        waitForAck: false,
+      });
 
       expect(send).toHaveBeenCalledWith(JSON.stringify(["AUTH", authEvent]));
       expect(result).toEqual({

--- a/tests/nip01/relay/relay.test.ts
+++ b/tests/nip01/relay/relay.test.ts
@@ -194,6 +194,24 @@ describe("Relay", () => {
 
       expect(authHandler).toHaveBeenCalledWith("challenge-123");
     });
+
+    test("should reject non-string AUTH challenges", () => {
+      const relay = new Relay(ephemeralRelay.url);
+      const authHandler = jest.fn();
+      const errorHandler = jest.fn();
+
+      relay.on(RelayEvent.Auth, authHandler);
+      relay.on(RelayEvent.Error, errorHandler);
+      asTestRelay(relay).handleMessage(["AUTH", 123]);
+
+      expect(authHandler).not.toHaveBeenCalled();
+      expect(errorHandler).toHaveBeenCalledTimes(1);
+      expect(errorHandler.mock.calls[0][0]).toBe(ephemeralRelay.url);
+      expect(errorHandler.mock.calls[0][1]).toBeInstanceOf(Error);
+      expect(errorHandler.mock.calls[0][1].message).toContain(
+        "Invalid AUTH challenge",
+      );
+    });
   });
 
   describe("Publishing Events", () => {

--- a/tests/nip42/nip42.test.ts
+++ b/tests/nip42/nip42.test.ts
@@ -66,4 +66,22 @@ describe("NIP-42", () => {
       ["challenge", "entry-challenge"],
     ]);
   });
+
+  test("should reject oversized auth challenge tag values", () => {
+    expect(() =>
+      createAuthEventTemplate(
+        "c".repeat(513),
+        "wss://relay.example.com",
+      ),
+    ).toThrow(/maximum length/i);
+  });
+
+  test("should reject oversized normalized relay tag values", () => {
+    expect(() =>
+      createAuthEventTemplate(
+        "challenge",
+        `wss://relay.example.com/${"r".repeat(600)}`,
+      ),
+    ).toThrow(/maximum length/i);
+  });
 });

--- a/tests/nip42/nip42.test.ts
+++ b/tests/nip42/nip42.test.ts
@@ -6,6 +6,7 @@ import {
   parseAuthRequiredReason,
   validateAuthEvent,
 } from "../../src/nip42";
+import { createAuthEventTemplate as createAuthEventTemplateFromEntry } from "../../src";
 import { generateKeypair } from "../../src/utils/crypto";
 
 describe("NIP-42", () => {
@@ -50,5 +51,19 @@ describe("NIP-42", () => {
       "membership required",
     );
     expect(parseAuthRequiredReason("blocked: nope")).toBeUndefined();
+  });
+
+  test("should expose NIP-42 helpers from the main entry surface", () => {
+    const template = createAuthEventTemplateFromEntry(
+      "entry-challenge",
+      "wss://relay.example.com",
+      42,
+    );
+
+    expect(template.kind).toBe(AUTH_EVENT_KIND);
+    expect(template.tags).toEqual([
+      ["relay", "wss://relay.example.com"],
+      ["challenge", "entry-challenge"],
+    ]);
   });
 });

--- a/tests/nip42/nip42.test.ts
+++ b/tests/nip42/nip42.test.ts
@@ -1,0 +1,54 @@
+import {
+  AUTH_EVENT_KIND,
+  createAuthEventTemplate,
+  createSignedAuthEvent,
+  isAuthEvent,
+  parseAuthRequiredReason,
+  validateAuthEvent,
+} from "../../src/nip42";
+import { generateKeypair } from "../../src/utils/crypto";
+
+describe("NIP-42", () => {
+  test("should create an auth event template with normalized relay tag", () => {
+    const template = createAuthEventTemplate(
+      "challenge-123",
+      "WSS://Relay.Example.com/",
+      1234,
+    );
+
+    expect(template.kind).toBe(AUTH_EVENT_KIND);
+    expect(template.content).toBe("");
+    expect(template.created_at).toBe(1234);
+    expect(template.tags).toEqual([
+      ["relay", "wss://relay.example.com"],
+      ["challenge", "challenge-123"],
+    ]);
+  });
+
+  test("should create and validate a signed auth event", async () => {
+    const keypair = await generateKeypair();
+    const authEvent = await createSignedAuthEvent(
+      "challenge-456",
+      "wss://relay.example.com",
+      keypair.privateKey,
+      Math.floor(Date.now() / 1000),
+    );
+
+    expect(authEvent.kind).toBe(AUTH_EVENT_KIND);
+    expect(isAuthEvent(authEvent)).toBe(true);
+
+    await expect(
+      validateAuthEvent(authEvent, {
+        challenge: "challenge-456",
+        relayUrl: "wss://relay.example.com",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("should parse auth-required NIP-20 reasons", () => {
+    expect(parseAuthRequiredReason("auth-required: membership required")).toBe(
+      "membership required",
+    );
+    expect(parseAuthRequiredReason("blocked: nope")).toBeUndefined();
+  });
+});

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1,6 +1,8 @@
 import {
   Nostr,
   NostrEvent,
+  PublishOptions,
+  PublishResponse,
   Relay,
   RelayEvent,
   RelayEventCallbacks,
@@ -15,11 +17,11 @@ import { normalizeRelayUrl as normalizeRelayUrlUtil } from "../../src/utils/rela
 export interface MockRelay {
   url: string;
   connected: boolean;
-  publishResults: { success: boolean; reason?: string }[];
+  publishResults: PublishResponse[];
   publish(
     event: NostrEvent,
-    options?: { timeout?: number },
-  ): Promise<{ success: boolean; reason?: string }>;
+    options?: PublishOptions,
+  ): Promise<PublishResponse>;
   connect(): Promise<boolean>;
   disconnect(): void;
   on(): void;
@@ -35,8 +37,8 @@ export interface MockRelay {
   getAddressableEventsByKind?(kind: number): NostrEvent[];
   authenticate?(
     authEvent: NostrEvent,
-    options?: { timeout?: number; waitForAck?: boolean },
-  ): Promise<{ success: boolean; reason?: string }>;
+    options?: PublishOptions,
+  ): Promise<PublishResponse>;
   getLatestReplaceableEvent?(pubkey: string, kind: number): NostrEvent | undefined;
 }
 

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -33,6 +33,11 @@ export interface MockRelay {
   ): NostrEvent | undefined;
   getAddressableEventsByPubkey?(pubkey: string): NostrEvent[];
   getAddressableEventsByKind?(kind: number): NostrEvent[];
+  authenticate?(
+    authEvent: NostrEvent,
+    options?: { timeout?: number; waitForAck?: boolean },
+  ): Promise<{ success: boolean; reason?: string }>;
+  getLatestReplaceableEvent?(pubkey: string, kind: number): NostrEvent | undefined;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NIP-42 authentication support: create, sign, validate, and parse auth events.
  * Relay-focused APIs: publish/authenticate to relays and relay-specific event queries.
  * Detailed fetch/subscribe variants that preserve per-relay context and metadata.

* **Public API Changes**
  * Auth challenges surfaced as plain strings in callbacks (instead of full events).

* **Tests**
  * New end-to-end and unit tests covering NIP-42 flows, relay auth, and relay provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->