### PR TITLE
Merge staging into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-07-06
+
+### Changed
+- NIP-01 event hashing, signed event validation, and relay ingress validation now share the centralized event validation path.
+- Relay inbound event timestamp drift can be configured through `RelayConnectionOptions.inboundValidation`.
+
+### Fixed
+- Relay ingress now requires signed events and validates NIP-01 `e`, `p`, and `a` tag references with lowercase hex semantics.
+- NIP-46 relay ingress now requires lowercase `p` tags consistently with event and filter validation.
+- Non-finite `created_at` values are rejected before timestamp drift enforcement.
+- Issue-tracker agent docs now show machine-readable GitHub issue reads and heredoc body-file usage.
+
 ## [0.3.3] - 2026-03-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SNSTR (Secure Nostr Software Toolkit for Renegades) is a comprehensive TypeScript library for the Nostr protocol. It implements multiple NIPs (Nostr Implementation Possibilities) with a focus on security, performance, and ease of use.
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live in GitHub Issues; external PRs are not a triage request surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default Matt Pocock skill label vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repo with root `CONTEXT.md` and root `docs/adr/` decisions. See `docs/agents/domain.md`.
+
 ## Essential Commands
 
 ### Build and Development

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# SNSTR
+
+SNSTR is a TypeScript library for building Nostr protocol clients, relay interactions, signing flows, and NIP-specific utilities.
+
+## Language
+
+**Nostr Event**:
+A signed protocol message with an id, public key, timestamp, kind, tags, content, and signature.
+_Avoid_: Message, payload
+
+**Event Template**:
+An unsigned description of a Nostr Event before its id and signature are produced.
+_Avoid_: Draft event, event input
+
+**Relay**:
+A WebSocket endpoint that receives, stores, filters, and returns Nostr Events.
+_Avoid_: Server, broker
+
+**Subscription Filter**:
+A Nostr filter object sent to a Relay to select matching Nostr Events.
+_Avoid_: Query, search parameters
+
+**NIP**:
+A Nostr Implementation Possibility that defines a protocol behavior or interoperable extension.
+_Avoid_: Plugin, feature spec

--- a/RELEASE_NOTES_0.3.4.md
+++ b/RELEASE_NOTES_0.3.4.md
@@ -1,0 +1,21 @@
+# snstr v0.3.4
+
+Release date: 2026-07-06
+
+## Highlights
+
+- Centralized NIP-01 event validation so event hashing, signed validation, and relay ingress use the same shape and tag checks.
+- Hardened relay ingress by requiring signed events, lowercase relay tag references, and lowercase NIP-46 `p` tags.
+- Added configurable inbound timestamp drift settings for relays.
+
+## Reliability fixes
+
+- Rejects non-finite `created_at` values before drift calculations.
+- Keeps relay validation defaults unchanged while allowing explicit future and past drift overrides.
+- Replaces a fixed relay validation test delay with bounded polling for async validation settlement.
+
+## Notes for release
+
+- Version bump: `0.3.3` -> `0.3.4`
+- Changelog entry: `CHANGELOG.md`
+- Suggested compare link: `https://github.com/AustinKelsay/snstr/compare/v0.3.3...v0.3.4`

--- a/docs/adr/0001-centralize-nostr-event-validation.md
+++ b/docs/adr/0001-centralize-nostr-event-validation.md
@@ -1,0 +1,13 @@
+# Centralize Nostr Event validation
+
+SNSTR currently validates Nostr Events in the event module, a generic security utility, and Relay-private methods, which splits locality for the same protocol facts. We will preserve the public `validateEvent` interface while introducing a dedicated internal validation module with separate seams for unknown input sanitization and signed-event verification, so Relay accepts events by using that module rather than carrying its own validation implementation.
+
+## Considered Options
+
+- Keep Relay-private validation and only extract helpers. Rejected because it keeps tests tied to private Relay implementation and leaves validation rules split across modules.
+- Replace the public `validateEvent` export. Rejected because it would break callers for a cleanup whose value is internal depth and locality.
+
+## Consequences
+
+- Tests should exercise validation through public event and Relay behavior wherever possible.
+- Relay-specific exceptions, such as NIP-46 encrypted events, must be explicit options at the validation seam rather than hidden branches in Relay.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,32 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists. It points at one `CONTEXT.md` per context; read each one relevant to the topic.
+- **`docs/adr/`** for ADRs that touch the area being changed.
+
+If any of these files do not exist, proceed silently. The `/domain-modeling` skill creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This repo uses a single-context layout:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When output names a domain concept in an issue title, refactor proposal, hypothesis, or test name, use the term as defined in `CONTEXT.md`. Do not drift to synonyms the glossary explicitly avoids.
+
+If a needed concept is missing from the glossary, either reconsider the term or add it through `/domain-modeling`.
+
+## Flag ADR conflicts
+
+If output contradicts an existing ADR, surface it explicitly instead of silently overriding it.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,8 +4,7 @@ How the engineering skills should consume this repo's domain documentation when 
 
 ## Before exploring, read these
 
-- **`CONTEXT.md`** at the repo root, or
-- **`CONTEXT-MAP.md`** at the repo root if it exists. It points at one `CONTEXT.md` per context; read each one relevant to the topic.
+- **`CONTEXT.md`** at the repo root.
 - **`docs/adr/`** for ADRs that touch the area being changed.
 
 If any of these files do not exist, proceed silently. The `/domain-modeling` skill creates them lazily when terms or decisions actually get resolved.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -15,9 +15,9 @@ Infer the repo from `git remote -v`; `gh` does this automatically when run insid
 
 ## Pull requests as a triage surface
 
-**PRs as a request surface: no.** `/triage` should not pull external PRs into the issue triage queue by default.
+**PRs as a request surface: no.** `/triage` should not pull external PRs into the issue triage queue by default. GitHub Issues are the source of truth for triage.
 
-GitHub shares one number space across issues and PRs, so a bare `#42` may be either. Resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either. Resolve triage references issue-first with `gh issue view 42`; only use `gh pr view 42` when the user explicitly asks about a pull request.
 
 ## When a skill says "publish to the issue tracker"
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,39 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** `/triage` should not pull external PRs into the issue triage queue by default.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either. Resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. Create with `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue where available. Where sub-issues are not enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body.
+- **Blocking**: native issue relationships where available; otherwise a `Blocked by: #<n>, #<n>` line at the top of the child body.
+- **Frontier query**: list the map's open children, drop any with an open `Blocked by` issue or the `wayfinder:claimed` label, and take the first in map order.
+- **Claim**: `gh issue edit <n> --add-label wayfinder:claimed`.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append the context pointer to the map's Decisions-so-far.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,8 +4,8 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **Create an issue**: `gh issue create --title "..." --body-file - <<'EOF'`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --json number,title,body,labels,comments --jq '{number, title, body, labels: [.labels[].name], comments: [.comments[].body]}'` to retrieve comments and labels in a machine-readable shape.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
@@ -25,7 +25,7 @@ Create a GitHub issue.
 
 ## When a skill says "fetch the relevant ticket"
 
-Run `gh issue view <number> --comments`.
+Run `gh issue view <number> --json number,title,body,labels,comments --jq '{number, title, body, labels: [.labels[].name], comments: [.comments[].body]}'`.
 
 ## Wayfinding operations
 

--- a/docs/agents/runs/coderabbit-round-collapse-event-validation.md
+++ b/docs/agents/runs/coderabbit-round-collapse-event-validation.md
@@ -1,0 +1,32 @@
+# CodeRabbit Round: Collapse Event Validation
+
+## Round
+
+- Scope: local
+- Round number: 1
+- Command or trigger: `coderabbit review --agent --type all --base staging`
+- Started: 2026-07-06
+- Completed: 2026-07-06
+- Availability: timed out after emitting actionable findings; rerun emitted no findings before hanging in `reviewing` heartbeats
+- Fallback review thread: Composer 2.5 via `agent` attempted twice; both broad and diff-only prompts produced no output before clean interruption
+
+## Findings To Address
+
+| Finding | Severity | Decision | Notes |
+| --- | --- | --- | --- |
+| `src/nip01/validation.ts` allowed non-hex `id`/`sig` values through shape validation when hash/signature checks were skipped. | minor | addressed | `sanitizeNostrEvent` now uses `isHexString` for `id` and `sig` shape checks before optional hash/signature checks. |
+| Relay ingress skipped id/signature validation for NIP-46 kind `24133` by default. | major | addressed | `validateRelayIngressEvent` defaults to no skip, `Relay.validateInboundEvent` no longer passes a skip, and Relay NIP-46 tests now use signed events. |
+| `docs/agents/issue-tracker.md` resolved ambiguous references PR-first. | minor | addressed | Triage guidance now treats GitHub Issues as source of truth and resolves issue-first. |
+| `docs/agents/domain.md` referenced `CONTEXT-MAP.md` despite this repo's single-context layout. | minor | addressed | Domain guidance now points only at root `CONTEXT.md` and relevant ADRs. |
+
+## Findings Not Addressed
+
+| Finding | Reason |
+| --- | --- |
+| None | All emitted findings were valid and addressed. |
+
+## Result
+
+- Continue: yes
+- Escalate: no
+- Notes: Initial CodeRabbit run was interrupted after several minutes of repeated `reviewing` heartbeats once findings had been captured. The post-fix rerun reached `tools_completed` and emitted no findings before repeating heartbeats; it was interrupted cleanly and Composer 2.5 fallback attempts were recorded as unavailable due no-output hangs.

--- a/docs/agents/runs/coderabbit-round-collapse-event-validation.md
+++ b/docs/agents/runs/coderabbit-round-collapse-event-validation.md
@@ -8,7 +8,7 @@
 - Started: 2026-07-06
 - Completed: 2026-07-06
 - Availability: timed out after emitting actionable findings; rerun emitted no findings before hanging in `reviewing` heartbeats
-- Fallback review thread: Composer 2.5 via `agent` attempted twice; both broad and diff-only prompts produced no output before clean interruption
+- Fallback review thread: Composer 2.5 via `agent`; broad prompt produced no output before interruption, narrowed prompt completed with no blocking findings
 
 ## Findings To Address
 
@@ -29,4 +29,4 @@
 
 - Continue: yes
 - Escalate: no
-- Notes: Initial CodeRabbit run was interrupted after several minutes of repeated `reviewing` heartbeats once findings had been captured. The post-fix rerun reached `tools_completed` and emitted no findings before repeating heartbeats; it was interrupted cleanly and Composer 2.5 fallback attempts were recorded as unavailable due no-output hangs.
+- Notes: Initial CodeRabbit run was interrupted after several minutes of repeated `reviewing` heartbeats once findings had been captured. The post-fix rerun reached `tools_completed` and emitted no findings before repeating heartbeats; it was interrupted cleanly. Composer 2.5 fallback review found no blocking findings. Non-blocking follow-ups were addressed with a Relay-level tampered NIP-46 ingress test and valid pubkeys in relay example fixtures.

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -42,7 +42,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 | --- | --- | --- | --- | --- | --- |
 | #83 - Add a central Nostr Event validation module | AFK | complete | Composer 2.5 via `agent` | duplicate hash/helper fixed; module-test finding retained with reason | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
 | #84 - Route Relay event acceptance through central validation | AFK | complete | Composer 2.5 via `agent` | tests/options/examples fixed; stricter ingress recorded as intentional | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
-| #85 - Retire duplicate validation test surfaces | AFK | implemented, pending commit | Composer 2.5 spec via `agent`; standards unavailable | duplicate publish validation removed; validation test-access hook removed | `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`; `npx tsc --noEmit` |
+| #85 - Retire duplicate validation test surfaces | AFK | complete | Composer 2.5 spec via `agent`; standards unavailable | duplicate publish validation removed; validation test-access hook removed | `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`; `npx tsc --noEmit` |
 
 ## Parked HITL Slices
 
@@ -56,7 +56,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 | --- | --- | --- | --- | --- | --- |
 | #83 | `439ff8691d12531b46461f2b79488c88d1764ba5` | current session | `3fbddb0` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
 | #84 | `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e` | current session | `983430b` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
-| #85 | `66855bfac276ea6bc27f7f6c0c240ac065712c63` | current session | pending | spec findings addressed; standards review unavailable after no-output attempt | `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`; `npx tsc --noEmit` |
+| #85 | `66855bfac276ea6bc27f7f6c0c240ac065712c63` | current session | `9c0c95d` | spec findings addressed; standards review unavailable after no-output attempt | `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`; `npx tsc --noEmit` |
 
 ## Open Questions
 

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -1,0 +1,67 @@
+# Feature Dev Run Ledger: Collapse Event Validation
+
+## Run
+
+- Run ID: `feature-collapse-event-validation-20260706`
+- Loop: Feature Dev
+- Target repo: `AustinKelsay/snstr`
+- Base branch: `origin/staging`
+- Feature branch: `feature/collapse-event-validation`
+- Human owner: plebdev
+- Started: 2026-07-06T13:30:37Z
+- Current status: in progress
+- Skill setup status: created `docs/agents/*`; GitHub triage labels confirmed/created
+
+## Goal
+
+Collapse the Nostr event validation surfaces so event shape sanitization, signed-event verification, and Relay acceptance logic are easier to test through a small module interface, while preserving the public SNSTR API.
+
+## Durable Artifacts
+
+- CONTEXT updates: `CONTEXT.md`
+- ADRs: `docs/adr/0001-centralize-nostr-event-validation.md`
+- PRD issue: #82 - PRD: Collapse Nostr Event validation surfaces
+- Slice issues: #83, #84, #85
+- Issue sessions: pending
+- Agent briefs: pending
+- Review packets: pending
+- Local CodeRabbit report: pending
+- PR URL: pending
+
+## Commands
+
+- Install: `npm install`
+- Typecheck: `npx tsc --noEmit`
+- Test: `npm test`
+- Build: `npm run build`
+- Visual verification: not applicable
+
+## Slice Ledger
+
+| Issue | Type | Status | Review thread | Fixes needed | Verified |
+| --- | --- | --- | --- | --- | --- |
+| #83 - Add a central Nostr Event validation module | AFK | pending | pending | pending | pending |
+| #84 - Route Relay event acceptance through central validation | AFK | pending | pending | pending | pending |
+| #85 - Retire duplicate validation test surfaces | AFK | pending | pending | pending | pending |
+
+## Parked HITL Slices
+
+| Issue | Why parked | Blocks | Required human action | Final PR decision |
+| --- | --- | --- | --- | --- |
+| None | | | | |
+
+## Issue Session Ledger
+
+| Issue | Fixed point | Worker session | Commit | Review result | Checks |
+| --- | --- | --- | --- | --- | --- |
+| #83 | `5e68a284399f02170a1a3d4d7d0e160c0520de22` | pending | pending | pending | pending |
+| #84 | pending | pending | pending | pending | pending |
+| #85 | pending | pending | pending | pending | pending |
+
+## Open Questions
+
+- None. Assumption: preserve the existing public `validateEvent` export and add internal module depth behind it.
+
+## Escalations
+
+- None.

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -9,7 +9,7 @@
 - Feature branch: `feature/collapse-event-validation`
 - Human owner: plebdev
 - Started: 2026-07-06T13:30:37Z
-- Current status: final gates passed; PR pending
+- Current status: PR opened
 - Skill setup status: created `docs/agents/*`; GitHub triage labels confirmed/created
 
 ## Goal
@@ -26,7 +26,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 - Agent briefs: not created; slices were handled in the current session with Composer 2.5 review subagents
 - Review packets: `docs/agents/runs/review-83-packet.md`, `docs/agents/runs/review-84-packet.md`, `docs/agents/runs/review-85-packet.md`
 - Local CodeRabbit report: `docs/agents/runs/coderabbit-round-collapse-event-validation.md`
-- PR URL: pending
+- PR URL: https://github.com/AustinKelsay/snstr/pull/86
 
 ## Commands
 

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -22,9 +22,9 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 - ADRs: `docs/adr/0001-centralize-nostr-event-validation.md`
 - PRD issue: #82 - PRD: Collapse Nostr Event validation surfaces
 - Slice issues: #83, #84, #85
-- Issue sessions: pending
+- Issue sessions: `docs/agents/runs/issue-83-session.md`
 - Agent briefs: pending
-- Review packets: pending
+- Review packets: `docs/agents/runs/review-83-packet.md`
 - Local CodeRabbit report: pending
 - PR URL: pending
 
@@ -40,7 +40,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 
 | Issue | Type | Status | Review thread | Fixes needed | Verified |
 | --- | --- | --- | --- | --- | --- |
-| #83 - Add a central Nostr Event validation module | AFK | pending | pending | pending | pending |
+| #83 - Add a central Nostr Event validation module | AFK | implemented, pending commit | Composer 2.5 via `agent` | duplicate hash/helper fixed; module-test finding retained with reason | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
 | #84 - Route Relay event acceptance through central validation | AFK | pending | pending | pending | pending |
 | #85 - Retire duplicate validation test surfaces | AFK | pending | pending | pending | pending |
 
@@ -54,7 +54,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 
 | Issue | Fixed point | Worker session | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
-| #83 | `5e68a284399f02170a1a3d4d7d0e160c0520de22` | pending | pending | pending | pending |
+| #83 | `439ff8691d12531b46461f2b79488c88d1764ba5` | current session | pending | standards/spec findings addressed or recorded | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
 | #84 | pending | pending | pending | pending | pending |
 | #85 | pending | pending | pending | pending | pending |
 

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -9,7 +9,7 @@
 - Feature branch: `feature/collapse-event-validation`
 - Human owner: plebdev
 - Started: 2026-07-06T13:30:37Z
-- Current status: in progress
+- Current status: final gates passed; PR pending
 - Skill setup status: created `docs/agents/*`; GitHub triage labels confirmed/created
 
 ## Goal
@@ -23,17 +23,19 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 - PRD issue: #82 - PRD: Collapse Nostr Event validation surfaces
 - Slice issues: #83, #84, #85
 - Issue sessions: `docs/agents/runs/issue-83-session.md`, `docs/agents/runs/issue-84-session.md`, `docs/agents/runs/issue-85-session.md`
-- Agent briefs: pending
+- Agent briefs: not created; slices were handled in the current session with Composer 2.5 review subagents
 - Review packets: `docs/agents/runs/review-83-packet.md`, `docs/agents/runs/review-84-packet.md`, `docs/agents/runs/review-85-packet.md`
-- Local CodeRabbit report: pending
+- Local CodeRabbit report: `docs/agents/runs/coderabbit-round-collapse-event-validation.md`
 - PR URL: pending
 
 ## Commands
 
 - Install: `npm install`
 - Typecheck: `npx tsc --noEmit`
-- Test: `npm test`
+- Test: `npm test -- --runInBand` (64 suites, 847 tests passed; existing Jest open-handle warning remains)
+- Lint: `npm run lint` (passed; existing TypeScript parser support warning remains)
 - Build: `npm run build`
+- Examples: `npm run build:examples`
 - Visual verification: not applicable
 
 ## Slice Ledger

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -40,7 +40,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 
 | Issue | Type | Status | Review thread | Fixes needed | Verified |
 | --- | --- | --- | --- | --- | --- |
-| #83 - Add a central Nostr Event validation module | AFK | implemented, pending commit | Composer 2.5 via `agent` | duplicate hash/helper fixed; module-test finding retained with reason | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
+| #83 - Add a central Nostr Event validation module | AFK | complete | Composer 2.5 via `agent` | duplicate hash/helper fixed; module-test finding retained with reason | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
 | #84 - Route Relay event acceptance through central validation | AFK | pending | pending | pending | pending |
 | #85 - Retire duplicate validation test surfaces | AFK | pending | pending | pending | pending |
 
@@ -54,8 +54,8 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 
 | Issue | Fixed point | Worker session | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
-| #83 | `439ff8691d12531b46461f2b79488c88d1764ba5` | current session | pending | standards/spec findings addressed or recorded | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
-| #84 | pending | pending | pending | pending | pending |
+| #83 | `439ff8691d12531b46461f2b79488c88d1764ba5` | current session | `3fbddb0` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
+| #84 | `3fbddb0` | pending | pending | pending | pending |
 | #85 | pending | pending | pending | pending | pending |
 
 ## Open Questions

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -22,9 +22,9 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 - ADRs: `docs/adr/0001-centralize-nostr-event-validation.md`
 - PRD issue: #82 - PRD: Collapse Nostr Event validation surfaces
 - Slice issues: #83, #84, #85
