### PR TITLE
chore: prepare v0.4.0 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Browser and React Native package entries now expose the platform-safe NIP-65 relay-list and NIP-66 relay-discovery APIs.
+- Package verification now enforces conditional-export resolution, runtime/type parity, and the transitive browser dependency graph.
+
+### Changed
+- NIP-47 client and service diagnostics now use configurable injected loggers, remain quiet at routine levels by default, and redact sensitive event data.
+- CommonJS and ESM production builds now compile library source independently from tests and examples.
+- Coverage, supported-NIP documentation, targeted test scripts, and package dependencies now match the implementation surface shipped by the repository.
+- The shared logger now lives in core utilities while the existing NIP-46 import path remains a runtime-compatible re-export.
+
+### Fixed
+- NIP-47 initialization now handles concurrent, malformed, failed, disconnected, and stale capability-discovery attempts atomically.
+- Relay teardown now invalidates stale reconnect callbacks without discarding replacement timers.
+
+### Security
+- Updated `ws` to `^8.21.0` to incorporate fixes for memory-disclosure and fragmented-frame denial-of-service advisories.
+
 ## [0.3.4] - 2026-07-06
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,15 +91,14 @@ The CI pipeline runs tests for both `main` and `staging` branches, but releases 
 
 ## Release Process
 
-SNSTR uses GitHub Actions for automated releases. For detailed release instructions, see [RELEASE.md](RELEASE.md).
+SNSTR releases are currently performed manually from `main` after verified
+changes are promoted from `staging`.
 
 ### Quick Release Guide
 