-- Issue sessions: `docs/agents/runs/issue-83-session.md`
+- Issue sessions: `docs/agents/runs/issue-83-session.md`, `docs/agents/runs/issue-84-session.md`
 - Agent briefs: pending
-- Review packets: `docs/agents/runs/review-83-packet.md`
+- Review packets: `docs/agents/runs/review-83-packet.md`, `docs/agents/runs/review-84-packet.md`
 - Local CodeRabbit report: pending
 - PR URL: pending
 
@@ -41,7 +41,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 | Issue | Type | Status | Review thread | Fixes needed | Verified |
 | --- | --- | --- | --- | --- | --- |
 | #83 - Add a central Nostr Event validation module | AFK | complete | Composer 2.5 via `agent` | duplicate hash/helper fixed; module-test finding retained with reason | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
-| #84 - Route Relay event acceptance through central validation | AFK | pending | pending | pending | pending |
+| #84 - Route Relay event acceptance through central validation | AFK | implemented, pending commit | Composer 2.5 via `agent` | tests/options/examples fixed; stricter ingress recorded as intentional | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
 | #85 - Retire duplicate validation test surfaces | AFK | pending | pending | pending | pending |
 
 ## Parked HITL Slices
@@ -55,7 +55,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 | Issue | Fixed point | Worker session | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
 | #83 | `439ff8691d12531b46461f2b79488c88d1764ba5` | current session | `3fbddb0` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
-| #84 | `3fbddb0` | pending | pending | pending | pending |
+| #84 | `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e` | current session | pending | standards/spec findings addressed or recorded | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
 | #85 | pending | pending | pending | pending | pending |
 
 ## Open Questions

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -22,9 +22,9 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 - ADRs: `docs/adr/0001-centralize-nostr-event-validation.md`
 - PRD issue: #82 - PRD: Collapse Nostr Event validation surfaces
 - Slice issues: #83, #84, #85
-- Issue sessions: `docs/agents/runs/issue-83-session.md`, `docs/agents/runs/issue-84-session.md`
+- Issue sessions: `docs/agents/runs/issue-83-session.md`, `docs/agents/runs/issue-84-session.md`, `docs/agents/runs/issue-85-session.md`
 - Agent briefs: pending
-- Review packets: `docs/agents/runs/review-83-packet.md`, `docs/agents/runs/review-84-packet.md`
+- Review packets: `docs/agents/runs/review-83-packet.md`, `docs/agents/runs/review-84-packet.md`, `docs/agents/runs/review-85-packet.md`
 - Local CodeRabbit report: pending
 - PR URL: pending
 
@@ -42,7 +42,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 | --- | --- | --- | --- | --- | --- |
 | #83 - Add a central Nostr Event validation module | AFK | complete | Composer 2.5 via `agent` | duplicate hash/helper fixed; module-test finding retained with reason | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
 | #84 - Route Relay event acceptance through central validation | AFK | complete | Composer 2.5 via `agent` | tests/options/examples fixed; stricter ingress recorded as intentional | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
-| #85 - Retire duplicate validation test surfaces | AFK | pending | pending | pending | pending |
+| #85 - Retire duplicate validation test surfaces | AFK | implemented, pending commit | Composer 2.5 spec via `agent`; standards unavailable | duplicate publish validation removed; validation test-access hook removed | `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`; `npx tsc --noEmit` |
 
 ## Parked HITL Slices
 
@@ -56,7 +56,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 | --- | --- | --- | --- | --- | --- |
 | #83 | `439ff8691d12531b46461f2b79488c88d1764ba5` | current session | `3fbddb0` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
 | #84 | `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e` | current session | `983430b` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
-| #85 | `983430b` | pending | pending | pending | pending |
+| #85 | `66855bfac276ea6bc27f7f6c0c240ac065712c63` | current session | pending | spec findings addressed; standards review unavailable after no-output attempt | `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`; `npx tsc --noEmit` |
 
 ## Open Questions
 

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -41,7 +41,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 | Issue | Type | Status | Review thread | Fixes needed | Verified |
 | --- | --- | --- | --- | --- | --- |
 | #83 - Add a central Nostr Event validation module | AFK | complete | Composer 2.5 via `agent` | duplicate hash/helper fixed; module-test finding retained with reason | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
-| #84 - Route Relay event acceptance through central validation | AFK | implemented, pending commit | Composer 2.5 via `agent` | tests/options/examples fixed; stricter ingress recorded as intentional | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
+| #84 - Route Relay event acceptance through central validation | AFK | complete | Composer 2.5 via `agent` | tests/options/examples fixed; stricter ingress recorded as intentional | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
 | #85 - Retire duplicate validation test surfaces | AFK | pending | pending | pending | pending |
 
 ## Parked HITL Slices
@@ -55,8 +55,8 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 | Issue | Fixed point | Worker session | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
 | #83 | `439ff8691d12531b46461f2b79488c88d1764ba5` | current session | `3fbddb0` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
-| #84 | `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e` | current session | pending | standards/spec findings addressed or recorded | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
-| #85 | pending | pending | pending | pending | pending |
+| #84 | `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e` | current session | `983430b` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
+| #85 | `983430b` | pending | pending | pending | pending |
 
 ## Open Questions
 

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -32,7 +32,7 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 
 - Install: `npm install`
 - Typecheck: `npx tsc --noEmit`
-- Test: `npm test -- --runInBand` (64 suites, 847 tests passed; existing Jest open-handle warning remains)
+- Test: `npm test -- --runInBand` (64 suites, 848 tests passed; existing Jest open-handle warning remains)
 - Lint: `npm run lint` (passed; existing TypeScript parser support warning remains)
 - Build: `npm run build`
 - Examples: `npm run build:examples`
@@ -59,6 +59,12 @@ Collapse the Nostr event validation surfaces so event shape sanitization, signed
 | #83 | `439ff8691d12531b46461f2b79488c88d1764ba5` | current session | `3fbddb0` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event --runInBand`; `npx tsc --noEmit` |
 | #84 | `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e` | current session | `983430b` | standards/spec findings addressed or recorded | `npx jest tests/nip01/event tests/nip01/relay --runInBand`; `npx tsc --noEmit` |
 | #85 | `66855bfac276ea6bc27f7f6c0c240ac065712c63` | current session | `9c0c95d` | spec findings addressed; standards review unavailable after no-output attempt | `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`; `npx tsc --noEmit` |
+
+## Final Review Gate
+
+- Local CodeRabbit: emitted four findings; all were addressed. The post-fix rerun reached `tools_completed`, emitted no findings, then hung in repeated `reviewing` heartbeats and was interrupted cleanly.
+- Fallback review: Composer 2.5 via `agent` completed with no blocking findings. Non-blocking follow-ups were addressed by adding a Relay-level tampered NIP-46 ingress test and fixing example fixture pubkeys.
+- PR review trigger: `@coderabbit full review` commented on PR #86.
 
 ## Open Questions
 

--- a/docs/agents/runs/issue-83-session.md
+++ b/docs/agents/runs/issue-83-session.md
@@ -1,0 +1,51 @@
+# Issue Session: #83 Add a central Nostr Event validation module
+
+## Issue
+
+- Issue: #83 - Add a central Nostr Event validation module
+- Fixed point before session: `439ff8691d12531b46461f2b79488c88d1764ba5`
+- Worker session: current Codex session with Composer 2.5 review subagents via `agent`
+- Commit: pending
+- Status: implementation complete, pending commit
+
+## Inputs
+
+- PRD issue: #82 - PRD: Collapse Nostr Event validation surfaces
+- Slice issue: #83 - Add a central Nostr Event validation module
+- Relevant glossary terms: Nostr Event, Event Template, Relay, Subscription Filter, NIP
+- Relevant ADRs: `docs/adr/0001-centralize-nostr-event-validation.md`
+- Prototype answer, if any: none
+
+## Implementation
+
+- Public interface used: existing `validateEvent`, `createSignedEvent`, and `createTextNote`; new internal seam `src/nip01/validation.ts`
+- Behaviors covered: event sanitization, malformed shape rejection before crypto, valid signed-event verification, mismatched id rejection, invalid signature rejection, encrypted Relay-ingress skip option, and public `validateEvent` compatibility
+- `tdd` used: yes; added focused red tests before the validation module existed
+- Commands run during implementation:
+  - `npx jest tests/nip01/event/event-validation.test.ts --runInBand`
+  - `npx jest tests/nip01/event --runInBand`
+  - `npx tsc --noEmit`
+  - `npx prettier --write src/nip01/event.ts src/nip01/validation.ts src/nip01/serialization.ts tests/nip01/event/event-validation.test.ts`
+- Full suite command: pending for final feature branch gate
+
+## Review
+
+- Review fixed point: `439ff8691d12531b46461f2b79488c88d1764ba5`
+- Standards findings:
+  - Duplicate NIP-01 hash calculation between `event.ts` and `validation.ts`
+  - Duplicate lowercase public-key format helper
+  - Tests exercise the new validation module directly, while ADR guidance prefers public event/Relay behavior where possible
+- Spec findings:
+  - #83 behavior is substantially delivered
+  - Future #84 must wire Relay acceptance through the new seam with `validateKindRange`
+  - Disabled id/signature validation should avoid accidental public behavior tightening
+- Worthy fixes applied:
+  - Added shared NIP-01 event serialization helper in `src/nip01/serialization.ts`
+  - Reused the lowercase public-key format helper from `src/nip01/validation.ts`
+  - Preserved historical disabled id/signature shape validation for lowercase opaque values
+- Findings ignored with reasons:
+  - Direct validation-module tests retained because #83 creates the module seam itself; public `validateEvent` compatibility is also covered, while #84 will add Relay-level behavior tests
+
+## Risks
+
+- None known for #83 after focused event tests and typecheck pass.

--- a/docs/agents/runs/issue-83-session.md
+++ b/docs/agents/runs/issue-83-session.md
@@ -19,14 +19,14 @@
 ## Implementation
 
 - Public interface used: existing `validateEvent`, `createSignedEvent`, and `createTextNote`; new internal seam `src/nip01/validation.ts`
-- Behaviors covered: event sanitization, malformed shape rejection before crypto, valid signed-event verification, mismatched id rejection, invalid signature rejection, encrypted Relay-ingress skip option, and public `validateEvent` compatibility
+- Behaviors covered: event sanitization, malformed shape rejection before crypto, valid signed-event verification, mismatched id rejection, invalid signature rejection, lower-level opt-in encrypted-event skip behavior, and public `validateEvent` compatibility
 - `tdd` used: yes; added focused red tests before the validation module existed
 - Commands run during implementation:
   - `npx jest tests/nip01/event/event-validation.test.ts --runInBand`
   - `npx jest tests/nip01/event --runInBand`
   - `npx tsc --noEmit`
   - `npx prettier --write src/nip01/event.ts src/nip01/validation.ts src/nip01/serialization.ts tests/nip01/event/event-validation.test.ts`
-- Full suite command: pending for final feature branch gate
+- Full suite command: `npm test -- --runInBand`
 
 ## Review
 

--- a/docs/agents/runs/issue-83-session.md
+++ b/docs/agents/runs/issue-83-session.md
@@ -5,8 +5,8 @@
 - Issue: #83 - Add a central Nostr Event validation module
 - Fixed point before session: `439ff8691d12531b46461f2b79488c88d1764ba5`
 - Worker session: current Codex session with Composer 2.5 review subagents via `agent`
-- Commit: pending
-- Status: implementation complete, pending commit
+- Commit: `3fbddb0`
+- Status: complete
 
 ## Inputs
 

--- a/docs/agents/runs/issue-84-session.md
+++ b/docs/agents/runs/issue-84-session.md
@@ -1,0 +1,56 @@
+# Issue Session: #84 Route Relay event acceptance through central validation
+
+## Issue
+
+- Issue: #84 - Route Relay event acceptance through central validation
+- Fixed point before session: `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e`
+- Worker session: current Codex session with Composer 2.5 review subagents via `agent`
+- Commit: pending
+- Status: implementation complete, pending commit
+
+## Inputs
+
+- PRD issue: #82 - PRD: Collapse Nostr Event validation surfaces
+- Slice issue: #84 - Route Relay event acceptance through central validation
+- Relevant glossary terms: Nostr Event, Relay, Subscription Filter, NIP
+- Relevant ADRs: `docs/adr/0001-centralize-nostr-event-validation.md`
+- Prototype answer, if any: none
+
+## Implementation
+
+- Public interface used: `Relay.subscribe` plus inbound `EVENT` message handling through the test harness; public Relay API unchanged
+- Behaviors covered: valid signed Relay events deliver, malformed events reject, invalid ids reject, invalid signatures reject, future timestamps reject, out-of-range kinds reject, invalid NIP-01 tag references reject, NIP-46 kind `24133` can explicitly skip id/signature checks, and NIP-46 events without `p` tags reject
+- `tdd` used: yes; the NIP-46 encrypted Relay ingress test failed against the old Relay-private validation path before the central ingress helper was wired
+- Commands run during implementation:
+  - `npx jest tests/nip01/relay/relay.test.ts --runInBand -t "NIP-46 encrypted inbound"`
+  - `npx jest tests/nip01/relay/relay.test.ts --runInBand`
+  - `npx jest tests/nip01/event tests/nip01/relay --runInBand`
+  - `npx tsc --noEmit`
+- Full suite command: pending for final feature branch gate
+
+## Review
+
+- Review fixed point: `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e`
+- Standards findings:
+  - Relay ingress is stricter than the old private path because central validation enforces lowercase event fields and valid pubkey curve points
+  - Relay-specific seam options should be explicit at the call site
+  - Relay tag-reference, kind-range, and NIP-46 negative paths needed Relay-level coverage
+  - Examples still referenced removed Relay-private validators
+  - Formatting-only churn should be minimized
+- Spec findings:
+  - Core #84 routing was delivered
+  - Relay-level coverage was partial before adding kind-range, tag-reference, and NIP-46 negative tests
+  - Negative tests should assert the expected validation path instead of only counting errors
+- Worthy fixes applied:
+  - Added Relay-level negative tests for out-of-range kind, invalid `p`/`a` tag references, and NIP-46 missing `p` tags
+  - Tightened existing rejection tests to assert central validation message fragments
+  - Passed `validateRelayTagReferences` and `requireNip46PTag` explicitly from Relay to the validation seam
+  - Updated examples to demonstrate `validateRelayIngressEvent` instead of removed private Relay validators
+  - Trimmed unrelated formatting noise from the main Relay/test-access files
+- Findings ignored with reasons:
+  - Stricter lowercase/curve-point validation is intentional for Relay ingress because #84 routes acceptance through the central NIP-01 validator; uppercase/non-curve event fields are not valid signed Nostr Events.
+  - Relay still wraps validation failures as `RelayEvent.Error` values to preserve the existing Relay error callback surface.
+
+## Risks
+
+- Relay ingress is intentionally stricter than the old private helper for malformed public keys and uppercase event fields.

--- a/docs/agents/runs/issue-84-session.md
+++ b/docs/agents/runs/issue-84-session.md
@@ -5,8 +5,8 @@
 - Issue: #84 - Route Relay event acceptance through central validation
 - Fixed point before session: `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e`
 - Worker session: current Codex session with Composer 2.5 review subagents via `agent`
-- Commit: pending
-- Status: implementation complete, pending commit
+- Commit: `983430b`
+- Status: complete
 
 ## Inputs
 

--- a/docs/agents/runs/issue-84-session.md
+++ b/docs/agents/runs/issue-84-session.md
@@ -19,14 +19,14 @@
 ## Implementation
 
 - Public interface used: `Relay.subscribe` plus inbound `EVENT` message handling through the test harness; public Relay API unchanged
-- Behaviors covered: valid signed Relay events deliver, malformed events reject, invalid ids reject, invalid signatures reject, future timestamps reject, out-of-range kinds reject, invalid NIP-01 tag references reject, NIP-46 kind `24133` can explicitly skip id/signature checks, and NIP-46 events without `p` tags reject
+- Behaviors covered: valid signed Relay events deliver, malformed events reject, invalid ids reject, invalid signatures reject, future timestamps reject, out-of-range kinds reject, invalid NIP-01 tag references reject, signed NIP-46 kind `24133` events with `p` tags deliver, and NIP-46 events without `p` tags reject
 - `tdd` used: yes; the NIP-46 encrypted Relay ingress test failed against the old Relay-private validation path before the central ingress helper was wired
 - Commands run during implementation:
   - `npx jest tests/nip01/relay/relay.test.ts --runInBand -t "NIP-46 encrypted inbound"`
   - `npx jest tests/nip01/relay/relay.test.ts --runInBand`
   - `npx jest tests/nip01/event tests/nip01/relay --runInBand`
   - `npx tsc --noEmit`
-- Full suite command: pending for final feature branch gate
+- Full suite command: `npm test -- --runInBand`
 
 ## Review
 
@@ -45,6 +45,7 @@
   - Added Relay-level negative tests for out-of-range kind, invalid `p`/`a` tag references, and NIP-46 missing `p` tags
   - Tightened existing rejection tests to assert central validation message fragments
   - Passed `validateRelayTagReferences` and `requireNip46PTag` explicitly from Relay to the validation seam
+  - Post-CodeRabbit, removed Relay's NIP-46 id/signature skip so Relay ingress requires signed kind `24133` events while lower-level skip remains opt-in outside Relay ingress
   - Updated examples to demonstrate `validateRelayIngressEvent` instead of removed private Relay validators
   - Trimmed unrelated formatting noise from the main Relay/test-access files
 - Findings ignored with reasons:
@@ -53,4 +54,4 @@
 
 ## Risks
 
-- Relay ingress is intentionally stricter than the old private helper for malformed public keys and uppercase event fields.
+- Relay ingress is intentionally stricter than the old private helper for malformed public keys, uppercase event fields, and unsigned/fake-id NIP-46 events.

--- a/docs/agents/runs/issue-85-session.md
+++ b/docs/agents/runs/issue-85-session.md
@@ -5,8 +5,8 @@
 - Issue: #85 - Retire duplicate validation test surfaces
 - Fixed point before session: `66855bfac276ea6bc27f7f6c0c240ac065712c63`
 - Worker session: current Codex session with Composer 2.5 spec review via `agent`
-- Commit: pending
-- Status: implementation complete, pending commit
+- Commit: `9c0c95d`
+- Status: complete
 
 ## Inputs
 

--- a/docs/agents/runs/issue-85-session.md
+++ b/docs/agents/runs/issue-85-session.md
@@ -1,0 +1,46 @@
+# Issue Session: #85 Retire duplicate validation test surfaces
+
+## Issue
+
+- Issue: #85 - Retire duplicate validation test surfaces
+- Fixed point before session: `66855bfac276ea6bc27f7f6c0c240ac065712c63`
+- Worker session: current Codex session with Composer 2.5 spec review via `agent`
+- Commit: pending
+- Status: implementation complete, pending commit
+
+## Inputs
+
+- PRD issue: #82 - PRD: Collapse Nostr Event validation surfaces
+- Slice issue: #85 - Retire duplicate validation test surfaces
+- Relevant glossary terms: Nostr Event, Relay, Subscription Filter
+- Relevant ADRs: `docs/adr/0001-centralize-nostr-event-validation.md`
+- Prototype answer, if any: none
+
+## Implementation
+
+- Public interface used: `Nostr.publishTextNote`, event factories, public event/Relay tests
+- Behaviors covered: text note publish validation still rejects oversized UTF-8 content; event creation/validation and Relay delivery tests still pass
+- `tdd` used: no new red test; this was a small cleanup protected by existing public behavior tests
+- Commands run during implementation:
+  - `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`
+  - `npx tsc --noEmit`
+- Full suite command: pending for final feature branch gate
+
+## Review
+
+- Review fixed point: `66855bfac276ea6bc27f7f6c0c240ac065712c63`
+- Standards findings:
+  - Composer 2.5 standards review attempt produced no output after several minutes and was interrupted cleanly.
+- Spec findings:
+  - Code changes match #85: `publishTextNote` delegates duplicate validation to `createTextNote`, and `RelayTestAccess` no longer exposes the private validation wrapper.
+  - Ledger needed #85 commit/check recording and an inventory of remaining deferred private test access.
+- Worthy fixes applied:
+  - Removed the unused `validateInboundEvent` test-access hook.
+  - Removed duplicate `publishTextNote` content/tag/byte-length validation setup now enforced by `createTextNote`.
+  - Recorded deferred private test access in this issue session.
+- Findings ignored with reasons:
+  - Remaining `RelayTestAccess` hooks are non-validation hooks used for message dispatch and event-store behavior tests: `handleMessage`, `processValidatedEvent`, `processReplaceableEvent`, `processAddressableEvent`, `flushSubscriptionBuffer`, and internal maps. They are deferred because #85 is scoped to validation surfaces.
+
+## Risks
+
+- None known. Existing publish/content-size tests cover the delegated validation path.

--- a/docs/agents/runs/issue-85-session.md
+++ b/docs/agents/runs/issue-85-session.md
@@ -24,7 +24,7 @@
 - Commands run during implementation:
   - `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`
   - `npx tsc --noEmit`
-- Full suite command: pending for final feature branch gate
+- Full suite command: `npm test -- --runInBand`
 
 ## Review
 

--- a/docs/agents/runs/review-83-packet.md
+++ b/docs/agents/runs/review-83-packet.md
@@ -6,7 +6,7 @@
 - Slice type: AFK
 - Acceptance criteria: central event validation module exists; `validateEvent` delegates shared shape/id/signature/timestamp behavior; behavior is covered by focused tests; public API remains compatible
 - Baseline: `439ff8691d12531b46461f2b79488c88d1764ba5`
-- Current diff: pending #83 commit
+- Current diff: `3fbddb0`
 
 ## Implementation Summary
 

--- a/docs/agents/runs/review-83-packet.md
+++ b/docs/agents/runs/review-83-packet.md
@@ -1,0 +1,53 @@
+# Review Packet: #83 Add a central Nostr Event validation module
+
+## Issue
+
+- Issue: #83
+- Slice type: AFK
+- Acceptance criteria: central event validation module exists; `validateEvent` delegates shared shape/id/signature/timestamp behavior; behavior is covered by focused tests; public API remains compatible
+- Baseline: `439ff8691d12531b46461f2b79488c88d1764ba5`
+- Current diff: pending #83 commit
+
+## Implementation Summary
+
+Added `src/nip01/validation.ts` as the central signed-event validation seam, added shared NIP-01 serialization in `src/nip01/serialization.ts`, and routed the existing public `validateEvent` shape/id/signature/timestamp checks through the shared validator while keeping kind-specific content validation in `event.ts`.
+
+## Implementation Evidence
+
+- `implement` session: current Codex session
+- `tdd` used: yes
+- Red test, if applicable: `tests/nip01/event/event-validation.test.ts` initially failed because `src/nip01/validation` did not exist
+- Green implementation, if applicable: validation module plus public `validateEvent` delegation
+- Refactor, if applicable: extracted shared NIP-01 serialization and public-key format helper
+- Commands run:
+  - `npx jest tests/nip01/event/event-validation.test.ts --runInBand`
+  - `npx jest tests/nip01/event --runInBand`
+  - `npx tsc --noEmit`
+
+## Review Instructions
+
+Review only #83 unless a severe cross-slice regression appears. Keep standards and spec findings separate.
+
+Check:
+
+- Acceptance criteria are met.
+- Tests verify behavior at the new module seam and preserve public `validateEvent` behavior.
+- No duplicate event hashing path remains.
+- No unrelated repo changes are included.
+- Relevant test and typecheck commands pass.
+
+## Reviewer Output
+
+```text
+STANDARDS_STATUS: changes_requested, then addressed
+STANDARDS_FINDINGS:
+- Duplicate NIP-01 hash path between event and validation modules.
+- Duplicate lowercase public-key helper.
+- Direct module tests should be justified against ADR public-interface guidance.
+
+SPEC_STATUS: changes_requested, then addressed/deferred
+SPEC_FINDINGS:
+- #83 behavior delivered.
+- #84 still needs Relay-level use of the central validator.
+- Disabled id/signature checks should preserve historical public behavior.
+```

--- a/docs/agents/runs/review-84-packet.md
+++ b/docs/agents/runs/review-84-packet.md
@@ -6,7 +6,7 @@
 - Slice type: AFK
 - Acceptance criteria: Relay inbound `EVENT` messages use the central validation module; valid signed events deliver; malformed events, invalid ids, invalid signatures, and future timestamps reject; NIP-46 encrypted handling remains explicit; targeted Relay tests pass without expanding public Relay API
 - Baseline: `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e`
-- Current diff: pending #84 commit
+- Current diff: #84 commit plus CodeRabbit follow-up tightening NIP-46 Relay ingress
 
 ## Implementation Summary
 
@@ -16,7 +16,7 @@ Relay inbound `EVENT` handling now delegates to `validateRelayIngressEvent` in t
 
 - `implement` session: current Codex session
 - `tdd` used: yes
-- Red test, if applicable: NIP-46 encrypted inbound `EVENT` was not delivered before Relay used the central skip option
+- Red test, if applicable: NIP-46 encrypted inbound `EVENT` was not delivered before Relay used the central ingress helper
 - Green implementation, if applicable: Relay `validateInboundEvent` now calls `validateRelayIngressEvent`
 - Refactor, if applicable: removed Relay-private `performBasicValidation`, `validateEvent`, `validateEventAsync`, and `isNostrEvent`
 - Commands run:
@@ -33,7 +33,7 @@ Check:
 
 - Relay inbound `EVENT` acceptance routes through `validateRelayIngressEvent`.
 - The public Relay API is unchanged.
-- NIP-46 kind `24133` skip behavior is explicit at the validation seam.
+- NIP-46 kind `24133` Relay ingress requires a signed event and an explicit `p` tag; hash/signature skip remains only as a lower-level opt-in validation option outside Relay ingress.
 - Relay-level tests cover accepted events and rejection paths.
 - Examples do not reference removed private Relay validators.
 
@@ -46,6 +46,7 @@ STANDARDS_FINDINGS:
 - Make Relay-specific validation options explicit at the seam.
 - Update examples that referenced removed Relay-private validation methods.
 - Document intentional stricter lowercase/curve-point Relay ingress behavior.
+- Post-CodeRabbit follow-up: remove Relay's NIP-46 id/signature skip and require signed kind `24133` Relay ingress events.
 
 SPEC_STATUS: changes_requested, then addressed
 SPEC_FINDINGS:

--- a/docs/agents/runs/review-84-packet.md
+++ b/docs/agents/runs/review-84-packet.md
@@ -1,0 +1,55 @@
+# Review Packet: #84 Route Relay event acceptance through central validation
+
+## Issue
+
+- Issue: #84
+- Slice type: AFK
+- Acceptance criteria: Relay inbound `EVENT` messages use the central validation module; valid signed events deliver; malformed events, invalid ids, invalid signatures, and future timestamps reject; NIP-46 encrypted handling remains explicit; targeted Relay tests pass without expanding public Relay API
+- Baseline: `1f26f97fa20d9fe201ed298e1ea36e8f399b1b0e`
+- Current diff: pending #84 commit
+
+## Implementation Summary
+
+Relay inbound `EVENT` handling now delegates to `validateRelayIngressEvent` in the central validation module. The old Relay-private shape/hash/signature validation methods were removed, Relay-specific tag-reference and NIP-46 checks live behind the central validation seam, examples no longer teach private Relay validation access, and Relay tests exercise acceptance/rejection through inbound messages.
+
+## Implementation Evidence
+
+- `implement` session: current Codex session
+- `tdd` used: yes
+- Red test, if applicable: NIP-46 encrypted inbound `EVENT` was not delivered before Relay used the central skip option
+- Green implementation, if applicable: Relay `validateInboundEvent` now calls `validateRelayIngressEvent`
+- Refactor, if applicable: removed Relay-private `performBasicValidation`, `validateEvent`, `validateEventAsync`, and `isNostrEvent`
+- Commands run:
+  - `npx jest tests/nip01/relay/relay.test.ts --runInBand -t "NIP-46 encrypted inbound"`
+  - `npx jest tests/nip01/relay/relay.test.ts --runInBand`
+  - `npx jest tests/nip01/event tests/nip01/relay --runInBand`
+  - `npx tsc --noEmit`
+
+## Review Instructions
+
+Review only #84 unless a severe cross-slice regression appears. Keep standards and spec findings separate.
+
+Check:
+
+- Relay inbound `EVENT` acceptance routes through `validateRelayIngressEvent`.
+- The public Relay API is unchanged.
+- NIP-46 kind `24133` skip behavior is explicit at the validation seam.
+- Relay-level tests cover accepted events and rejection paths.
+- Examples do not reference removed private Relay validators.
+
+## Reviewer Output
+
+```text
+STANDARDS_STATUS: changes_requested, then addressed/recorded
+STANDARDS_FINDINGS:
+- Add Relay-level negative coverage for kind range, tag references, and NIP-46 missing p tags.
+- Make Relay-specific validation options explicit at the seam.
+- Update examples that referenced removed Relay-private validation methods.
+- Document intentional stricter lowercase/curve-point Relay ingress behavior.
+
+SPEC_STATUS: changes_requested, then addressed
+SPEC_FINDINGS:
+- Main #84 routing is met.
+- Rejection-path coverage needed kind-range, tag-reference, and NIP-46 negative cases.
+- Negative tests should assert the expected error path rather than only counting errors.
+```

--- a/docs/agents/runs/review-85-packet.md
+++ b/docs/agents/runs/review-85-packet.md
@@ -1,0 +1,48 @@
+# Review Packet: #85 Retire duplicate validation test surfaces
+
+## Issue
+
+- Issue: #85
+- Slice type: AFK
+- Acceptance criteria: remove deprecated Relay-private validation test/helper access when public behavior is available; reduce duplicate validation setup in high-level publish helpers; keep public event creation, validation, and Relay delivery behavior unchanged; targeted NIP-01 event and Relay tests pass; ledger records remaining deferred private test access
+- Baseline: `66855bfac276ea6bc27f7f6c0c240ac065712c63`
+- Current diff: pending #85 commit
+
+## Implementation Summary
+
+Removed the unused `validateInboundEvent` private validation hook from the shared Relay test-access type and simplified `Nostr.publishTextNote` so it delegates content, tag, and byte-length validation to `createTextNote`, matching the other high-level publish helpers.
+
+## Implementation Evidence
+
+- `implement` session: current Codex session
+- `tdd` used: no new red test; existing public behavior tests cover the cleanup
+- Red test, if applicable: not applicable
+- Green implementation, if applicable: targeted public event/Relay/Nostr/UTF-8 tests pass
+- Refactor, if applicable: removed duplicate high-level validation setup
+- Commands run:
+  - `npx jest tests/nip01/event tests/nip01/relay tests/nip01/nostr.test.ts tests/utils/utf8-byte-length.test.ts --runInBand`
+  - `npx tsc --noEmit`
+
+## Review Instructions
+
+Review only #85 unless a severe cross-slice regression appears. Keep standards and spec findings separate.
+
+Check:
+
+- No tests or shared helpers expose Relay-private validation methods.
+- `publishTextNote` still preserves public error behavior through `createTextNote`.
+- Remaining private test access is non-validation and explicitly recorded as deferred.
+- Relevant tests and typecheck pass.
+
+## Reviewer Output
+
+```text
+STANDARDS_STATUS: unavailable
+STANDARDS_FINDINGS:
+- Composer 2.5 standards review attempt produced no output after several minutes and was interrupted.
+
+SPEC_STATUS: pass with process follow-up
+SPEC_FINDINGS:
+- Code changes satisfy the substantive #85 cleanup.
+- Ledger/session docs needed check recording and deferred private test-access inventory before closeout.
+```

--- a/docs/agents/runs/review-85-packet.md
+++ b/docs/agents/runs/review-85-packet.md
@@ -6,7 +6,7 @@
 - Slice type: AFK
 - Acceptance criteria: remove deprecated Relay-private validation test/helper access when public behavior is available; reduce duplicate validation setup in high-level publish helpers; keep public event creation, validation, and Relay delivery behavior unchanged; targeted NIP-01 event and Relay tests pass; ledger records remaining deferred private test access
 - Baseline: `66855bfac276ea6bc27f7f6c0c240ac065712c63`
-- Current diff: pending #85 commit
+- Current diff: `9c0c95d`
 
 ## Implementation Summary
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
+| `needs-info` | `needs-info` | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+When a skill mentions a role, use the corresponding label string from this table.

--- a/examples/client/validation-flow.ts
+++ b/examples/client/validation-flow.ts
@@ -5,7 +5,7 @@
  * where events are only propagated after full validation including signature verification.
  */
 
-import { Nostr, Relay, RelayEvent, NostrEvent } from "../../src";
+import { Nostr, Relay, RelayEvent } from "../../src";
 import { NostrRelay } from "../../src/utils/ephemeral-relay";
 import { validateRelayIngressEvent } from "../../src/nip01/validation";
 

--- a/examples/client/validation-flow.ts
+++ b/examples/client/validation-flow.ts
@@ -7,11 +7,10 @@
 
 import { Nostr, Relay, RelayEvent, NostrEvent } from "../../src";
 import { NostrRelay } from "../../src/utils/ephemeral-relay";
+import { validateRelayIngressEvent } from "../../src/nip01/validation";
 
-// Type for accessing private relay methods for demonstration
+// Type for debug-only message injection in this example.
 interface RelayInternal {
-  performBasicValidation(event: Record<string, unknown>): boolean;
-  validateEventAsync(event: NostrEvent): Promise<boolean>;
   handleMessage(message: [string, string, unknown]): void;
 }
 
@@ -121,40 +120,17 @@ async function main() {
     // No signature
   };
 
-  // Show the validation flow happening internally
-  console.log("Internal validation process:");
+  // Show the central Relay ingress validation seam.
+  console.log("Relay ingress validation process:");
 
-  // 1. Basic validation (manually demonstrate)
-  let validationPassed;
   try {
-    validationPassed = (
-      relay as unknown as RelayInternal
-    ).performBasicValidation(invalidEvent);
-    console.log(
-      `  1. Basic Validation: ${validationPassed ? "✅ Passed" : "❌ Failed"}`,
-    );
+    await validateRelayIngressEvent(invalidEvent);
+    console.log("  1. Central Relay ingress validation: ✅ Passed");
   } catch (error) {
-    console.log(`  1. Basic Validation: ❌ Failed with error: ${error}`);
-    validationPassed = false;
-  }
-
-  // 2. Attempt to process event manually to demonstrate flow
-  if (validationPassed) {
+    const message = error instanceof Error ? error.message : String(error);
     console.log(
-      "  2. Event would proceed to async validation (signature/hash verification)",
+      `  1. Central Relay ingress validation: ❌ Failed with error: ${message}`,
     );
-
-    // This would normally be handled by the relay
-    try {
-      const asyncResult = await (
-        relay as unknown as RelayInternal
-      ).validateEventAsync(invalidEvent as NostrEvent);
-      console.log(
-        `  3. Async Validation: ${asyncResult ? "✅ Passed" : "❌ Failed"}`,
-      );
-    } catch (error) {
-      console.log(`  3. Async Validation: ❌ Failed with error: ${error}`);
-    }
   }
 
   console.log(
@@ -170,7 +146,7 @@ async function main() {
         subscriptionId[0],
         invalidEvent,
       ]);
-      console.log("→ Event sent to validation pipeline");
+      console.log("→ Event sent to Relay ingress validation pipeline");
       console.log("→ Check your debug logs to see full validation flow");
     } catch (error) {
       console.error("Error injecting event:", error);
@@ -180,7 +156,7 @@ async function main() {
       "→ Enable DEBUG=nostr:* environment variable to see full validation details",
     );
     console.log(
-      "→ Events failing validation won't be propagated to subscribers",
+      "→ Events failing Relay ingress validation won't be propagated to subscribers",
     );
   }
 
@@ -214,7 +190,7 @@ async function main() {
   }
 
   console.log(
-    "\n✅ Example completed - Events must pass BOTH basic and cryptographic validation",
+    "\n✅ Example completed - Events must pass central Relay ingress validation",
   );
   console.log("This ensures full compliance with NIP-01 §7 specification.");
 

--- a/examples/nip01/relay/relay-connection-example.ts
+++ b/examples/nip01/relay/relay-connection-example.ts
@@ -133,6 +133,7 @@ async function main() {
         ]),
         DEMO_PRIVATE_KEY,
       );
+      const demoPubkey = validEvent.pubkey;
       await testValidation(validEvent, "Valid signed event");
 
       // Test 2: Event with future timestamp (should fail)