-1. Ensure you're on the main branch with all changes merged
-2. Update [CHANGELOG.md](CHANGELOG.md) with release notes
-3. Go to [Actions](https://github.com/AustinKelsay/snstr/actions) → "Release to NPM"
-4. Run workflow with appropriate version bump (patch/minor/major)
+1. Ensure the release candidate is merged to `main` and CI is green.
+2. Update [CHANGELOG.md](CHANGELOG.md) with release notes.
+3. Run `npm run release:prepare` and `npm publish --dry-run` from a clean checkout.
+4. Follow the versioning, tag, publish, and GitHub release commands in [RELEASE.md](RELEASE.md).
 
-The workflow will automatically handle versioning, tagging, npm publishing, and GitHub release creation.
-
-For the complete release process, requirements, and troubleshooting, refer to [RELEASE.md](RELEASE.md). 
+For the complete release process, requirements, and troubleshooting, refer to [RELEASE.md](RELEASE.md).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,33 +4,24 @@ This document describes how to release new versions of SNSTR.
 
 ## Quick Start
 
-### Option 1: GitHub Actions (Recommended)
-
-1. Go to [Actions](https://github.com/AustinKelsay/snstr/actions) → "Release to NPM"
-2. Click "Run workflow"
-3. Select version type:
-   - **patch**: Bug fixes (0.1.0 → 0.1.1)
-   - **minor**: New features (0.1.0 → 0.2.0)
-   - **major**: Breaking changes (0.1.0 → 1.0.0)
-4. Click "Run workflow"
-
-The workflow will automatically:
-- ✅ Run tests and linting
-- ✅ Bump version in package.json
-- ✅ Create git tag
-- ✅ Publish to npm
-- ✅ Create GitHub release
-
-### Option 2: Manual Tag
+Releases are currently performed manually from `main`; the repository does not
+have an npm publishing workflow. Promote the verified `staging` branch first,
+then run the release from a clean, up-to-date `main` checkout.
 
 ```bash
-# 1. Update version in package.json
-npm version patch  # or minor/major
-
-# 2. Push changes and tag
-git push origin main
-git push origin --tags
+git checkout main
+git pull --ff-only origin main
+npm ci
+npm run release:prepare
+npm publish --dry-run
+npm version minor # or patch/major
+git push origin main --follow-tags
+npm publish --access public
+gh release create "v$(node -p 'require("./package.json").version')" --generate-notes
 ```
+
+The cleanup release is backward-compatible and adds browser/React Native
+exports, so its expected version bump is **minor** (`0.3.4` → `0.4.0`).
 
 ## Pre-release Checklist
 
@@ -44,14 +35,13 @@ Before releasing:
 
 ## Dry Run
 
-To test the release process without publishing:
-
-1. Run workflow with "Dry run" checked
-2. Review the output to ensure everything looks correct
+Run `npm publish --dry-run` from the clean release candidate and inspect the
+package contents before creating the version commit and tag.
 
 ## Requirements
 
-- **NPM_TOKEN**: Must be set in repository secrets for npm publishing
+- **npm authentication**: The releasing maintainer must be logged in with
+  publish access to the `snstr` package.
 - **Branch**: Releases can only be made from the main branch
 - **Node**: The release uses Node.js 20.x
 
@@ -63,18 +53,17 @@ To test the release process without publishing:
 
 ## After Release
 
-The workflow will provide links to:
-- 📦 [npm package](https://www.npmjs.com/package/snstr)
-- 🏷️ GitHub release page
-- 📊 Bundle size info
+- Verify the published version on [npm](https://www.npmjs.com/package/snstr).
+- Verify the tag and GitHub release point to the same commit on `main`.
+- Install the published package in a clean consumer project and exercise both
+  Node and browser conditional exports.
 
 ## Troubleshooting
 
 If the release fails:
 
-1. Check the [Actions log](https://github.com/AustinKelsay/snstr/actions) for errors
-2. Ensure NPM_TOKEN is correctly set in repository secrets
-3. Verify you're on the main branch
-4. Make sure all tests pass locally
-
-For manual releases, ensure you have npm publish permissions for the snstr package.
+1. Verify `npm whoami` and package publish permissions.
+2. Verify you're on the main branch and the working tree is clean.
+3. Re-run `npm run release:prepare` and `npm publish --dry-run`.
+4. If a tag was pushed but publishing failed, fix the publishing issue without
+   reusing or moving an already published version tag.

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "crypto-js": "^4.2.0",
         "light-bolt11-decoder": "^3.2.0",
         "websocket-polyfill": "^0.0.3",
-        "ws": "^8.15.1",
+        "ws": "^8.21.0",
       },
       "devDependencies": {
         "@types/crypto-js": "^4.2.2",
@@ -778,7 +778,7 @@
 
     "write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
 
-    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" } }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "crypto-js": "^4.2.0",
         "light-bolt11-decoder": "^3.2.0",
         "websocket-polyfill": "^0.0.3",
-        "ws": "^8.15.1"
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/crypto-js": "^4.2.2",
@@ -5620,9 +5620,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -249,6 +249,6 @@
     "crypto-js": "^4.2.0",
     "light-bolt11-decoder": "^3.2.0",
     "websocket-polyfill": "^0.0.3",
-    "ws": "^8.15.1"
+    "ws": "^8.21.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^0.0.3
     version: 0.0.3
   ws:
-    specifier: ^8.15.1
-    version: 8.18.3
+    specifier: ^8.21.0
+    version: 8.21.0
 
 devDependencies:
   '@types/crypto-js':
@@ -3246,8 +3246,8 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  /ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1

--- a/scripts/verify-pack.js
+++ b/scripts/verify-pack.js
@@ -170,7 +170,9 @@ function verifyWebEntryGraph(entryTarget) {
     "nip46/simple-bunker.js",
     "nip46/simple-client.js",
     "nip46/utils/auth.js",
-    "nip47/",
+    "nip47/client.js",
+    "nip47/service.js",
+    "nip47/index.js",
   ];
   // These exact Node crypto fallbacks are runtime-guarded and preserve Node 16
   // and pure-ESM compatibility. Any new file, form, or dependency must be

--- a/src/NIP_STANDARDIZATION.md
+++ b/src/NIP_STANDARDIZATION.md
@@ -443,13 +443,18 @@ When implementing a NIP, ensure:
 - ✅ **NIP-17**: Gift Wrapped Direct Messages
 - ✅ **NIP-19**: Bech32-encoded Entities
 - ✅ **NIP-21**: URI Scheme
+- ✅ **NIP-29**: Relay-based Groups
+- ✅ **NIP-42**: Authentication of Clients to Relays
 - ✅ **NIP-44**: Versioned Encryption
 - ✅ **NIP-46**: Remote Signing
 - ✅ **NIP-47**: Nostr Wallet Connect
 - ✅ **NIP-50**: Search Capability
+- ✅ **NIP-56**: Reporting
 - ✅ **NIP-57**: Lightning Zaps
 - ✅ **NIP-65**: Relay List Metadata
 - ✅ **NIP-66**: Relay Discovery
+- ✅ **NIP-70**: Protected Events
+- ✅ **NIP-86**: Relay Management API
 
 ## Migration Plan
 

--- a/src/entries/index.web.ts
+++ b/src/entries/index.web.ts
@@ -292,8 +292,8 @@ export type {
 // Export NIP-07 adapter
 export { Nip07Nostr } from "../nip07/adapter";
 
-// NIP-46 utilities are Node-oriented; omit from RN/web entry to reduce bundle size
-// Consumers can import platform-appropriate implementations directly if needed.
+// NIP-46 implementations are Node-oriented; expose only platform-safe protocol enums.
+export { NIP46Method } from "../nip46/types";
 
 // NIP-57: Lightning Zaps
 export {
@@ -334,7 +334,15 @@ export {
   parseBolt11Invoice,
 } from "../nip57/utils";
 
-// NIP-47 is Node-leaning and may pull NIP-04; omit from RN/web entry.
+// NIP-47 wallet implementations are Node-leaning; expose platform-safe protocol enums.
+export {
+  NIP47Method,
+  NIP47EventKind,
+  NIP47NotificationType,
+  NIP47ErrorCode,
+  TransactionType,
+  NIP47EncryptionScheme,
+} from "../nip47/types";
 
 // NIP-50 search utilities
 export { createSearchFilter } from "../nip50";

--- a/src/nip47/client.ts
+++ b/src/nip47/client.ts
@@ -286,7 +286,7 @@ export class NostrWalletConnectClient {
       // Connect to relays
       await this.client.connectToRelays();
       this.assertInitializationCurrent(generation);
-      this.logger.info(`Client connected to relays: ${this.relays.join(", ")}`);
+      this.logger.info("Client connected to configured relays");
 
       // Set up subscription to receive responses
       attemptSubIds = this.setupSubscription();
@@ -470,15 +470,13 @@ export class NostrWalletConnectClient {
 
     const subIds = this.client.subscribe(
       [responseFilter, infoFilter],
-      (event: NostrEvent, relay: string) => {
-        this.logger.debug(
-          `Received event: ${event.id} of kind ${event.kind} from ${relay}`,
-        );
+      (event: NostrEvent, _relay: string) => {
+        this.logger.debug(`Received event of kind ${event.kind}`);
 
         this.handleEvent(event);
       },
     );
-    this.logger.debug(`Subscription IDs: ${subIds.join(", ")}`);
+    this.logger.debug(`Established ${subIds.length} client subscription(s)`);
     return subIds;
   }
 
@@ -487,7 +485,6 @@ export class NostrWalletConnectClient {
    */
   private async handleEvent(event: NostrEvent): Promise<void> {
     this.logger.debug(`Handling event of kind ${event.kind}`);
-    this.logger.debug(`Event id: ${event.id}`);
 
     if (event.kind === NIP47EventKind.RESPONSE) {
       this.logger.debug(
@@ -671,12 +668,12 @@ export class NostrWalletConnectClient {
         `Validated response of type: ${(response as NIP47Response).result_type}`,
       );
 
-      this.logger.debug(`Found request ID from e-tag: ${requestId}`);
+      this.logger.debug("Correlated response with a pending request");
 
       // Resolve the pending request
       pendingRequest.resolve(response as NIP47Response);
       this.pendingRequests.delete(requestId);
-      this.logger.debug(`Request ${requestId} resolved successfully`);
+      this.logger.debug("Pending request resolved successfully");
     } catch (error) {
       if (error instanceof SecurityValidationError) {
         this.logger.warn(

--- a/src/nip47/service.ts
+++ b/src/nip47/service.ts
@@ -239,7 +239,7 @@ export class NostrWalletService {
   public async init(): Promise<void> {
     // Connect to relays
     await this.client.connectToRelays();
-    this.logger.info(`Service connected to relays: ${this.relays.join(", ")}`);
+    this.logger.info("Service connected to configured relays");
 
     // Set up subscription to receive requests
     this.setupSubscription();
@@ -682,7 +682,7 @@ export class NostrWalletService {
     const unsignedEvent = createEvent(eventTemplate, this.pubkey);
 
     this.logger.debug("Encrypting response");
-    this.logger.debug(`Response will reference request ID: ${requestId}`);
+    this.logger.debug("Response will reference the correlated request");
 
     // Get the encryption scheme used in the request
     const encryptionScheme =
@@ -712,7 +712,7 @@ export class NostrWalletService {
     // Sign the event
     const signedEvent = await createSignedEvent(unsignedEvent, this.privkey);
 
-    this.logger.debug(`Sending response for request ${requestId}`);
+    this.logger.debug("Sending response for correlated request");
 
     // Publish the event
     await this.client.publishEvent(signedEvent);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,6 +2,7 @@
  * Simple logger with configurable log levels
  */
 
+/** Supported logger verbosity levels, ordered from silent to most verbose. */
 export enum LogLevel {
   NONE = 0,
   ERROR = 1,
@@ -11,6 +12,7 @@ export enum LogLevel {
   TRACE = 5,
 }
 
+/** Configuration for a {@link Logger} instance. */
 export interface LoggerOptions {
   level?: LogLevel;
   prefix?: string;
@@ -21,6 +23,7 @@ export interface LoggerOptions {
 // Type for log arguments that covers most common use cases
 type LogArg = string | number | boolean | object | null | undefined;
 
+/** Lightweight console-backed logger with level filtering and optional prefixes. */
 export class Logger {
   private level: LogLevel;
   private prefix: string;

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -31,10 +31,7 @@ function resolveDefaultWebSocket(): typeof WebSocket | undefined {
 
   const candidatesWithPriority: (typeof WebSocket | undefined)[] = [];
 
-  if (
-    currentGlobal &&
-    currentGlobal !== OriginalWebSocket
-  ) {
+  if (currentGlobal && currentGlobal !== OriginalWebSocket) {
     candidatesWithPriority.push(currentGlobal);
   }
 
@@ -79,12 +76,23 @@ export function getWebSocketImplementation(): typeof WebSocket {
   return WebSocketImpl;
 }
 
+/**
+ * Register the process-wide factory used to resolve deterministic in-memory sockets.
+ * Registering a new factory replaces the previous one for subsequent lookups.
+ */
 export function useInMemoryWebSocketFactory(
   factory: InMemoryWebSocketFactory,
 ): void {
   inMemoryWebSocketFactory = factory;
 }
 
+/**
+ * Resolve an in-memory socket for the supplied URL when a factory is registered.
+ *
+ * This is an internal transport seam used by deterministic relay tests. It has
+ * no effect until {@link useInMemoryWebSocketFactory} installs a process-wide
+ * factory.
+ */
 export function getInMemoryWebSocket(url: string): unknown | undefined {
   return inMemoryWebSocketFactory?.(url);
 }

--- a/tests/entries/web-exports.test.ts
+++ b/tests/entries/web-exports.test.ts
@@ -83,19 +83,12 @@ describe("platform entry export policy", () => {
 
     expect(webKeys.filter((key) => !nodeKeys.includes(key)).sort()).toEqual([]);
     expect(nodeKeys.filter((key) => !webKeys.includes(key)).sort()).toEqual([
-      "NIP46Method",
-      "NIP47EncryptionScheme",
-      "NIP47ErrorCode",
-      "NIP47EventKind",
-      "NIP47Method",
-      "NIP47NotificationType",
       "NostrRemoteSignerBunker",
       "NostrRemoteSignerClient",
       "NostrWalletConnectClient",
       "NostrWalletService",
       "SimpleNIP46Bunker",
       "SimpleNIP46Client",
-      "TransactionType",
       "generateNWCURL",
       "isValidAuthUrl",
       "parseNWCURL",

--- a/tests/nip47/nip47.test.ts
+++ b/tests/nip47/nip47.test.ts
@@ -628,9 +628,13 @@ describe("NIP-47: Nostr Wallet Connect", () => {
         await diagnosticService.init();
         expect(messages).toEqual(
           expect.arrayContaining([
-            expect.stringContaining("Service connected to relays"),
+            expect.stringContaining("Service connected to configured relays"),
           ]),
         );
+        const diagnostics = messages.join("\n");
+        expect(diagnostics).not.toContain(relay.url);
+        expect(diagnostics).not.toContain(serviceKeys.publicKey);
+        expect(diagnostics).not.toContain(serviceKeys.privateKey);
       } finally {
         await diagnosticService.disconnect();
       }
@@ -652,11 +656,19 @@ describe("NIP-47: Nostr Wallet Connect", () => {
 
       try {
         await diagnosticClient.init();
+        await diagnosticClient.getInfo();
         expect(messages).toEqual(
           expect.arrayContaining([
-            expect.stringContaining("Client connected to relays"),
+            expect.stringContaining("Client connected to configured relays"),
           ]),
         );
+        const diagnostics = messages.join("\n");
+        expect(diagnostics).not.toContain(relay.url);
+        expect(diagnostics).not.toContain(connectionOptions.pubkey);
+        expect(diagnostics).not.toContain(connectionOptions.secret);
+        expect(diagnostics).not.toContain(diagnosticClient.getPublicKey());
+        expect(diagnostics).not.toMatch(/\b[0-9a-f]{64}\b/i);
+        expect(diagnostics).not.toMatch(/event id|request id|subscription ids?/i);
       } finally {
         await diagnosticClient.disconnect();
       }


### PR DESCRIPTION
## Summary

- close final review gaps in browser-safe protocol exports and NIP-47 diagnostic redaction
- raise the production `ws` dependency floor to 8.21.0 and synchronize npm, Bun, and pnpm locks
- document the cleanup release, current manual release flow, and completed NIP inventory
- tighten package verification around the actual Node-only NIP-47 modules

## Review

- standards review: PASS
- spec review: PASS
- pre-v0.3.4 documentation/example gaps remain backlog and are not release blockers

## Validation

- `npm run release:prepare` (lint, 879 Jest tests, CJS/ESM build, pack verification)
- `npm run test:bun` (879 tests)
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)
- `npm publish --dry-run --json`
- frozen installs verified for npm, Bun, and pnpm 8.15.9

Expected release bump after promotion to `main`: `0.3.4` -> `0.4.0`.