@@ -145,7 +146,7 @@ async function main() {
       // Test 3: Event with missing field
       const missingFieldEvent = {
         id: "a".repeat(64),
-        pubkey: "b".repeat(64),
+        pubkey: demoPubkey,
         // missing created_at
         kind: 1,
         tags: [],
@@ -157,7 +158,7 @@ async function main() {
       // Test 4: Event with invalid field type
       const invalidFieldTypeEvent = {
         id: "a".repeat(64),
-        pubkey: "b".repeat(64),
+        pubkey: demoPubkey,
         created_at: "not a number" as unknown as number, // wrong type
         kind: 1,
         tags: [],
@@ -172,7 +173,7 @@ async function main() {
       // Test 5: Event with invalid tag structure
       const invalidTagsEvent = {
         id: "a".repeat(64),
-        pubkey: "b".repeat(64),
+        pubkey: demoPubkey,
         created_at: Math.floor(Date.now() / 1000),
         kind: 1,
         tags: ["not an array of arrays"] as unknown as string[][], // invalid tag structure
@@ -187,7 +188,7 @@ async function main() {
       // Test 6: Event with too short ID
       const invalidIdEvent = {
         id: "a".repeat(60), // too short
-        pubkey: "b".repeat(64),
+        pubkey: demoPubkey,
         created_at: Math.floor(Date.now() / 1000),
         kind: 1,
         tags: [],

--- a/examples/nip01/relay/relay-connection-example.ts
+++ b/examples/nip01/relay/relay-connection-example.ts
@@ -1,13 +1,34 @@
 import { Relay } from "../../../src/nip01/relay";
 import { RelayEvent, NostrEvent } from "../../../src/types/nostr";
 import { NostrRelay } from "../../../src/utils/ephemeral-relay";
-import { createSignedEvent, createTextNote } from "../../../src/nip01/event";
+import { createEvent, createSignedEvent } from "../../../src/nip01/event";
 import { validateRelayIngressEvent } from "../../../src/nip01/validation";
+import { getPublicKey } from "../../../src/utils/crypto";
 
 const USE_EPHEMERAL = process.env.USE_PUBLIC_RELAYS !== "true";
 const RELAY_PORT = 0;
 const DEMO_PRIVATE_KEY =
   "1111111111111111111111111111111111111111111111111111111111111111";
+
+async function createSignedRelayExampleEvent(
+  overrides: {
+    tags?: string[][];
+    content?: string;
+    created_at?: number;
+  } = {},
+): Promise<NostrEvent> {
+  const unsigned = createEvent(
+    {
+      kind: 1,
+      tags: overrides.tags ?? [],
+      content: overrides.content ?? "Relay ingress event",
+      created_at: overrides.created_at ?? Math.floor(Date.now() / 1000),
+    },
+    getPublicKey(DEMO_PRIVATE_KEY),
+  );
+
+  return createSignedEvent(unsigned, DEMO_PRIVATE_KEY);
+}
 
 /**
  * This example demonstrates the improved connection handling in SNSTR
@@ -127,20 +148,19 @@ async function main() {
       };
 
       // Test 1: Valid event (should pass Relay ingress validation)
-      const validEvent = await createSignedEvent(
-        createTextNote("This is a valid event", DEMO_PRIVATE_KEY, [
-          ["t", "test"],
-        ]),
-        DEMO_PRIVATE_KEY,
-      );
+      const validEvent = await createSignedRelayExampleEvent({
+        content: "This is a valid event",
+        tags: [["t", "test"]],
+      });
       const demoPubkey = validEvent.pubkey;
       await testValidation(validEvent, "Valid signed event");
 
       // Test 2: Event with future timestamp (should fail)
-      const futureEvent = {
-        ...validEvent,
+      const futureEvent = await createSignedRelayExampleEvent({
+        content: validEvent.content,
+        tags: validEvent.tags,
         created_at: Math.floor(Date.now() / 1000) + 7200, // 2 hours in the future
-      };
+      });
       await testValidation(futureEvent, "Event with future timestamp");
 
       // Test 3: Event with missing field

--- a/examples/nip01/relay/relay-connection-example.ts
+++ b/examples/nip01/relay/relay-connection-example.ts
@@ -1,9 +1,13 @@
 import { Relay } from "../../../src/nip01/relay";
 import { RelayEvent, NostrEvent } from "../../../src/types/nostr";
 import { NostrRelay } from "../../../src/utils/ephemeral-relay";
+import { createSignedEvent, createTextNote } from "../../../src/nip01/event";
+import { validateRelayIngressEvent } from "../../../src/nip01/validation";
 
 const USE_EPHEMERAL = process.env.USE_PUBLIC_RELAYS !== "true";
 const RELAY_PORT = 0;
+const DEMO_PRIVATE_KEY =
+  "1111111111111111111111111111111111111111111111111111111111111111";
 
 /**
  * This example demonstrates the improved connection handling in SNSTR
@@ -99,45 +103,44 @@ async function main() {
         },
       );
 
-      // Test the relay's validation by attempting to process invalid events
+      // Test Relay ingress validation by attempting to process invalid events
       console.log("\nTesting event validation with various invalid events...");
 
-      // Direct access to basic validation for testing purposes
-      const testValidation = (
+      const testValidation = async (
         event: Partial<NostrEvent>,
         description: string,
       ) => {
-        // Get access to private validation method for demonstration purposes
-        // Using index signature to access private method for demo purposes
-        const validationResult = (
-          relay as unknown as {
-            performBasicValidation(event: Partial<NostrEvent>): boolean;
-          }
-        ).performBasicValidation(event);
-        console.log(
-          `${validationResult ? "✅" : "❌"} ${description}: ${validationResult ? "PASSED basic validation" : "REJECTED in basic validation"}`,
-        );
-        return validationResult;
+        try {
+          await validateRelayIngressEvent(event);
+          console.log(
+            `✅ ${description}: ACCEPTED by Relay ingress validation`,
+          );
+          return true;
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          console.log(
+            `❌ ${description}: REJECTED by Relay ingress validation (${message})`,
+          );
+          return false;
+        }
       };
 
-      // Test 1: Valid event (should pass basic validation)
-      const validEvent: NostrEvent = {
-        id: "a".repeat(64),
-        pubkey: "b".repeat(64),
-        created_at: Math.floor(Date.now() / 1000),
-        kind: 1,
-        tags: [["t", "test"]],
-        content: "This is a valid event",
-        sig: "c".repeat(128),
-      };
-      testValidation(validEvent, "Well-formed event");
+      // Test 1: Valid event (should pass Relay ingress validation)
+      const validEvent = await createSignedEvent(
+        createTextNote("This is a valid event", DEMO_PRIVATE_KEY, [
+          ["t", "test"],
+        ]),
+        DEMO_PRIVATE_KEY,
+      );
+      await testValidation(validEvent, "Valid signed event");
 
       // Test 2: Event with future timestamp (should fail)
       const futureEvent = {
         ...validEvent,
         created_at: Math.floor(Date.now() / 1000) + 7200, // 2 hours in the future
       };
-      testValidation(futureEvent, "Event with future timestamp");
+      await testValidation(futureEvent, "Event with future timestamp");
 
       // Test 3: Event with missing field
       const missingFieldEvent = {
@@ -149,7 +152,7 @@ async function main() {
         content: "Missing created_at",
         sig: "c".repeat(128),
       };
-      testValidation(missingFieldEvent, "Event missing required field");
+      await testValidation(missingFieldEvent, "Event missing required field");
 
       // Test 4: Event with invalid field type
       const invalidFieldTypeEvent = {
@@ -161,7 +164,10 @@ async function main() {
         content: "Invalid created_at type",
         sig: "c".repeat(128),
       };
-      testValidation(invalidFieldTypeEvent, "Event with invalid field type");
+      await testValidation(
+        invalidFieldTypeEvent,
+        "Event with invalid field type",
+      );
 
       // Test 5: Event with invalid tag structure
       const invalidTagsEvent = {
@@ -173,7 +179,10 @@ async function main() {
         content: "Invalid tags",
         sig: "c".repeat(128),
       };
-      testValidation(invalidTagsEvent, "Event with invalid tag structure");
+      await testValidation(
+        invalidTagsEvent,
+        "Event with invalid tag structure",
+      );
 
       // Test 6: Event with too short ID
       const invalidIdEvent = {
@@ -185,19 +194,19 @@ async function main() {
         content: "ID too short",
         sig: "c".repeat(128),
       };
-      testValidation(invalidIdEvent, "Event with invalid ID length");
+      await testValidation(invalidIdEvent, "Event with invalid ID length");
 
       console.log("\nImproved Validation Process (NIP-01 §7 Compliant):");
       console.log(
-        "1. 🔍 Basic Validation: Synchronous checks for required fields and formats",
+        "1. 🔍 Shape Validation: Checks for required fields and formats",
       );
-      console.log("   - Performed immediately upon receipt of an event");
+      console.log(
+        "   - Performed at the central Relay ingress validation seam",
+      );
       console.log(
         "   - Rejects obviously invalid events without further processing",
       );
-      console.log(
-        "\n2. 🔐 Cryptographic Validation: Asynchronous verification of:",
-      );
+      console.log("\n2. 🔐 Cryptographic Validation: Verification of:");
       console.log("   - Event ID matches the SHA-256 hash of event data");
       console.log("   - Signature is valid for the event ID and pubkey");
       console.log("\n3. ⏱️ Process Flow:");
@@ -205,7 +214,7 @@ async function main() {
         "   - Events are held in a pending state until async validation completes",
       );
       console.log(
-        "   - Only events that pass BOTH validation stages are processed",
+        "   - Only events that pass Relay ingress validation are processed",
       );
       console.log(
         "   - Invalid events are rejected with appropriate error messages",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snstr",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snstr",
-      "version": "0.3.2",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snstr",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "description": "Secure Nostr Software Toolkit for Renegades - A comprehensive TypeScript library for Nostr protocol implementation",
   "files": [
     "dist/src/**",

--- a/src/nip01/event.ts
+++ b/src/nip01/event.ts
@@ -7,24 +7,18 @@ import {
   TaggedEvent,
   TagValues,
   EventTags,
-  Filter,
 } from "../types/nostr";
-import { getPublicKey, verifySignature } from "../utils/crypto";
-import { sha256Hex } from "../utils/crypto";
-import { signEvent as signEventCrypto } from "../utils/crypto";
+import { getPublicKey, signEvent as signEventCrypto } from "../utils/crypto";
+import { getUnixTime } from "../utils/time";
 import { isValidRelayUrl } from "../nip19";
 import { isValidPrivateKey, isValidPublicKeyPoint } from "../nip44";
 import { getRegisteredNIP04 } from "../nip04/registry";
-
-/**
- * Validate if a string is a valid lowercase hex public key format for NIP-01 events
- * NIP-01 specifically requires lowercase hex for event fields
- */
-function isValidLowercasePublicKeyFormat(publicKey: string): boolean {
-  // Must be exactly 64 characters of lowercase hex
-  return /^[0-9a-f]{64}$/.test(publicKey);
-}
-import { getUnixTime } from "../utils/time";
+import { calculateEventHash } from "./serialization";
+import {
+  isValidLowercasePublicKeyFormat,
+  NostrValidationError,
+  validateSignedNostrEvent,
+} from "./validation";
 import {
   validateEventContent,
   validateTags,
@@ -34,36 +28,9 @@ import {
   safeArrayAccess,
 } from "../utils/security-validator";
 
+export { NostrValidationError } from "./validation";
+
 export type UnsignedEvent = Omit<NostrEvent, "id" | "sig">;
-
-/**
- * Custom error class for Nostr event validation errors
- */
-export class NostrValidationError extends Error {
-  /** The field that failed validation */
-  readonly field?: string;
-  /** The data that failed validation (can be an event, filter, etc.) */
-  readonly invalidData?:
-    | Partial<NostrEvent>
-    | Filter
-    | Record<string, unknown>
-    | EventTemplate;
-
-  constructor(
-    message: string,
-    field?: string,
-    invalidData?:
-      | Partial<NostrEvent>
-      | Filter
-      | Record<string, unknown>
-      | EventTemplate,
-  ) {
-    super(message);
-    this.name = "NostrValidationError";
-    this.field = field;
-    this.invalidData = invalidData;
-  }
-}
 
 /**
  * Calculate the event hash following NIP-01 specification exactly
@@ -125,32 +92,7 @@ export async function getEventHash(
       event,
     );
 
-  // NIP-01 specifies the serialization format as:
-  // [0, pubkey, created_at, kind, tags, content]
-  // We need to ensure deterministic serialization
-
-  // Create the array to be serialized
-  const eventData = [
-    0,
-    event.pubkey,
-    event.created_at,
-    event.kind,
-    event.tags,
-    event.content,
-  ];
-
-  // Per NIP-01: whitespace, line breaks or other unnecessary formatting
-  // should not be included in the output JSON
-  // JavaScript's JSON.stringify doesn't add whitespace by default
-  // so we don't need to pass additional options
-
-  // Serialize to JSON without pretty formatting
-  // JSON.stringify on arrays is deterministic in all JS engines
-  // because array order is preserved
-  const serialized = JSON.stringify(eventData);
-
-  // Hash the serialized data
-  return sha256Hex(serialized);
+  return calculateEventHash(event);
 }
 
 /**
@@ -339,7 +281,11 @@ export async function createDirectMessage(
     // Encrypt the content using NIP-04
     // Registry pattern: implementation registered at import time by snstr or snstr/nip04
     const { encrypt } = getRegisteredNIP04();
-    const encryptedContent = encrypt(privateKey, recipientPubkey, validatedContent);
+    const encryptedContent = encrypt(
+      privateKey,
+      recipientPubkey,
+      validatedContent,
+    );
 
     return {
       pubkey,
@@ -492,202 +438,11 @@ export async function validateEvent(
   event: NostrEvent,
   options: ValidationOptions = {},
 ): Promise<boolean> {
-  const {
-    validateSignatures = true,
-    maxTimestampDrift = 60 * 60, // 1 hour by default
-    validateIds = true,
-    validateFields = true,
-    validateTags = true,
-    validateContent = true,
-    customValidator,
-  } = options;
+  const { validateContent = true, customValidator } = options;
 
-  // 1. Validate basic required fields
-  if (validateFields) {
-    // Check ID exists
-    if (!event.id || typeof event.id !== "string" || event.id.length !== 64) {
-      throw new NostrValidationError(
-        "Invalid or missing event ID: must be a 64-character hex string",
-        "id",
-        event,
-      );
-    }
-    if (event.id !== event.id.toLowerCase()) {
-      throw new NostrValidationError(
-        "Invalid event ID: must be lowercase hex",
-        "id",
-        event,
-      );
-    }
+  await validateSignedNostrEvent(event, options);
 
-    // Check pubkey exists and is valid hex
-    if (!event.pubkey || typeof event.pubkey !== "string") {
-      throw new NostrValidationError(
-        "Invalid or missing pubkey: must be a string",
-        "pubkey",
-        event,
-      );
-    }
-
-    // First check basic format validation (hex format and case)
-    if (!isValidLowercasePublicKeyFormat(event.pubkey)) {
-      // Check for uppercase to provide specific error message
-      if (/^[0-9A-F]{64}$/.test(event.pubkey)) {
-        throw new NostrValidationError(
-          "Invalid pubkey: must be lowercase hex",
-          "pubkey",
-          event,
-        );
-      }
-      // Check length
-      if (event.pubkey.length !== 64) {
-        throw new NostrValidationError(
-          "Invalid pubkey: must be 64 characters long",
-          "pubkey",
-          event,
-        );
-      }
-      // Generic format error
-      throw new NostrValidationError(
-        "Invalid pubkey: must be a 64-character lowercase hex string",
-        "pubkey",
-        event,
-      );
-    }
-
-    // Then check if it represents a valid curve point
-    if (!isValidPublicKeyPoint(event.pubkey)) {
-      throw new NostrValidationError(
-        "Invalid pubkey: must be a valid secp256k1 curve point",
-        "pubkey",
-        event,
-      );
-    }
-
-    // Check signature exists
-    if (
-      !event.sig ||
-      typeof event.sig !== "string" ||
-      event.sig.length !== 128
-    ) {
-      throw new NostrValidationError(
-        "Invalid or missing signature: must be a 128-character hex string",
-        "sig",
-        event,
-      );
-    }
-    if (event.sig !== event.sig.toLowerCase()) {
-      throw new NostrValidationError(
-        "Invalid signature: must be lowercase hex",
-        "sig",
-        event,
-      );
-    }
-
-    // Check kind is a number
-    if (typeof event.kind !== "number") {
-      throw new NostrValidationError("Kind must be a number", "kind", event);
-    }
-
-    // Check created_at is a valid timestamp
-    if (typeof event.created_at !== "number" || event.created_at < 0) {
-      throw new NostrValidationError(
-        "Invalid created_at timestamp",
-        "created_at",
-        event,
-      );
-    }
-
-    // Check content is a string
-    if (typeof event.content !== "string") {
-      throw new NostrValidationError(
-        "Content must be a string",
-        "content",
-        event,
-      );
-    }
-  }
-
-  // 2. Validate tags format
-  if (validateTags) {
-    if (!Array.isArray(event.tags)) {
-      throw new NostrValidationError("Tags must be an array", "tags", event);
-    }
-
-    for (const tag of event.tags) {
-      if (!Array.isArray(tag)) {
-        throw new NostrValidationError(
-          "Each tag must be an array",
-          "tags",
-          event,
-        );
-      }
-
-      if (tag.length === 0) {
-        throw new NostrValidationError(
-          "Tags cannot be empty arrays",
-          "tags",
-          event,
-        );
-      }
-
-      for (const item of tag) {
-        if (typeof item !== "string") {
-          throw new NostrValidationError(
-            "Tag items must be strings",
-            "tags",
-            event,
-          );
-        }
-      }
-    }
-  }
-
-  // 3. Validate timestamp drift if enabled
-  if (maxTimestampDrift > 0) {
-    const now = getUnixTime();
-    const drift = Math.abs(now - event.created_at);
-
-    if (drift > maxTimestampDrift) {
-      throw new NostrValidationError(
-        `Event timestamp is too far from current time (drift: ${drift}s, max allowed: ${maxTimestampDrift}s)`,
-        "created_at",
-        event,
-      );
-    }
-  }
-
-  // 4. Validate event ID matches serialized content
-  if (validateIds) {
-    const unsignedEvent: UnsignedEvent = {
-      pubkey: event.pubkey,
-      created_at: event.created_at,
-      kind: event.kind,
-      tags: event.tags,
-      content: event.content,
-    };
-
-    const calculatedId = await getEventHash(unsignedEvent);
-
-    if (calculatedId !== event.id) {
-      throw new NostrValidationError(
-        "Event ID does not match content hash",
-        "id",
-        event,
-      );
-    }
-  }
-
-  // 5. Validate signature
-  if (validateSignatures) {
-    const isValid = await verifySignature(event.id, event.sig, event.pubkey);
-
-    if (!isValid) {
-      throw new NostrValidationError("Invalid signature", "sig", event);
-    }
-  }
-
-  // 6. Validate content format based on kind
+  // Validate content format based on kind
   if (validateContent) {
     switch (event.kind) {
       case NostrKind.Metadata:

--- a/src/nip01/event.ts
+++ b/src/nip01/event.ts
@@ -17,6 +17,8 @@ import { calculateEventHash } from "./serialization";
 import {
   isValidLowercasePublicKeyFormat,
   NostrValidationError,
+  sanitizeUnsignedNostrEvent,
+  type UnsignedNostrEvent,
   validateSignedNostrEvent,
 } from "./validation";
 import {
@@ -30,7 +32,7 @@ import {
 
 export { NostrValidationError } from "./validation";
 
-export type UnsignedEvent = Omit<NostrEvent, "id" | "sig">;
+export type UnsignedEvent = UnsignedNostrEvent;
 
 /**
  * Calculate the event hash following NIP-01 specification exactly
@@ -40,59 +42,8 @@ export type UnsignedEvent = Omit<NostrEvent, "id" | "sig">;
 export async function getEventHash(
   event: UnsignedEvent | NostrEvent,
 ): Promise<string> {
-  // Validate event structure first - these fields are required by the Nostr protocol
-  if (!event.pubkey)
-    throw new NostrValidationError(
-      "Invalid event: missing pubkey",
-      "pubkey",
-      event,
-    );
-  if (event.created_at === undefined || event.created_at === null)
-    throw new NostrValidationError(
-      "Invalid event: missing created_at",
-      "created_at",
-      event,
-    );
-  if (event.kind === undefined)
-    throw new NostrValidationError(
-      "Invalid event: missing kind",
-      "kind",
-      event,
-    );
-  if (!Array.isArray(event.tags))
-    throw new NostrValidationError(
-      "Invalid event: tags must be an array",
-      "tags",
-      event,
-    );
-
-  // Ensure the tags are valid arrays of strings
-  for (const tag of event.tags) {
-    if (!Array.isArray(tag))
-      throw new NostrValidationError(
-        "Invalid event: each tag must be an array",
-        "tags",
-        event,
-      );
-    for (const item of tag) {
-      if (typeof item !== "string")
-        throw new NostrValidationError(
-          "Invalid event: tag items must be strings",
-          "tags",
-          event,
-        );
-    }
-  }
-
-  // Check that content is a string
-  if (typeof event.content !== "string")
-    throw new NostrValidationError(
-      "Invalid event: content must be a string",
-      "content",
-      event,
-    );
-
-  return calculateEventHash(event);
+  const sanitized = sanitizeUnsignedNostrEvent(event);
+  return calculateEventHash(sanitized);
 }
 
 /**

--- a/src/nip01/nostr.ts
+++ b/src/nip01/nostr.ts
@@ -9,6 +9,7 @@ import {
   PublishResponse,
   SubscriptionOptions,
 } from "../types/nostr";
+import type { RelayConnectionOptions } from "../types/protocol";
 import { getPublicKey, generateKeypair } from "../utils/crypto";
 import { isValidRelayUrl } from "../nip19";
 import { createSignedAuthEvent } from "../nip42";
@@ -60,10 +61,7 @@ export interface NostrRateLimits {
  */
 export interface NostrOptions {
   /** Options to pass to each Relay instance */
-  relayOptions?: {
-    connectionTimeout?: number;
-    bufferFlushDelay?: number;
-  };
+  relayOptions?: RelayConnectionOptions;
   /** Rate limiting configuration for different operations */
   rateLimits?: NostrRateLimits;
 }
@@ -124,10 +122,7 @@ export class Nostr {
   private relays: Map<string, Relay> = new Map();
   private privateKey?: string;
   private publicKey?: string;
-  private relayOptions?: {
-    connectionTimeout?: number;
-    bufferFlushDelay?: number;
-  };
+  private relayOptions?: RelayConnectionOptions;
   private eventCallbacks: Map<RelayEvent, Set<NostrEventCallback>> = new Map();
   private logger: Logger;
 

--- a/src/nip01/nostr.ts
+++ b/src/nip01/nostr.ts
@@ -26,13 +26,10 @@ import {
 import { Logger, LogLevel } from "../nip46/utils/logger";
 import {
   validateFilters,
-  validateEventContent,
-  validateTags,
   validateNumber,
   SecurityValidationError,
   checkRateLimit,
   RateLimitState,
-  SECURITY_LIMITS,
 } from "../utils/security-validator";
 import { getRegisteredNIP04 } from "../nip04/registry";
 
@@ -551,26 +548,8 @@ export class Nostr {
       throw new Error("Private key is not set");
     }
 
-    // Validate inputs
     try {
-      const validatedContent = validateEventContent(content);
-      const validatedTags = validateTags(tags);
-
-      // Calculate actual UTF-8 byte length for proper size validation
-      const contentByteLength = new TextEncoder().encode(
-        validatedContent,
-      ).length;
-      if (contentByteLength > SECURITY_LIMITS.MAX_CONTENT_SIZE) {
-        throw new Error(
-          `Content too large: ${contentByteLength} bytes (max ${SECURITY_LIMITS.MAX_CONTENT_SIZE})`,
-        );
-      }
-
-      const noteTemplate = createTextNote(
-        validatedContent,
-        this.privateKey,
-        validatedTags,
-      );
+      const noteTemplate = createTextNote(content, this.privateKey, tags);
       const signedEvent = await createSignedEvent(
         noteTemplate,
         this.privateKey,

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -14,9 +14,7 @@ import {
   SubscriptionOptions,
 } from "../types/nostr";
 import { RelayConnectionOptions } from "../types/protocol";
-import { NostrValidationError, getEventHash } from "./event";
-import { getUnixTime } from "../utils/time";
-import { verifySignature } from "../utils/crypto";
+import { NostrValidationError, validateRelayIngressEvent } from "./validation";
 import { Logger, LogLevel } from "../nip46/utils/logger";
 import {
   SECURITY_LIMITS,
@@ -841,40 +839,9 @@ export class Relay {
 
         this.incrementPendingValidation(subscriptionId);
 
-        // Type guard to ensure event is a NostrEvent
-        if (!this.isNostrEvent(event)) {
-          this.decrementPendingValidation(subscriptionId);
-          this.triggerEvent(
-            RelayEvent.Error,
-            this.url,
-            new Error(`Invalid event structure: ${JSON.stringify(event)}`),
-          );
-          break;
-        }
-
-        // Perform initial synchronous validation
-        if (!this.performBasicValidation(event)) {
-          this.triggerEvent(
-            RelayEvent.Error,
-            this.url,
-            new Error(`Invalid event: ${event.id}`),
-          );
-          this.decrementPendingValidation(subscriptionId);
-          break;
-        }
-
-        // Launch async validation and handle the event only if validation passes
-        this.validateEventAsync(event)
-          .then((isValid) => {
-            if (isValid) {
-              this.processValidatedEvent(event, subscriptionId);
-            } else {
-              this.triggerEvent(
-                RelayEvent.Error,
-                this.url,
-                new Error(`Async validation failed for event: ${event.id}`),
-              );
-            }
+        this.validateInboundEvent(event)
+          .then((validatedEvent) => {
+            this.processValidatedEvent(validatedEvent, subscriptionId);
           })
           .catch((error) => {
             this.triggerEvent(
@@ -969,7 +936,7 @@ export class Relay {
   }
 
   /**
-   * Process a validated event - called only after both basic and async validation
+   * Process a validated event - called only after Relay ingress validation
    */
   private processValidatedEvent(
     event: NostrEvent,
@@ -996,209 +963,15 @@ export class Relay {
     }
   }
 
-  // Helper function to check if a string is a valid hex string of a specific length
-  private isHexString(value: unknown, length?: number): boolean {
-    if (typeof value !== "string") {
-      return false;
-    }
-    if (!/^[0-9a-fA-F]+$/.test(value)) {
-      return false;
-    }
-    if (length !== undefined && value.length !== length) {
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Perform basic synchronous validation of an event
-   *
-   * This checks:
-   * 1. Required fields are present with correct types
-   * 2. Fields have valid formats (lengths, structure)
-   * 3. Timestamps are reasonable
-   */
-  private performBasicValidation(event: unknown): boolean {
-    // Skip validation if event is not a NostrEvent
-    if (!this.isNostrEvent(event)) {
-      return false;
-    }
-
-    try {
-      // Now we can safely access event properties
-      // Check that all required fields are present and have the correct types
-      if (!this.isHexString(event.id, 64)) {
-        return false;
-      }
-
-      if (!this.isHexString(event.pubkey, 64)) {
-        return false;
-      }
-
-      if (event.kind < 0 || event.kind > 65535) {
-        return false;
-      }
-
-      // Validate tag structure
-      for (const tag of event.tags) {
-        if (!Array.isArray(tag) || tag.length === 0) {
-          // Ensure tag is a non-empty array
-          return false;
-        }
-
-        // All tag items must be strings according to NIP-01
-        for (const item of tag) {
-          if (typeof item !== "string") {
-            return false;
-          }
-        }
-
-        // Specific NIP-01 tag parameter validation
-        const tagName = tag[0];
-        if (tagName === "e" || tagName === "p") {
-          // For 'e' (event ID) and 'p' (pubkey) tags, the second element must be a 64-char hex string
-          // NIP-01: ["e", <event-id-hex>, <optional-relay-url-string>]
-          // NIP-01: ["p", <pubkey-hex>, <optional-relay-url-string>]
-          if (tag.length < 2 || !this.isHexString(tag[1], 64)) {
-            return false;
-          }
-        } else if (tagName === "a") {
-          // For 'a' tags, validate the <kind>:<pubkey>:<d-identifier> structure
-          // NIP-01: ["a", "<kind>:<pubkey>:<d-identifier>", <optional-relay-url>]
-          if (tag.length < 2 || typeof tag[1] !== "string") {
-            return false; // Must have at least name and value, value must be a string
-          }
-          const valueParts = tag[1].split(":");
-          if (valueParts.length !== 3) {
-            // This structure must contain exactly three parts: kind, pubkey, and d-tag value (which can be empty).
-            // e.g., "30023:pubkeyhex:identifier" or "10002:pubkeyhex:"
-            return false;
-          }
-
-          const kindStr = valueParts[0];
-          const pubkeyStr = valueParts[1];
-          // const dValueStr = valueParts[2]; // dValueStr is implicitly validated as a string by split
-
-          // Validate kind (must be a non-negative integer string)
-          const kindNum = parseInt(kindStr, 10);
-          if (
-            isNaN(kindNum) ||
-            !Number.isInteger(kindNum) ||
-            kindNum < 0 || // Kinds must be non-negative
-            String(kindNum) !== kindStr // Ensures no trailing characters, e.g., "123xyz"
-          ) {
-            return false;
-          }
-
-          // Validate pubkey (must be 64-char hex)
-          if (!this.isHexString(pubkeyStr, 64)) {
-            return false;
-          }
-          // dValueStr (valueParts[2]) is a string by virtue of the split.
-          // NIP-01 doesn't impose further generic constraints on its content for the 'a' tag structure itself.
-        }
-        // Other tag types might have different validation rules, not covered by this specific claim.
-      }
-
-      if (!this.isHexString(event.sig, 128)) {
-        return false;
-      }
-
-      // Check reasonable timestamp (not more than 1 hour in the future and not too far in the past)
-      const now = getUnixTime();
-      if (event.created_at > now + 3600) {
-        return false; // Reject events with future timestamps
-      }
-
-      // Special handling for NIP-46 events (kind 24133)
-      if (event.kind === 24133) {
-        // NIP-46 events require at least one 'p' tag.
-        // The format of such a 'p' tag (tag[0]==='p', tag.length >= 2, and tag[1] is 64-char hex)
-        // would have already been validated by the general tag loop above.
-        // Here, we just ensure at least one such 'p' tag exists.
-        const hasValidPTagForNIP46 = event.tags.some(
-          (tag: string[]) => tag.length >= 2 && tag[0] === "p",
-        );
-
-        if (!hasValidPTagForNIP46) {
-          // Optionally log here if needed
-          return false;
-        }
-      }
-
-      // Optionally log a warning for very old events (e.g., older than a year)
-      if (event.created_at < now - 31536000) {
-        // Optionally log here if needed
-      }
-
-      return true;
-    } catch (error) {
-      // If any validation throws an exception, reject the event
-      return false;
-    }
-  }
-
-  /**
-   * Validate an event (deprecated - use async validation directly)
-   * Maintained for backward compatibility with existing code
-   */
-  private validateEvent(event: unknown): boolean {
-    if (!this.isNostrEvent(event)) {
-      return false;
-    }
-
-    if (!this.performBasicValidation(event)) {
-      return false;
-    }
-
-    // For NIP-46 encrypted events, we can skip async validation since
-    // their content can only be verified after decryption
-    if (event.kind === 24133) {
-      return true;
-    }
-
-    // For all other events, indicate that basic validation passed, but defer
-    // to async validation before actually accepting the event
-    return true;
-  }
-
-  /**
-   * Perform async validations on an event
-   *
-   * This includes:
-   * 1. Verifying the event ID matches the hash of serialized data
-   * 2. Verifying the signature is valid
-   *
-   * These operations are computationally expensive, so they're performed
-   * asynchronously to avoid blocking the main thread.
-   */
-  private async validateEventAsync(event: NostrEvent): Promise<boolean> {
-    try {
-      // Extract the data needed for ID verification (excluding id and sig)
-      const eventData = {
-        pubkey: event.pubkey,
-        created_at: event.created_at,
-        kind: event.kind,
-        tags: event.tags,
-        content: event.content,
-      };
-
-      // Step 1: Validate event ID by comparing with calculated hash
-      const calculatedId = await getEventHash(eventData);
-      if (calculatedId !== event.id) {
-        return false;
-      }
-
-      // Step 2: Validate signature
-      return await verifySignature(event.id, event.sig, event.pubkey);
-    } catch (error) {
-      // Log error details if in debug mode
-      const debug = process.env.DEBUG?.includes("nostr:*") || false;
-      if (debug) {
-        console.error(`Relay(${this.url}): Event validation error:`, error);
-      }
-      return false;
-    }
+  private validateInboundEvent(event: unknown): Promise<NostrEvent> {
+    return validateRelayIngressEvent(event, {
+      validateKindRange: true,
+      validateRelayTagReferences: true,
+      requireNip46PTag: true,
+      maxFutureTimestampDrift: 60 * 60,
+      maxPastTimestampDrift: 0,
+      skipIdAndSignatureValidationForKinds: [24133],
+    });
   }
 
   // Use a type-safe approach with overloads for each event type
@@ -1649,23 +1422,6 @@ export class Relay {
       }
     }
     return result;
-  }
-
-  // Add this helper method to type guard for NostrEvent
-  private isNostrEvent(event: unknown): event is NostrEvent {
-    if (!event || typeof event !== "object") return false;
-
-    const e = event as Record<string, unknown>;
-
-    return (
-      typeof e.id === "string" &&
-      typeof e.pubkey === "string" &&
-      typeof e.created_at === "number" &&
-      typeof e.kind === "number" &&
-      Array.isArray(e.tags) &&
-      typeof e.content === "string" &&
-      typeof e.sig === "string"
-    );
   }
 
   // New private helper method for validating NIP-01 filter identifiers

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -970,7 +970,6 @@ export class Relay {
       requireNip46PTag: true,
       maxFutureTimestampDrift: 60 * 60,
       maxPastTimestampDrift: 0,
-      skipIdAndSignatureValidationForKinds: [24133],
     });
   }
 

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -81,6 +81,8 @@ export class Relay {
   private autoReconnect = true; // Whether to automatically reconnect
   private maxReconnectAttempts = 10; // Maximum number of reconnection attempts
   private maxReconnectDelay = 30000; // Maximum delay between reconnect attempts (ms)
+  private maxFutureTimestampDrift = 60 * 60; // Maximum accepted future event timestamp drift (s)
+  private maxPastTimestampDrift = 0; // Maximum accepted past event timestamp drift (s); 0 disables this check
   // Track replaceable and addressable events according to NIP-01 with memory limits
   private replaceableEvents: Map<string, Map<number, NostrEvent>> = new Map();
   private replaceableEventAccessTimes: Map<string, number> = new Map(); // For LRU eviction
@@ -117,6 +119,14 @@ export class Relay {
     }
     if (options.maxReconnectDelay !== undefined) {
       this.maxReconnectDelay = options.maxReconnectDelay;
+    }
+    if (options.inboundValidation?.maxFutureTimestampDrift !== undefined) {
+      this.maxFutureTimestampDrift =
+        options.inboundValidation.maxFutureTimestampDrift;
+    }
+    if (options.inboundValidation?.maxPastTimestampDrift !== undefined) {
+      this.maxPastTimestampDrift =
+        options.inboundValidation.maxPastTimestampDrift;
     }
   }
 
@@ -968,8 +978,8 @@ export class Relay {
       validateKindRange: true,
       validateRelayTagReferences: true,
       requireNip46PTag: true,
-      maxFutureTimestampDrift: 60 * 60,
-      maxPastTimestampDrift: 0,
+      maxFutureTimestampDrift: this.maxFutureTimestampDrift,
+      maxPastTimestampDrift: this.maxPastTimestampDrift,
     });
   }
 

--- a/src/nip01/serialization.ts
+++ b/src/nip01/serialization.ts
@@ -1,0 +1,23 @@
+import { NostrEvent } from "../types/nostr";
+import { sha256Hex } from "../utils/crypto";
+
+export type EventHashInput = Pick<
+  NostrEvent,
+  "pubkey" | "created_at" | "kind" | "tags" | "content"
+>;
+
+/**
+ * Calculate the event hash following NIP-01 serialization.
+ */
+export function calculateEventHash(event: EventHashInput): string {
+  return sha256Hex(
+    JSON.stringify([
+      0,
+      event.pubkey,
+      event.created_at,
+      event.kind,
+      event.tags,
+      event.content,
+    ]),
+  );
+}

--- a/src/nip01/validation.ts
+++ b/src/nip01/validation.ts
@@ -83,6 +83,10 @@ function isHexString(value: unknown, length: number): value is string {
   );
 }
 
+function isValidCreatedAtTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 function validateNostrEventPayload(
   candidate: Partial<NostrEvent>,
   options: SignedEventValidationOptions = {},
@@ -153,7 +157,7 @@ function validateNostrEventPayload(
       );
     }
 
-    if (typeof candidate.created_at !== "number" || candidate.created_at < 0) {
+    if (!isValidCreatedAtTimestamp(candidate.created_at)) {
       throw new NostrValidationError(
         "Invalid created_at timestamp",
         "created_at",
@@ -317,6 +321,14 @@ export async function validateSignedNostrEvent(
     maxFutureTimestampDrift !== undefined ||
     maxPastTimestampDrift !== undefined
   ) {
+    if (!isValidCreatedAtTimestamp(sanitized.created_at)) {
+      throw new NostrValidationError(
+        "Invalid created_at timestamp",
+        "created_at",
+        sanitized,
+      );
+    }
+
     const now = getUnixTime();
     const futureDrift = sanitized.created_at - now;
     const pastDrift = now - sanitized.created_at;
@@ -345,6 +357,14 @@ export async function validateSignedNostrEvent(
       );
     }
   } else if (maxTimestampDrift > 0) {
+    if (!isValidCreatedAtTimestamp(sanitized.created_at)) {
+      throw new NostrValidationError(
+        "Invalid created_at timestamp",
+        "created_at",
+        sanitized,
+      );
+    }
+
     const now = getUnixTime();
     const drift = Math.abs(now - sanitized.created_at);
 

--- a/src/nip01/validation.ts
+++ b/src/nip01/validation.ts
@@ -15,6 +15,8 @@ type ValidationInvalidData =
   | Record<string, unknown>
   | EventTemplate;
 
+export type UnsignedNostrEvent = Omit<NostrEvent, "id" | "sig">;
+
 /**
  * Custom error class for Nostr event validation errors.
  */
@@ -62,7 +64,15 @@ export interface RelayIngressValidationOptions
  * Validate if a string is a valid lowercase hex public key format for NIP-01 events.
  */
 export function isValidLowercasePublicKeyFormat(publicKey: string): boolean {
-  return /^[0-9a-f]{64}$/.test(publicKey);
+  return isLowercaseHexString(publicKey, 64);
+}
+
+function isLowercaseHexString(value: unknown, length: number): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]+$/.test(value) &&
+    value.length === length
+  );
 }
 
 function isHexString(value: unknown, length: number): value is string {
@@ -73,48 +83,17 @@ function isHexString(value: unknown, length: number): value is string {
   );
 }
 
-/**
- * Sanitizes unknown input into a Nostr Event shape.
- *
- * This is intentionally synchronous: it validates shape, scalar formats, tag
- * structure, and timestamp shape, but not the event id or signature.
- */
-export function sanitizeNostrEvent(
-  event: unknown,
+function validateNostrEventPayload(
+  candidate: Partial<NostrEvent>,
   options: SignedEventValidationOptions = {},
-): NostrEvent {
+): void {
   const {
     validateFields = true,
     validateTags = true,
     validateKindRange = false,
   } = options;
 
-  if (!event || typeof event !== "object") {
-    throw new NostrValidationError("Invalid event: must be an object", "event");
-  }
-
-  const candidate = event as Partial<NostrEvent>;
-
   if (validateFields) {
-    if (
-      !candidate.id ||
-      typeof candidate.id !== "string" ||
-      !isHexString(candidate.id, 64)
-    ) {
-      throw new NostrValidationError(
-        "Invalid or missing event ID: must be a 64-character hex string",
-        "id",
-        candidate,
-      );
-    }
-    if (candidate.id !== candidate.id.toLowerCase()) {
-      throw new NostrValidationError(
-        "Invalid event ID: must be lowercase hex",
-        "id",
-        candidate,
-      );
-    }
-
     if (!candidate.pubkey || typeof candidate.pubkey !== "string") {
       throw new NostrValidationError(
         "Invalid or missing pubkey: must be a string",
@@ -149,25 +128,6 @@ export function sanitizeNostrEvent(
       throw new NostrValidationError(
         "Invalid pubkey: must be a valid secp256k1 curve point",
         "pubkey",
-        candidate,
-      );
-    }
-
-    if (
-      !candidate.sig ||
-      typeof candidate.sig !== "string" ||
-      !isHexString(candidate.sig, 128)
-    ) {
-      throw new NostrValidationError(
-        "Invalid or missing signature: must be a 128-character hex string",
-        "sig",
-        candidate,
-      );
-    }
-    if (candidate.sig !== candidate.sig.toLowerCase()) {
-      throw new NostrValidationError(
-        "Invalid signature: must be lowercase hex",
-        "sig",
         candidate,
       );
     }
@@ -247,6 +207,90 @@ export function sanitizeNostrEvent(
       }
     }
   }
+}
+
+/**
+ * Sanitizes unknown input into the unsigned Nostr Event shape used for hashing.
+ */
+export function sanitizeUnsignedNostrEvent(
+  event: unknown,
+  options: SignedEventValidationOptions = {},
+): UnsignedNostrEvent {
+  if (!event || typeof event !== "object") {
+    throw new NostrValidationError("Invalid event: must be an object", "event");
+  }
+
+  const candidate = event as Partial<NostrEvent>;
+  validateNostrEventPayload(candidate, options);
+
+  return {
+    pubkey: candidate.pubkey,
+    created_at: candidate.created_at,
+    kind: candidate.kind,
+    tags: candidate.tags,
+    content: candidate.content,
+  } as UnsignedNostrEvent;
+}
+
+/**
+ * Sanitizes unknown input into a Nostr Event shape.
+ *
+ * This is intentionally synchronous: it validates shape, scalar formats, tag
+ * structure, and timestamp shape, but not the event id or signature.
+ */
+export function sanitizeNostrEvent(
+  event: unknown,
+  options: SignedEventValidationOptions = {},
+): NostrEvent {
+  const { validateFields = true } = options;
+
+  if (!event || typeof event !== "object") {
+    throw new NostrValidationError("Invalid event: must be an object", "event");
+  }
+
+  const candidate = event as Partial<NostrEvent>;
+
+  if (validateFields) {
+    if (
+      !candidate.id ||
+      typeof candidate.id !== "string" ||
+      !isHexString(candidate.id, 64)
+    ) {
+      throw new NostrValidationError(
+        "Invalid or missing event ID: must be a 64-character hex string",
+        "id",
+        candidate,
+      );
+    }
+    if (candidate.id !== candidate.id.toLowerCase()) {
+      throw new NostrValidationError(
+        "Invalid event ID: must be lowercase hex",
+        "id",
+        candidate,
+      );
+    }
+
+    if (
+      !candidate.sig ||
+      typeof candidate.sig !== "string" ||
+      !isHexString(candidate.sig, 128)
+    ) {
+      throw new NostrValidationError(
+        "Invalid or missing signature: must be a 128-character hex string",
+        "sig",
+        candidate,
+      );
+    }
+    if (candidate.sig !== candidate.sig.toLowerCase()) {
+      throw new NostrValidationError(
+        "Invalid signature: must be lowercase hex",
+        "sig",
+        candidate,
+      );
+    }
+  }
+
+  validateNostrEventPayload(candidate, options);
 
   return candidate as NostrEvent;
 }
@@ -349,9 +393,9 @@ function validateRelayTagReferences(event: NostrEvent): void {
     const tagName = tag[0];
 
     if (tagName === "e" || tagName === "p") {
-      if (tag.length < 2 || !isHexString(tag[1], 64)) {
+      if (tag.length < 2 || !isLowercaseHexString(tag[1], 64)) {
         throw new NostrValidationError(
-          `Invalid NIP-01 '${tagName}' tag: tag[1] must be a 64-character hex string`,
+          `Invalid NIP-01 '${tagName}' tag: tag[1] must be a 64-character lowercase hex string`,
           "tags",
           event,
         );
@@ -394,9 +438,9 @@ function validateRelayTagReferences(event: NostrEvent): void {
       );
     }
 
-    if (!isHexString(pubkeyValue, 64)) {
+    if (!isLowercaseHexString(pubkeyValue, 64)) {
       throw new NostrValidationError(
-        "Invalid NIP-01 'a' tag: pubkey must be a 64-character hex string",
+        "Invalid NIP-01 'a' tag: pubkey must be a 64-character lowercase hex string",
         "tags",
         event,
       );
@@ -410,7 +454,8 @@ function validateNip46RelayIngress(event: NostrEvent): void {
   }
 
   const hasPTag = event.tags.some(
-    (tag) => tag[0] === "p" && tag.length >= 2 && isHexString(tag[1], 64),
+    (tag) =>
+      tag[0] === "p" && tag.length >= 2 && isLowercaseHexString(tag[1], 64),
   );
 
   if (!hasPTag) {

--- a/src/nip01/validation.ts
+++ b/src/nip01/validation.ts
@@ -99,7 +99,7 @@ export function sanitizeNostrEvent(
     if (
       !candidate.id ||
       typeof candidate.id !== "string" ||
-      candidate.id.length !== 64
+      !isHexString(candidate.id, 64)
     ) {
       throw new NostrValidationError(
         "Invalid or missing event ID: must be a 64-character hex string",
@@ -156,7 +156,7 @@ export function sanitizeNostrEvent(
     if (
       !candidate.sig ||
       typeof candidate.sig !== "string" ||
-      candidate.sig.length !== 128
+      !isHexString(candidate.sig, 128)
     ) {
       throw new NostrValidationError(
         "Invalid or missing signature: must be a 128-character hex string",
@@ -432,7 +432,7 @@ export async function validateRelayIngressEvent(
   const {
     validateRelayTagReferences: shouldValidateRelayTagReferences = true,
     requireNip46PTag = true,
-    skipIdAndSignatureValidationForKinds = [24133],
+    skipIdAndSignatureValidationForKinds = [],
     validateKindRange = true,
     maxFutureTimestampDrift = 60 * 60,
     maxPastTimestampDrift = 0,

--- a/src/nip01/validation.ts
+++ b/src/nip01/validation.ts
@@ -44,6 +44,18 @@ export interface SignedEventValidationOptions extends ValidationOptions {
   skipIdAndSignatureValidationForKinds?: number[];
   /** Whether kind must be in the NIP-01 0-65535 range. */
   validateKindRange?: boolean;
+  /** Maximum allowed future timestamp deviation in seconds. */
+  maxFutureTimestampDrift?: number;
+  /** Maximum allowed past timestamp deviation in seconds. */
+  maxPastTimestampDrift?: number;
+}
+
+export interface RelayIngressValidationOptions
+  extends SignedEventValidationOptions {
+  /** Whether Relay ingress should validate NIP-01 e/p/a tag references. */
+  validateRelayTagReferences?: boolean;
+  /** Whether NIP-46 remote-signing events must carry at least one p tag. */
+  requireNip46PTag?: boolean;
 }
 
 /**
@@ -51,6 +63,14 @@ export interface SignedEventValidationOptions extends ValidationOptions {
  */
 export function isValidLowercasePublicKeyFormat(publicKey: string): boolean {
   return /^[0-9a-f]{64}$/.test(publicKey);
+}
+
+function isHexString(value: unknown, length: number): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-fA-F]+$/.test(value) &&
+    value.length === length
+  );
 }
 
 /**
@@ -242,12 +262,45 @@ export async function validateSignedNostrEvent(
     validateIds = true,
     validateSignatures = true,
     maxTimestampDrift = 60 * 60,
+    maxFutureTimestampDrift,
+    maxPastTimestampDrift,
     skipIdAndSignatureValidationForKinds = [],
   } = options;
 
   const sanitized = sanitizeNostrEvent(event, options);
 
-  if (maxTimestampDrift > 0) {
+  if (
+    maxFutureTimestampDrift !== undefined ||
+    maxPastTimestampDrift !== undefined
+  ) {
+    const now = getUnixTime();
+    const futureDrift = sanitized.created_at - now;
+    const pastDrift = now - sanitized.created_at;
+
+    if (
+      maxFutureTimestampDrift !== undefined &&
+      maxFutureTimestampDrift > 0 &&
+      futureDrift > maxFutureTimestampDrift
+    ) {
+      throw new NostrValidationError(
+        `Event timestamp is too far in the future (drift: ${futureDrift}s, max allowed: ${maxFutureTimestampDrift}s)`,
+        "created_at",
+        sanitized,
+      );
+    }
+
+    if (
+      maxPastTimestampDrift !== undefined &&
+      maxPastTimestampDrift > 0 &&
+      pastDrift > maxPastTimestampDrift
+    ) {
+      throw new NostrValidationError(
+        `Event timestamp is too far in the past (drift: ${pastDrift}s, max allowed: ${maxPastTimestampDrift}s)`,
+        "created_at",
+        sanitized,
+      );
+    }
+  } else if (maxTimestampDrift > 0) {
     const now = getUnixTime();
     const drift = Math.abs(now - sanitized.created_at);
 
@@ -286,6 +339,120 @@ export async function validateSignedNostrEvent(
     if (!isValid) {
       throw new NostrValidationError("Invalid signature", "sig", sanitized);
     }
+  }
+
+  return sanitized;
+}
+
+function validateRelayTagReferences(event: NostrEvent): void {
+  for (const tag of event.tags) {
+    const tagName = tag[0];
+
+    if (tagName === "e" || tagName === "p") {
+      if (tag.length < 2 || !isHexString(tag[1], 64)) {
+        throw new NostrValidationError(
+          `Invalid NIP-01 '${tagName}' tag: tag[1] must be a 64-character hex string`,
+          "tags",
+          event,
+        );
+      }
+      continue;
+    }
+
+    if (tagName !== "a") {
+      continue;
+    }
+
+    if (tag.length < 2 || typeof tag[1] !== "string") {
+      throw new NostrValidationError(
+        "Invalid NIP-01 'a' tag: tag[1] must be a coordinate string",
+        "tags",
+        event,
+      );
+    }
+
+    const coordinateParts = tag[1].split(":");
+    if (coordinateParts.length !== 3) {
+      throw new NostrValidationError(
+        "Invalid NIP-01 'a' tag: coordinate must be <kind>:<pubkey>:<d-identifier>",
+        "tags",
+        event,
+      );
+    }
+
+    const [kindValue, pubkeyValue] = coordinateParts;
+    const parsedKind = Number(kindValue);
+    if (
+      !Number.isInteger(parsedKind) ||
+      parsedKind < 0 ||
+      String(parsedKind) !== kindValue
+    ) {
+      throw new NostrValidationError(
+        "Invalid NIP-01 'a' tag: kind must be a non-negative integer string",
+        "tags",
+        event,
+      );
+    }
+
+    if (!isHexString(pubkeyValue, 64)) {
+      throw new NostrValidationError(
+        "Invalid NIP-01 'a' tag: pubkey must be a 64-character hex string",
+        "tags",
+        event,
+      );
+    }
+  }
+}
+
+function validateNip46RelayIngress(event: NostrEvent): void {
+  if (event.kind !== 24133) {
+    return;
+  }
+
+  const hasPTag = event.tags.some(
+    (tag) => tag[0] === "p" && tag.length >= 2 && isHexString(tag[1], 64),
+  );
+
+  if (!hasPTag) {
+    throw new NostrValidationError(
+      "NIP-46 Relay ingress events must include at least one p tag",
+      "tags",
+      event,
+    );
+  }
+}
+
+/**
+ * Validate an inbound Relay EVENT message through the central validation seam.
+ */
+export async function validateRelayIngressEvent(
+  event: unknown,
+  options: RelayIngressValidationOptions = {},
+): Promise<NostrEvent> {
+  const {
+    validateRelayTagReferences: shouldValidateRelayTagReferences = true,
+    requireNip46PTag = true,
+    skipIdAndSignatureValidationForKinds = [24133],
+    validateKindRange = true,
+    maxFutureTimestampDrift = 60 * 60,
+    maxPastTimestampDrift = 0,
+    ...signedOptions
+  } = options;
+
+  const sanitized = await validateSignedNostrEvent(event, {
+    ...signedOptions,
+    skipIdAndSignatureValidationForKinds,
+    validateKindRange,
+    maxFutureTimestampDrift,
+    maxPastTimestampDrift,
+  });
+
+  if (shouldValidateRelayTagReferences) {
+    validateRelayTagReferences(sanitized);
+  }
+
+  if (requireNip46PTag) {
+    validateNip46RelayIngress(sanitized);
   }
 
   return sanitized;

--- a/src/nip01/validation.ts
+++ b/src/nip01/validation.ts
@@ -1,0 +1,307 @@
+import {
+  EventTemplate,
+  Filter,
+  NostrEvent,
+  ValidationOptions,
+} from "../types/nostr";
+import { verifySignature } from "../utils/crypto";
+import { getUnixTime } from "../utils/time";
+import { isValidPublicKeyPoint } from "../nip44";
+import { calculateEventHash } from "./serialization";
+
+type ValidationInvalidData =
+  | Partial<NostrEvent>
+  | Filter
+  | Record<string, unknown>
+  | EventTemplate;
+
+/**
+ * Custom error class for Nostr event validation errors.
+ */
+export class NostrValidationError extends Error {
+  /** The field that failed validation */
+  readonly field?: string;
+  /** The data that failed validation (can be an event, filter, etc.) */
+  readonly invalidData?: ValidationInvalidData;
+
+  constructor(
+    message: string,
+    field?: string,
+    invalidData?: ValidationInvalidData,
+  ) {
+    super(message);
+    this.name = "NostrValidationError";
+    this.field = field;
+    this.invalidData = invalidData;
+  }
+}
+
+export interface SignedEventValidationOptions extends ValidationOptions {
+  /**
+   * Event kinds whose encrypted content should be accepted after shape checks
+   * without recomputing id/signature validity at this seam.
+   */
+  skipIdAndSignatureValidationForKinds?: number[];
+  /** Whether kind must be in the NIP-01 0-65535 range. */
+  validateKindRange?: boolean;
+}
+
+/**
+ * Validate if a string is a valid lowercase hex public key format for NIP-01 events.
+ */
+export function isValidLowercasePublicKeyFormat(publicKey: string): boolean {
+  return /^[0-9a-f]{64}$/.test(publicKey);
+}
+
+/**
+ * Sanitizes unknown input into a Nostr Event shape.
+ *
+ * This is intentionally synchronous: it validates shape, scalar formats, tag
+ * structure, and timestamp shape, but not the event id or signature.
+ */
+export function sanitizeNostrEvent(
+  event: unknown,
+  options: SignedEventValidationOptions = {},
+): NostrEvent {
+  const {
+    validateFields = true,
+    validateTags = true,
+    validateKindRange = false,
+  } = options;
+
+  if (!event || typeof event !== "object") {
+    throw new NostrValidationError("Invalid event: must be an object", "event");
+  }
+
+  const candidate = event as Partial<NostrEvent>;
+
+  if (validateFields) {
+    if (
+      !candidate.id ||
+      typeof candidate.id !== "string" ||
+      candidate.id.length !== 64
+    ) {
+      throw new NostrValidationError(
+        "Invalid or missing event ID: must be a 64-character hex string",
+        "id",
+        candidate,
+      );
+    }
+    if (candidate.id !== candidate.id.toLowerCase()) {
+      throw new NostrValidationError(
+        "Invalid event ID: must be lowercase hex",
+        "id",
+        candidate,
+      );
+    }
+
+    if (!candidate.pubkey || typeof candidate.pubkey !== "string") {
+      throw new NostrValidationError(
+        "Invalid or missing pubkey: must be a string",
+        "pubkey",
+        candidate,
+      );
+    }
+
+    if (!isValidLowercasePublicKeyFormat(candidate.pubkey)) {
+      if (/^[0-9A-F]{64}$/.test(candidate.pubkey)) {
+        throw new NostrValidationError(
+          "Invalid pubkey: must be lowercase hex",
+          "pubkey",
+          candidate,
+        );
+      }
+      if (candidate.pubkey.length !== 64) {
+        throw new NostrValidationError(
+          "Invalid pubkey: must be 64 characters long",
+          "pubkey",
+          candidate,
+        );
+      }
+      throw new NostrValidationError(
+        "Invalid pubkey: must be a 64-character lowercase hex string",
+        "pubkey",
+        candidate,
+      );
+    }
+
+    if (!isValidPublicKeyPoint(candidate.pubkey)) {
+      throw new NostrValidationError(
+        "Invalid pubkey: must be a valid secp256k1 curve point",
+        "pubkey",
+        candidate,
+      );
+    }
+
+    if (
+      !candidate.sig ||
+      typeof candidate.sig !== "string" ||
+      candidate.sig.length !== 128
+    ) {
+      throw new NostrValidationError(
+        "Invalid or missing signature: must be a 128-character hex string",
+        "sig",
+        candidate,
+      );
+    }
+    if (candidate.sig !== candidate.sig.toLowerCase()) {
+      throw new NostrValidationError(
+        "Invalid signature: must be lowercase hex",
+        "sig",
+        candidate,
+      );
+    }
+
+    if (typeof candidate.kind !== "number") {
+      throw new NostrValidationError(
+        "Kind must be a number",
+        "kind",
+        candidate,
+      );
+    }
+
+    if (
+      validateKindRange &&
+      (!Number.isInteger(candidate.kind) ||
+        candidate.kind < 0 ||
+        candidate.kind > 65535)
+    ) {
+      throw new NostrValidationError(
+        "Kind must be an integer between 0 and 65535",
+        "kind",
+        candidate,
+      );
+    }
+
+    if (typeof candidate.created_at !== "number" || candidate.created_at < 0) {
+      throw new NostrValidationError(
+        "Invalid created_at timestamp",
+        "created_at",
+        candidate,
+      );
+    }
+
+    if (typeof candidate.content !== "string") {
+      throw new NostrValidationError(
+        "Content must be a string",
+        "content",
+        candidate,
+      );
+    }
+  }
+
+  if (validateTags) {
+    if (!Array.isArray(candidate.tags)) {
+      throw new NostrValidationError(
+        "Tags must be an array",
+        "tags",
+        candidate,
+      );
+    }
+
+    for (const tag of candidate.tags) {
+      if (!Array.isArray(tag)) {
+        throw new NostrValidationError(
+          "Each tag must be an array",
+          "tags",
+          candidate,
+        );
+      }
+
+      if (tag.length === 0) {
+        throw new NostrValidationError(
+          "Tags cannot be empty arrays",
+          "tags",
+          candidate,
+        );
+      }
+
+      for (const item of tag) {
+        if (typeof item !== "string") {
+          throw new NostrValidationError(
+            "Tag items must be strings",
+            "tags",
+            candidate,
+          );
+        }
+      }
+    }
+  }
+
+  return candidate as NostrEvent;
+}
+
+/**
+ * Validate a signed Nostr Event's shape, timestamp drift, id, and signature.
+ */
+export async function validateSignedNostrEvent(
+  event: unknown,
+  options: SignedEventValidationOptions = {},
+): Promise<NostrEvent> {
+  const {
+    validateIds = true,
+    validateSignatures = true,
+    maxTimestampDrift = 60 * 60,
+    skipIdAndSignatureValidationForKinds = [],
+  } = options;
+
+  const sanitized = sanitizeNostrEvent(event, options);
+
+  if (maxTimestampDrift > 0) {
+    const now = getUnixTime();
+    const drift = Math.abs(now - sanitized.created_at);
+
+    if (drift > maxTimestampDrift) {
+      throw new NostrValidationError(
+        `Event timestamp is too far from current time (drift: ${drift}s, max allowed: ${maxTimestampDrift}s)`,
+        "created_at",
+        sanitized,
+      );
+    }
+  }
+
+  if (skipIdAndSignatureValidationForKinds.includes(sanitized.kind)) {
+    return sanitized;
+  }
+
+  if (validateIds) {
+    const calculatedId = calculateEventHash(sanitized);
+
+    if (calculatedId !== sanitized.id) {
+      throw new NostrValidationError(
+        "Event ID does not match content hash",
+        "id",
+        sanitized,
+      );
+    }
+  }
+
+  if (validateSignatures) {
+    const isValid = await verifySignature(
+      sanitized.id,
+      sanitized.sig,
+      sanitized.pubkey,
+    );
+
+    if (!isValid) {
+      throw new NostrValidationError("Invalid signature", "sig", sanitized);
+    }
+  }
+
+  return sanitized;
+}
+
+/**
+ * Boolean convenience wrapper for signed Nostr Event validation.
+ */
+export async function verifySignedNostrEvent(
+  event: unknown,
+  options: SignedEventValidationOptions = {},
+): Promise<boolean> {
+  try {
+    await validateSignedNostrEvent(event, options);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -79,9 +79,9 @@ export interface RelayConnectionOptions {
   maxReconnectDelay?: number;
   /** Inbound relay EVENT validation settings */
   inboundValidation?: {
-    /** Maximum allowed future timestamp deviation in seconds */
+    /** Maximum allowed future timestamp deviation in seconds; values greater than 0 enable the check, while 0 or negative values disable it */
     maxFutureTimestampDrift?: number;
-    /** Maximum allowed past timestamp deviation in seconds */
+    /** Maximum allowed past timestamp deviation in seconds; values greater than 0 enable the check, while 0 or negative values disable it */
     maxPastTimestampDrift?: number;
   };
   /** Optional list of ephemeral subscriptions to initialize with */

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -77,6 +77,13 @@ export interface RelayConnectionOptions {
   maxReconnectAttempts?: number;
   /** Maximum delay between reconnection attempts (ms) */
   maxReconnectDelay?: number;
+  /** Inbound relay EVENT validation settings */
+  inboundValidation?: {
+    /** Maximum allowed future timestamp deviation in seconds */
+    maxFutureTimestampDrift?: number;
+    /** Maximum allowed past timestamp deviation in seconds */
+    maxPastTimestampDrift?: number;
+  };
   /** Optional list of ephemeral subscriptions to initialize with */
   ephemeralSubscriptions?: Array<{
     filters: NostrFilter[];

--- a/tests/nip01/event/event-validation.test.ts
+++ b/tests/nip01/event/event-validation.test.ts
@@ -1,0 +1,124 @@
+import {
+  createSignedEvent,
+  createTextNote,
+  validateEvent,
+  NostrValidationError,
+} from "../../../src/nip01/event";
+import {
+  sanitizeNostrEvent,
+  validateSignedNostrEvent,
+  verifySignedNostrEvent,
+} from "../../../src/nip01/validation";
+import { NostrEvent } from "../../../src/types/nostr";
+import { getPublicKey } from "../../../src/utils/crypto";
+
+describe("Nostr Event validation module", () => {
+  const privateKey =
+    "1111111111111111111111111111111111111111111111111111111111111111";
+  const publicKey = getPublicKey(privateKey);
+
+  async function signedTextNote(content = "central validation") {
+    return createSignedEvent(createTextNote(content, privateKey), privateKey);
+  }
+
+  it("sanitizes unknown input into a Nostr Event", async () => {
+    const signed = await signedTextNote();
+    const sanitized = sanitizeNostrEvent({ ...signed });
+
+    expect(sanitized).toEqual(signed);
+  });
+
+  it("rejects malformed event shape before signature verification", () => {
+    expect(() =>
+      sanitizeNostrEvent({
+        id: "a".repeat(64),
+        created_at: Math.floor(Date.now() / 1000),
+        kind: 1,
+        tags: [],
+        content: "missing pubkey",
+        sig: "b".repeat(128),
+      }),
+    ).toThrow(
+      new NostrValidationError(
+        "Invalid or missing pubkey: must be a string",
+        "pubkey",
+      ),
+    );
+  });
+
+  it("verifies a valid signed Nostr Event", async () => {
+    const signed = await signedTextNote();
+
+    await expect(validateSignedNostrEvent(signed)).resolves.toEqual(signed);
+    await expect(verifySignedNostrEvent(signed)).resolves.toBe(true);
+  });
+
+  it("rejects an event whose id does not match its content", async () => {
+    const signed = await signedTextNote();
+    const tampered: NostrEvent = {
+      ...signed,
+      content: "different content",
+    };
+
+    await expect(validateSignedNostrEvent(tampered)).rejects.toThrow(
+      new NostrValidationError("Event ID does not match content hash", "id"),
+    );
+    await expect(verifySignedNostrEvent(tampered)).resolves.toBe(false);
+  });
+
+  it("rejects an event with an invalid signature", async () => {
+    const signed = await signedTextNote();
+    const tampered: NostrEvent = {
+      ...signed,
+      sig: "0".repeat(128),
+    };
+
+    await expect(validateSignedNostrEvent(tampered)).rejects.toThrow(
+      new NostrValidationError("Invalid signature", "sig"),
+    );
+    await expect(verifySignedNostrEvent(tampered)).resolves.toBe(false);
+  });
+
+  it("can explicitly skip id and signature checks for encrypted NIP-46 Relay ingress", async () => {
+    const encryptedRequest: NostrEvent = {
+      id: "a".repeat(64),
+      pubkey: publicKey,
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 24133,
+      tags: [["p", publicKey]],
+      content: "encrypted request",
+      sig: "b".repeat(128),
+    };
+
+    await expect(
+      validateSignedNostrEvent(encryptedRequest, {
+        skipIdAndSignatureValidationForKinds: [24133],
+      }),
+    ).resolves.toEqual(encryptedRequest);
+    await expect(validateSignedNostrEvent(encryptedRequest)).rejects.toThrow(
+      NostrValidationError,
+    );
+  });
+
+  it("keeps the existing public validateEvent interface compatible", async () => {
+    const signed = await signedTextNote("public compatibility");
+
+    await expect(validateEvent(signed)).resolves.toBe(true);
+  });
+
+  it("keeps disabled id and signature checks compatible with existing shape validation", async () => {
+    const signed = await signedTextNote("shape compatibility");
+    const eventWithOpaqueIdAndSig: NostrEvent = {
+      ...signed,
+      id: "g".repeat(64),
+      sig: "z".repeat(128),
+    };
+
+    await expect(
+      validateEvent(eventWithOpaqueIdAndSig, {
+        validateIds: false,
+        validateSignatures: false,
+      }),
+    ).resolves.toBe(true);
+  });
+});

--- a/tests/nip01/event/event-validation.test.ts
+++ b/tests/nip01/event/event-validation.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../src/nip01/event";
 import {
   sanitizeNostrEvent,
+  validateRelayIngressEvent,
   validateSignedNostrEvent,
   verifySignedNostrEvent,
 } from "../../../src/nip01/validation";
@@ -119,6 +120,30 @@ describe("Nostr Event validation module", () => {
       new NostrValidationError(
         "Invalid or missing event ID: must be a 64-character hex string",
         "id",
+      ),
+    );
+  });
+
+  it("requires lowercase NIP-46 p tags even when relay tag reference checks are disabled", async () => {
+    const encryptedRequest = await createSignedEvent(
+      {
+        pubkey: publicKey,
+        created_at: Math.floor(Date.now() / 1000),
+        kind: 24133,
+        tags: [["p", publicKey.toUpperCase()]],
+        content: "encrypted request",
+      },
+      privateKey,
+    );
+
+    await expect(
+      validateRelayIngressEvent(encryptedRequest, {
+        validateRelayTagReferences: false,
+      }),
+    ).rejects.toThrow(
+      new NostrValidationError(
+        "NIP-46 Relay ingress events must include at least one p tag",
+        "tags",
       ),
     );
   });

--- a/tests/nip01/event/event-validation.test.ts
+++ b/tests/nip01/event/event-validation.test.ts
@@ -47,6 +47,45 @@ describe("Nostr Event validation module", () => {
     );
   });
 
+  it("rejects non-finite created_at values during shape validation", () => {
+    expect(() =>
+      sanitizeNostrEvent({
+        id: "a".repeat(64),
+        pubkey: publicKey,
+        created_at: Number.NaN,
+        kind: 1,
+        tags: [],
+        content: "non-finite timestamp",
+        sig: "b".repeat(128),
+      }),
+    ).toThrow(
+      new NostrValidationError("Invalid created_at timestamp", "created_at"),
+    );
+  });
+
+  it("rejects non-finite created_at values before drift enforcement", async () => {
+    const signedLikeEvent = {
+      id: "a".repeat(64),
+      pubkey: publicKey,
+      created_at: Number.NaN,
+      kind: 1,
+      tags: [],
+      content: "non-finite timestamp",
+      sig: "b".repeat(128),
+    };
+
+    await expect(
+      validateSignedNostrEvent(signedLikeEvent, {
+        validateFields: false,
+        validateIds: false,
+        validateSignatures: false,
+        maxFutureTimestampDrift: 60,
+      }),
+    ).rejects.toThrow(
+      new NostrValidationError("Invalid created_at timestamp", "created_at"),
+    );
+  });
+
   it("verifies a valid signed Nostr Event", async () => {
     const signed = await signedTextNote();
 

--- a/tests/nip01/event/event-validation.test.ts
+++ b/tests/nip01/event/event-validation.test.ts
@@ -79,7 +79,7 @@ describe("Nostr Event validation module", () => {
     await expect(verifySignedNostrEvent(tampered)).resolves.toBe(false);
   });
 
-  it("can explicitly skip id and signature checks for encrypted NIP-46 Relay ingress", async () => {
+  it("can explicitly skip id and signature checks for opt-in encrypted event paths", async () => {
     const encryptedRequest: NostrEvent = {
       id: "a".repeat(64),
       pubkey: publicKey,
@@ -100,6 +100,29 @@ describe("Nostr Event validation module", () => {
     );
   });
 
+  it("still rejects malformed id and signature shapes when hash and signature checks are skipped", async () => {
+    const encryptedRequest: NostrEvent = {
+      id: "g".repeat(64),
+      pubkey: publicKey,
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 24133,
+      tags: [["p", publicKey]],
+      content: "encrypted request",
+      sig: "z".repeat(128),
+    };
+
+    await expect(
+      validateSignedNostrEvent(encryptedRequest, {
+        skipIdAndSignatureValidationForKinds: [24133],
+      }),
+    ).rejects.toThrow(
+      new NostrValidationError(
+        "Invalid or missing event ID: must be a 64-character hex string",
+        "id",
+      ),
+    );
+  });
+
   it("keeps the existing public validateEvent interface compatible", async () => {
     const signed = await signedTextNote("public compatibility");
 
@@ -110,8 +133,8 @@ describe("Nostr Event validation module", () => {
     const signed = await signedTextNote("shape compatibility");
     const eventWithOpaqueIdAndSig: NostrEvent = {
       ...signed,
-      id: "g".repeat(64),
-      sig: "z".repeat(128),
+      id: "a".repeat(64),
+      sig: "b".repeat(128),
     };
 
     await expect(

--- a/tests/nip01/event/event.test.ts
+++ b/tests/nip01/event/event.test.ts
@@ -46,7 +46,7 @@ describe("Event Creation and Signing", () => {
       } as unknown as UnsignedEvent;
 
       await expect(getEventHash(event)).rejects.toThrow(
-        "Invalid event: missing pubkey",
+        "Invalid or missing pubkey: must be a string",
       );
     });
 
@@ -59,7 +59,21 @@ describe("Event Creation and Signing", () => {
       } as unknown as UnsignedEvent;
 
       await expect(getEventHash(event)).rejects.toThrow(
-        "Invalid event: missing created_at",
+        "Invalid created_at timestamp",
+      );
+    });
+
+    it("should throw error for non-number created_at", async () => {
+      const event = {
+        pubkey: publicKey,
+        created_at: "1652347275",
+        kind: 1,
+        tags: [],
+        content: "Hello, world!",
+      } as unknown as UnsignedEvent;
+
+      await expect(getEventHash(event)).rejects.toThrow(
+        "Invalid created_at timestamp",
       );
     });
 
@@ -71,9 +85,19 @@ describe("Event Creation and Signing", () => {
         content: "Hello, world!",
       } as unknown as UnsignedEvent;
 
-      await expect(getEventHash(event)).rejects.toThrow(
-        "Invalid event: missing kind",
-      );
+      await expect(getEventHash(event)).rejects.toThrow("Kind must be a number");
+    });
+
+    it("should throw error for non-number kind", async () => {
+      const event = {
+        pubkey: publicKey,
+        created_at: 1652347275,
+        kind: "1",
+        tags: [],
+        content: "Hello, world!",
+      } as unknown as UnsignedEvent;
+
+      await expect(getEventHash(event)).rejects.toThrow("Kind must be a number");
     });
 
     it("should throw error for invalid tags (not an array)", async () => {
@@ -85,9 +109,7 @@ describe("Event Creation and Signing", () => {
         content: "Hello, world!",
       } as unknown as UnsignedEvent;
 
-      await expect(getEventHash(event)).rejects.toThrow(
-        "Invalid event: tags must be an array",
-      );
+      await expect(getEventHash(event)).rejects.toThrow("Tags must be an array");
     });
 
     it("should throw error for invalid tag item (not an array)", async () => {
@@ -100,7 +122,7 @@ describe("Event Creation and Signing", () => {
       } as unknown as UnsignedEvent;
 
       await expect(getEventHash(event)).rejects.toThrow(
-        "Invalid event: each tag must be an array",
+        "Each tag must be an array",
       );
     });
 
@@ -114,7 +136,7 @@ describe("Event Creation and Signing", () => {
       } as unknown as UnsignedEvent;
 
       await expect(getEventHash(event)).rejects.toThrow(
-        "Invalid event: tag items must be strings",
+        "Tag items must be strings",
       );
     });
 
@@ -128,7 +150,7 @@ describe("Event Creation and Signing", () => {
       } as unknown as UnsignedEvent;
 
       await expect(getEventHash(event)).rejects.toThrow(
-        "Invalid event: content must be a string",
+        "Content must be a string",
       );
     });
 

--- a/tests/nip01/relay/relay.test.ts
+++ b/tests/nip01/relay/relay.test.ts
@@ -1172,6 +1172,28 @@ describe("Relay", () => {
       );
     });
 
+    test("should reject NIP-46 encrypted inbound EVENT messages with invalid signatures", async () => {
+      const onEvent = jest.fn();
+      const errors: unknown[] = [];
+      relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
+      const subscriptionId = relay.subscribe([{ kinds: [24133] }], onEvent);
+      const pubkey = getPublicKey(RELAY_TEST_PRIVATE_KEY);
+      const encryptedEvent = await createSignedRelayEvent({
+        kind: 24133,
+        tags: [["p", pubkey]],
+        content: "encrypted request",
+      });
+      const tamperedEvent: NostrEvent = {
+        ...encryptedEvent,
+        sig: "0".repeat(128),
+      };
+
+      await handleInboundEvent(relay, subscriptionId, tamperedEvent);
+
+      expect(onEvent).not.toHaveBeenCalled();
+      expectRelayError(errors, "Invalid signature");
+    });
+
     test("should accept signed NIP-46 encrypted inbound EVENT messages with p tags", async () => {
       const onEvent = jest.fn();
       const subscriptionId = relay.subscribe([{ kinds: [24133] }], onEvent);

--- a/tests/nip01/relay/relay.test.ts
+++ b/tests/nip01/relay/relay.test.ts
@@ -1112,6 +1112,44 @@ describe("Relay", () => {
       expectRelayError(errors, "too far in the future");
     });
 
+    test("should allow inbound EVENT messages within configured future timestamp drift", async () => {
+      relay = new Relay("wss://example.com", {
+        inboundValidation: {
+          maxFutureTimestampDrift: 3 * 60 * 60,
+        },
+      });
+      const onEvent = jest.fn();
+      const subscriptionId = relay.subscribe([{ kinds: [1] }], onEvent);
+      const event = await createSignedRelayEvent({
+        created_at: Math.floor(Date.now() / 1000) + 7200,
+      });
+
+      await handleInboundEvent(relay, subscriptionId, event);
+
+      expect(onEvent).toHaveBeenCalledTimes(1);
+      expect(onEvent).toHaveBeenCalledWith(event);
+    });
+
+    test("should reject inbound EVENT messages outside configured past timestamp drift", async () => {
+      relay = new Relay("wss://example.com", {
+        inboundValidation: {
+          maxPastTimestampDrift: 60,
+        },
+      });
+      const onEvent = jest.fn();
+      const errors: unknown[] = [];
+      relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
+      const subscriptionId = relay.subscribe([{ kinds: [1] }], onEvent);
+      const event = await createSignedRelayEvent({
+        created_at: Math.floor(Date.now() / 1000) - 120,
+      });
+
+      await handleInboundEvent(relay, subscriptionId, event);
+
+      expect(onEvent).not.toHaveBeenCalled();
+      expectRelayError(errors, "too far in the past");
+    });
+
     test("should reject inbound EVENT messages with out-of-range kinds", async () => {
       const onEvent = jest.fn();
       const errors: unknown[] = [];
@@ -1132,9 +1170,24 @@ describe("Relay", () => {
         expectedMessage: "Invalid NIP-01 'p' tag",
       },
       {
+        description: "mixed-case e tag reference",
+        tags: [["e", "A".repeat(64)]],
+        expectedMessage: "Invalid NIP-01 'e' tag",
+      },
+      {
+        description: "mixed-case p tag reference",
+        tags: [["p", "A".repeat(64)]],
+        expectedMessage: "Invalid NIP-01 'p' tag",
+      },
+      {
         description: "invalid a tag coordinate",
         tags: [["a", "bad-coordinate"]],
         expectedMessage: "Invalid NIP-01 'a' tag",
+      },
+      {
+        description: "mixed-case a tag pubkey coordinate",
+        tags: [["a", `1:${"A".repeat(64)}:identifier`]],
+        expectedMessage: "Invalid NIP-01 'a' tag: pubkey",
       },
     ])(
       "should reject inbound EVENT messages with $description",

--- a/tests/nip01/relay/relay.test.ts
+++ b/tests/nip01/relay/relay.test.ts
@@ -72,8 +72,24 @@ async function handleInboundEvent(
   subscriptionId: string,
   event: unknown,
 ): Promise<void> {
-  asTestRelay(relay).handleMessage(["EVENT", subscriptionId, event]);
-  await testUtils.sleep(20);
+  const relayInternals = asTestRelay(relay);
+  relayInternals.handleMessage(["EVENT", subscriptionId, event]);
+
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    const pendingValidations =
+      relayInternals.pendingValidationCounts.get(subscriptionId) ?? 0;
+
+    if (pendingValidations === 0) {
+      return;
+    }
+
+    await testUtils.sleep(1);
+  }
+
+  throw new Error(
+    `Timed out waiting for inbound EVENT validation for ${subscriptionId}`,
+  );
 }
 
 function expectRelayError(errors: unknown[], message: string): void {

--- a/tests/nip01/relay/relay.test.ts
+++ b/tests/nip01/relay/relay.test.ts
@@ -6,6 +6,10 @@ import {
   PublishResponse,
   NIP20Prefix,
   ParsedOkReason,
+  createEvent,
+  getEventHash,
+  getPublicKey,
+  signEvent,
 } from "../../../src";
 import { NostrRelay } from "../../../src/utils/ephemeral-relay";
 import { testUtils } from "../../types";
@@ -32,6 +36,54 @@ type AnyRelayCallback =
 
 // Ephemeral relay port for tests
 const RELAY_TEST_PORT = 0;
+const RELAY_TEST_PRIVATE_KEY =
+  "1111111111111111111111111111111111111111111111111111111111111111";
+
+async function createSignedRelayEvent(
+  overrides: {
+    kind?: number;
+    tags?: string[][];
+    content?: string;
+    created_at?: number;
+  } = {},
+): Promise<NostrEvent> {
+  const pubkey = getPublicKey(RELAY_TEST_PRIVATE_KEY);
+  const unsigned = createEvent(
+    {
+      kind: overrides.kind ?? 1,
+      tags: overrides.tags ?? [],
+      content: overrides.content ?? "Relay ingress event",
+      created_at: overrides.created_at ?? Math.floor(Date.now() / 1000),
+    },
+    pubkey,
+  );
+  const id = await getEventHash(unsigned);
+  const sig = await signEvent(id, RELAY_TEST_PRIVATE_KEY);
+
+  return {
+    ...unsigned,
+    id,
+    sig,
+  };
+}
+
+async function handleInboundEvent(
+  relay: Relay,
+  subscriptionId: string,
+  event: unknown,
+): Promise<void> {
+  asTestRelay(relay).handleMessage(["EVENT", subscriptionId, event]);
+  await testUtils.sleep(20);
+}
+
+function expectRelayError(errors: unknown[], message: string): void {
+  const errorMessages = errors.map((error) =>
+    error instanceof Error ? error.message : String(error),
+  );
+  expect(errorMessages).toEqual(
+    expect.arrayContaining([expect.stringContaining(message)]),
+  );
+}
 
 describe("Relay", () => {
   // Setup ephemeral relay for integration tests
@@ -982,302 +1034,167 @@ describe("Relay", () => {
       relay = new Relay("wss://example.com");
     });
 
-    test("should validate properly formed events", () => {
-      // Create a valid event
-      const validEvent: NostrEvent = {
-        id: "a".repeat(64),
-        pubkey: "b".repeat(64),
-        created_at: Math.floor(Date.now() / 1000),
-        kind: 1,
-        tags: [],
-        content: "Valid event",
-        sig: "d".repeat(128),
-      };
-
-      // Test basic validation
-      const internalRelay = asTestRelay(relay);
-      const basicResult = internalRelay.performBasicValidation(validEvent);
-      expect(basicResult).toBe(true);
-
-      // Test backward compatibility through validateEvent
-      const result = internalRelay.validateEvent(validEvent);
-      expect(result).toBe(true);
-    });
-
-    test("should reject events with future timestamps", () => {
-      // Create an event with a future timestamp
-      const futureEvent: NostrEvent = {
-        id: "a".repeat(64),
-        pubkey: "b".repeat(64),
-        created_at: Math.floor(Date.now() / 1000) + 7200, // 2 hours in the future
-        kind: 1,
-        tags: [],
-        content: "Future event",
-        sig: "d".repeat(128),
-      };
-
-      // Event should be rejected by basic validation
-      const internalRelay = asTestRelay(relay);
-      const basicResult = internalRelay.performBasicValidation(futureEvent);
-      expect(basicResult).toBe(false);
-
-      // And by the compatibility method
-      const result = internalRelay.validateEvent(futureEvent);
-      expect(result).toBe(false);
-    });
-
-    test("should reject events with invalid structure", () => {
-      // Test various invalid structures
-      const internalRelay = asTestRelay(relay);
-
-      // Missing fields
-      const missingFields = {
-        id: "a".repeat(64),
-        // missing pubkey field
-        created_at: Math.floor(Date.now() / 1000),
-        kind: 1,
-        tags: [],
-        content: "Missing pubkey",
-        sig: "d".repeat(128),
-      };
-      expect(
-        internalRelay.performBasicValidation(
-          missingFields as unknown as NostrEvent,
-        ),
-      ).toBe(false);
-      expect(
-        internalRelay.validateEvent(missingFields as unknown as NostrEvent),
-      ).toBe(false);
-
-      // Invalid id length
-      const invalidId = {
-        id: "a".repeat(63), // Too short
-        pubkey: "b".repeat(64),
-        created_at: Math.floor(Date.now() / 1000),
-        kind: 1,
-        tags: [],
-        content: "Invalid ID",
-        sig: "d".repeat(128),
-      };
-      expect(
-        internalRelay.performBasicValidation(
-          invalidId as unknown as NostrEvent,
-        ),
-      ).toBe(false);
-      expect(
-        internalRelay.validateEvent(invalidId as unknown as NostrEvent),
-      ).toBe(false);
-
-      // Invalid kind (outside range)
-      const invalidKind = {
-        id: "a".repeat(64),
-        pubkey: "b".repeat(64),
-        created_at: Math.floor(Date.now() / 1000),
-        kind: 70000, // Outside valid range
-        tags: [],
-        content: "Invalid kind",
-        sig: "d".repeat(128),
-      };
-      expect(
-        internalRelay.performBasicValidation(
-          invalidKind as unknown as NostrEvent,
-        ),
-      ).toBe(false);
-      expect(
-        internalRelay.validateEvent(invalidKind as unknown as NostrEvent),
-      ).toBe(false);
-
-      // Invalid tag structure
-      const invalidTags = {
-        id: "a".repeat(64),
-        pubkey: "b".repeat(64),
-        created_at: Math.floor(Date.now() / 1000),
-        kind: 1,
-        tags: [["p", 123]], // Tag value is not a string
-        content: "Invalid tags",
-        sig: "d".repeat(128),
-      };
-      expect(
-        internalRelay.performBasicValidation(
-          invalidTags as unknown as NostrEvent,
-        ),
-      ).toBe(false);
-      expect(
-        internalRelay.validateEvent(invalidTags as unknown as NostrEvent),
-      ).toBe(false);
-    });
-
-    test("should properly handle async validation workflow", async () => {
-      // Create a valid event for structure validation
-      const event: NostrEvent = {
-        id: "a".repeat(64),
-        pubkey: "b".repeat(64),
-        created_at: Math.floor(Date.now() / 1000),
-        kind: 1,
-        tags: [],
-        content: "Test event",
-        sig: "d".repeat(128),
-      };
-
-      const internalRelay = asTestRelay(relay);
-
-      // Mock processValidatedEvent to track if it gets called
-      let eventProcessed = false;
-      const originalProcessValidatedEvent = internalRelay.processValidatedEvent;
-      internalRelay.processValidatedEvent = jest.fn((event, subId) => {
-        eventProcessed = true;
-        return originalProcessValidatedEvent.call(internalRelay, event, subId);
-      });
-
-      // Mock error tracking
-      let errorTriggered = false;
-      relay.on(RelayEvent.Error, () => {
-        errorTriggered = true;
-      });
-
-      // Test 1: Simulate failed async validation
-      internalRelay.validateEventAsync = jest.fn().mockResolvedValue(false);
-
-      // Trigger the validation via handleMessage
-      internalRelay.handleMessage(["EVENT", "test-sub", event]);
-
-      // Wait for promises to resolve
-      await testUtils.sleep(10);
-
-      // The event should not have been processed
-      expect(internalRelay.validateEventAsync).toHaveBeenCalledWith(event);
-      expect(errorTriggered).toBe(true);
-      expect(eventProcessed).toBe(false);
-
-      // Reset mocks for next test
-      errorTriggered = false;
-      eventProcessed = false;
-      jest.clearAllMocks();
-
-      // Test 2: Simulate successful async validation
-      internalRelay.validateEventAsync = jest.fn().mockResolvedValue(true);
-
-      // Trigger the validation via handleMessage
-      internalRelay.handleMessage(["EVENT", "test-sub", event]);
-
-      // Wait for promises to resolve
-      await testUtils.sleep(10);
-
-      // The event should have been processed
-      expect(internalRelay.validateEventAsync).toHaveBeenCalledWith(event);
-      expect(errorTriggered).toBe(false);
-      expect(eventProcessed).toBe(true);
-
-      // Restore original implementation
-      internalRelay.processValidatedEvent = originalProcessValidatedEvent;
-    });
-
-    test("should properly verify event through full validation flow", async () => {
-      // Mock subscriptions and handlers
-      const subscriptionId = "test-sub";
+    test("should deliver valid signed inbound EVENT messages", async () => {
       const onEvent = jest.fn();
-      const testRelay = asTestRelay(relay);
-      testRelay.subscriptions.set(subscriptionId, {
-        id: subscriptionId,
-        filters: [],
-        onEvent,
-      });
-      testRelay.eventBuffers.set(subscriptionId, []);
+      const subscriptionId = relay.subscribe([{ kinds: [1] }], onEvent);
+      const event = await createSignedRelayEvent();
 
-      // Create a valid event
-      const validEvent: NostrEvent = {
-        id: "a".repeat(64),
-        pubkey: "b".repeat(64),
-        created_at: Math.floor(Date.now() / 1000),
-        kind: 1,
-        tags: [],
-        content: "Valid event",
-        sig: "d".repeat(128),
-      };
+      await handleInboundEvent(relay, subscriptionId, event);
 
-      // Override the async validation to always return true for testing
-      testRelay.validateEventAsync = jest.fn().mockResolvedValue(true);
-
-      // Also override processValidatedEvent to track calls
-      const originalProcessValidatedEvent = testRelay.processValidatedEvent;
-      const processValidatedEventMock = jest.fn((event, subId) => {
-        return originalProcessValidatedEvent.call(relay, event, subId);
-      });
-      testRelay.processValidatedEvent = processValidatedEventMock;
-
-      // Process the valid event through handleMessage
-      testRelay.handleMessage(["EVENT", subscriptionId, validEvent]);
-
-      // Verify validateEventAsync was called
-      expect(testRelay.validateEventAsync).toHaveBeenCalledWith(validEvent);
-
-      // Wait for promises to resolve
-      await testUtils.sleep(10);
-
-      // Verify the event was processed
-      expect(processValidatedEventMock).toHaveBeenCalledWith(
-        validEvent,
-        subscriptionId,
-      );
-
-      // Restore original implementation
-      testRelay.processValidatedEvent = originalProcessValidatedEvent;
+      expect(onEvent).toHaveBeenCalledTimes(1);
+      expect(onEvent).toHaveBeenCalledWith(event);
     });
 
-    test("should properly validate event ID and signature", async () => {
-      // Create a test event
-      const event: NostrEvent = {
-        id: "test-id-verification",
-        pubkey: "test-pubkey",
+    test("should reject malformed inbound EVENT messages", async () => {
+      const onEvent = jest.fn();
+      const errors: unknown[] = [];
+      relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
+      const subscriptionId = relay.subscribe([{ kinds: [1] }], onEvent);
+      const event = {
+        id: "a".repeat(64),
         created_at: Math.floor(Date.now() / 1000),
         kind: 1,
         tags: [],
-        content: "Test content",
-        sig: "test-signature",
+        content: "missing pubkey",
+        sig: "b".repeat(128),
       };
 
-      // Instead of trying to mock dynamic imports which is complex in Jest,
-      // create a custom implementation of validateEventAsync for testing
-      const validateEventAsyncTest = async (
-        event: NostrEvent,
-      ): Promise<boolean> => {
-        try {
-          // Extract the data for ID verification
-          const _eventData = {
-            pubkey: event.pubkey,
-            created_at: event.created_at,
-            kind: event.kind,
-            tags: event.tags,
-            content: event.content,
-          };
+      await handleInboundEvent(relay, subscriptionId, event);
 
-          // For positive test case, return true
-          if (event.id === "test-id-verification") {
-            return true;
-          }
+      expect(onEvent).not.toHaveBeenCalled();
+      expectRelayError(errors, "Invalid or missing pubkey");
+    });
 
-          // For negative test case, return false
-          return false;
-        } catch (error) {
-          return false;
-        }
+    test("should reject inbound EVENT messages with invalid ids", async () => {
+      const onEvent = jest.fn();
+      const errors: unknown[] = [];
+      relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
+      const subscriptionId = relay.subscribe([{ kinds: [1] }], onEvent);
+      const event = {
+        ...(await createSignedRelayEvent()),
+        id: "0".repeat(64),
       };
 
-      // Replace the method in the relay instance
-      const testRelay = asTestRelay(relay);
-      testRelay.validateEventAsync = validateEventAsyncTest;
+      await handleInboundEvent(relay, subscriptionId, event);
 
-      // Test with valid ID
-      const result = await testRelay.validateEventAsync(event);
-      expect(result).toBe(true);
+      expect(onEvent).not.toHaveBeenCalled();
+      expectRelayError(errors, "Event ID does not match content hash");
+    });
 
-      // Test with invalid ID
-      const invalidEvent = {
-        ...event,
-        id: "invalid-id",
+    test("should reject inbound EVENT messages with invalid signatures", async () => {
+      const onEvent = jest.fn();
+      const errors: unknown[] = [];
+      relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
+      const subscriptionId = relay.subscribe([{ kinds: [1] }], onEvent);
+      const event = {
+        ...(await createSignedRelayEvent()),
+        sig: "0".repeat(128),
       };
-      const invalidResult = await testRelay.validateEventAsync(invalidEvent);
-      expect(invalidResult).toBe(false);
+
+      await handleInboundEvent(relay, subscriptionId, event);
+
+      expect(onEvent).not.toHaveBeenCalled();
+      expectRelayError(errors, "Invalid signature");
+    });
+
+    test("should reject inbound EVENT messages with future timestamps", async () => {
+      const onEvent = jest.fn();
+      const errors: unknown[] = [];
+      relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
+      const subscriptionId = relay.subscribe([{ kinds: [1] }], onEvent);
+      const event = await createSignedRelayEvent({
+        created_at: Math.floor(Date.now() / 1000) + 7200,
+      });
+
+      await handleInboundEvent(relay, subscriptionId, event);
+
+      expect(onEvent).not.toHaveBeenCalled();
+      expectRelayError(errors, "too far in the future");
+    });
+
+    test("should reject inbound EVENT messages with out-of-range kinds", async () => {
+      const onEvent = jest.fn();
+      const errors: unknown[] = [];
+      relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
+      const subscriptionId = relay.subscribe([{}], onEvent);
+      const event = await createSignedRelayEvent({ kind: 70000 });
+
+      await handleInboundEvent(relay, subscriptionId, event);
+
+      expect(onEvent).not.toHaveBeenCalled();
+      expectRelayError(errors, "Kind must be an integer between 0 and 65535");
+    });
+
+    test.each([
+      {
+        description: "invalid p tag reference",
+        tags: [["p", "z".repeat(64)]],
+        expectedMessage: "Invalid NIP-01 'p' tag",
+      },
+      {
+        description: "invalid a tag coordinate",
+        tags: [["a", "bad-coordinate"]],
+        expectedMessage: "Invalid NIP-01 'a' tag",
+      },
+    ])(
+      "should reject inbound EVENT messages with $description",
+      async ({ tags, expectedMessage }) => {
+        const onEvent = jest.fn();
+        const errors: unknown[] = [];
+        relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
+        const subscriptionId = relay.subscribe([{}], onEvent);
+        const event = await createSignedRelayEvent({ tags });
+
+        await handleInboundEvent(relay, subscriptionId, event);
+
+        expect(onEvent).not.toHaveBeenCalled();
+        expectRelayError(errors, expectedMessage);
+      },
+    );
+
+    test("should reject NIP-46 encrypted inbound EVENT messages without p tags", async () => {
+      const onEvent = jest.fn();
+      const errors: unknown[] = [];
+      relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
+      const subscriptionId = relay.subscribe([{ kinds: [24133] }], onEvent);
+      const pubkey = getPublicKey(RELAY_TEST_PRIVATE_KEY);
+      const encryptedEvent: NostrEvent = {
+        id: "a".repeat(64),
+        pubkey,
+        created_at: Math.floor(Date.now() / 1000),
+        kind: 24133,
+        tags: [],
+        content: "encrypted request",
+        sig: "b".repeat(128),
+      };
+
+      await handleInboundEvent(relay, subscriptionId, encryptedEvent);
+
+      expect(onEvent).not.toHaveBeenCalled();
+      expectRelayError(
+        errors,
+        "NIP-46 Relay ingress events must include at least one p tag",
+      );
+    });
+
+    test("should keep NIP-46 encrypted inbound EVENT validation explicit", async () => {
+      const onEvent = jest.fn();
+      const subscriptionId = relay.subscribe([{ kinds: [24133] }], onEvent);
+      const pubkey = getPublicKey(RELAY_TEST_PRIVATE_KEY);
+      const encryptedEvent: NostrEvent = {
+        id: "a".repeat(64),
+        pubkey,
+        created_at: Math.floor(Date.now() / 1000),
+        kind: 24133,
+        tags: [["p", pubkey]],
+        content: "encrypted request",
+        sig: "b".repeat(128),
+      };
+
+      await handleInboundEvent(relay, subscriptionId, encryptedEvent);
+
+      expect(onEvent).toHaveBeenCalledTimes(1);
+      expect(onEvent).toHaveBeenCalledWith(encryptedEvent);
     });
   });
 
@@ -1456,55 +1373,32 @@ describe("Relay", () => {
       expect(events.some((e) => e.id === differentPubkeyEvent.id)).toBe(true);
     });
 
-    test("should properly handle addressable events through handleMessage", () => {
+    test("should properly handle addressable events through handleMessage", async () => {
       // Create a subscription to receive events
-      const subscriptionId = "test-sub-id";
       const onEvent = jest.fn();
-      relay.subscribe([{}], onEvent);
-
-      // Manually set up the buffer for the subscription
+      const subscriptionId = relay.subscribe([{}], onEvent);
       const testRelay = asTestRelay(relay);
-      testRelay.eventBuffers.set(subscriptionId, []);
 
       // Create a valid addressable event
-      const addressableEvent: NostrEvent = {
-        id: "h0635d6a9851d3aed0bc1c4f0c0924235bff013e037bf21eee532da2bba4f403",
-        pubkey: testEvent.pubkey,
-        created_at: Math.floor(Date.now() / 1000),
+      const addressableEvent = await createSignedRelayEvent({
         kind: 30001,
         tags: [["d", "test-identifier"]],
         content: "Addressable event through handleMessage",
-        sig: "d".repeat(128),
-      };
-
-      // Override both validation methods to make the test pass
-      // 1. Override the basic validation to return true
-      testRelay.performBasicValidation = jest.fn().mockReturnValue(true);
-
-      // 2. Override the async validation to always return true for testing
-      testRelay.validateEventAsync = jest.fn().mockResolvedValue(true);
+      });
 
       // Process the event through handleMessage
       testRelay.handleMessage(["EVENT", subscriptionId, addressableEvent]);
 
-      // Wait for async validation promise to resolve
-      return new Promise<void>((resolve) => {
-        setTimeout(() => {
-          // Manually flush the event buffer
-          testRelay.flushSubscriptionBuffer(subscriptionId);
+      await testUtils.sleep(20);
 
-          // Verify the event was processed as an addressable event
-          const storedEvent = relay.getLatestAddressableEvent(
-            30001,
-            testEvent.pubkey,
-            "test-identifier",
-          );
-          expect(storedEvent).toBeDefined();
-          expect(storedEvent?.id).toBe(addressableEvent.id);
-
-          resolve();
-        }, 10); // Small timeout to ensure promises resolve
-      });
+      const storedEvent = relay.getLatestAddressableEvent(
+        30001,
+        addressableEvent.pubkey,
+        "test-identifier",
+      );
+      expect(storedEvent).toBeDefined();
+      expect(storedEvent?.id).toBe(addressableEvent.id);
+      expect(onEvent).toHaveBeenCalledWith(addressableEvent);
     });
   });
 

--- a/tests/nip01/relay/relay.test.ts
+++ b/tests/nip01/relay/relay.test.ts
@@ -1157,16 +1157,11 @@ describe("Relay", () => {
       const errors: unknown[] = [];
       relay.on(RelayEvent.Error, (_url, error) => errors.push(error));
       const subscriptionId = relay.subscribe([{ kinds: [24133] }], onEvent);
-      const pubkey = getPublicKey(RELAY_TEST_PRIVATE_KEY);
-      const encryptedEvent: NostrEvent = {
-        id: "a".repeat(64),
-        pubkey,
-        created_at: Math.floor(Date.now() / 1000),
+      const encryptedEvent = await createSignedRelayEvent({
         kind: 24133,
         tags: [],
         content: "encrypted request",
-        sig: "b".repeat(128),
-      };
+      });
 
       await handleInboundEvent(relay, subscriptionId, encryptedEvent);
 
@@ -1177,19 +1172,15 @@ describe("Relay", () => {
       );
     });
 
-    test("should keep NIP-46 encrypted inbound EVENT validation explicit", async () => {
+    test("should accept signed NIP-46 encrypted inbound EVENT messages with p tags", async () => {
       const onEvent = jest.fn();
       const subscriptionId = relay.subscribe([{ kinds: [24133] }], onEvent);
       const pubkey = getPublicKey(RELAY_TEST_PRIVATE_KEY);
-      const encryptedEvent: NostrEvent = {
-        id: "a".repeat(64),
-        pubkey,
-        created_at: Math.floor(Date.now() / 1000),
+      const encryptedEvent = await createSignedRelayEvent({
         kind: 24133,
         tags: [["p", pubkey]],
         content: "encrypted request",
-        sig: "b".repeat(128),
-      };
+      });
 
       await handleInboundEvent(relay, subscriptionId, encryptedEvent);
 

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -104,7 +104,6 @@ export interface RelayTestAccess {
   processReplaceableEvent(event: NostrEvent): void;
   processAddressableEvent(event: NostrEvent): void;
   flushSubscriptionBuffer(subscriptionId: string): void;
-  validateInboundEvent(event: unknown): Promise<NostrEvent>;
 }
 
 /**

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -8,6 +8,7 @@ import {
   RelayEventCallbacks,
   Subscription,
 } from "../../src";
+import type { RelayConnectionOptions } from "../../src/types/protocol";
 import { NostrRelay } from "../../src/utils/ephemeral-relay";
 import { normalizeRelayUrl as normalizeRelayUrlUtil } from "../../src/utils/relayUrl";
 
@@ -50,10 +51,7 @@ export interface NostrInternals {
   privateKey: string;
   publicKey: string;
   relays: Map<string, Relay | MockRelay>;
-  relayOptions?: {
-    connectionTimeout?: number;
-    bufferFlushDelay?: number;
-  };
+  relayOptions?: RelayConnectionOptions;
 }
 
 /**

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -94,6 +94,7 @@ export interface RelayTestAccess {
   // Private internal state
   subscriptions: Map<string, Subscription>;
   eventBuffers: Map<string, NostrEvent[]>;
+  pendingValidationCounts: Map<string, number>;
   status: string;
 
   // Private internal methods

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -104,9 +104,7 @@ export interface RelayTestAccess {
   processReplaceableEvent(event: NostrEvent): void;
   processAddressableEvent(event: NostrEvent): void;
   flushSubscriptionBuffer(subscriptionId: string): void;
-  performBasicValidation(event: NostrEvent): boolean;
-  validateEvent(event: NostrEvent): boolean;
-  validateEventAsync(event: NostrEvent): Promise<boolean>;
+  validateInboundEvent(event: unknown): Promise<NostrEvent>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Centralize Nostr event validation and route relay ingress through the shared validation seam
- Enforce lowercase relay tag identifiers consistently for event validation and relay ingress
- Add configurable inbound timestamp drift validation through relay connection options
- Update agent issue-tracker docs for machine-readable GitHub issue reads and heredoc issue creation
- Prepare `snstr` v0.3.4 release metadata, changelog, and release notes

## Release Prep
- Version: `0.3.4`
- Latest published npm version checked: `0.3.3`
- Release notes: `RELEASE_NOTES_0.3.4.md`
- Tag intentionally not created yet; create `v0.3.4` after PR merge if you want the tag to point at the final `main` release commit

## Validation
- `npm run release:prepare`
- `npm run build:examples`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added agent skills guidance (issue-tracker workflows, triage labels, and domain-document usage) plus NIP-01/relay validation ADR and detailed run/session/review notes.
  * Updated changelog and added release notes for **v0.3.4 (2026-07-06)**.
* **New Features**
  * Centralized NIP-01 and relay ingress validation with configurable inbound timestamp drift limits.
* **Bug Fixes**
  * Hardened relay event acceptance (stricter signed-event requirements, relay tag-reference rules, lowercase `p` for NIP-46) and earlier rejection of non-finite `created_at`; improved async validation settling.
* **Examples**
  * Updated examples to use the standard relay ingress validation API.
* **Tests**
  * Expanded end-to-end relay inbound validation coverage and updated validation/error expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
