### PR TITLE
Fix NIP-44 legacy version handling

### DIFF
--- a/docs/agents/runs/deep-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/deep-cleanup-1-8-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, rebased from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: umbrella spec and tickets published; issue #112 implementation starting
+- Current status: issue #112 implementation and integrated verification complete; local CodeRabbit gate pending
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, single-context domain docs)
 
 ## Goal
@@ -41,7 +41,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 
 | Issue | Type | Status | Branch | Review | Verified |
 | --- | --- | --- | --- | --- | --- |
-| #112 NIP-44 legacy behavior | AFK | in progress | `feature/nip44-legacy-compat` | pending | no |
+| #112 NIP-44 legacy behavior | AFK | local review passed | `feature/nip44-legacy-compat` | standards/spec pass after one fix | yes |
 | #118 authoritative protocol messages | AFK | ready | `feature/protocol-message-types` | pending | no |
 | #113 Relay event-store seam | AFK | blocked by #118 | `feature/relay-event-store` | pending | no |
 | #114 NIP-47 protocol machinery | AFK | blocked by #118 | `feature/nip47-protocol-codecs` | pending | no |
@@ -60,7 +60,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 
 | Issue | Fixed point | Implementation owner | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
-| #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | pending | pending | pending |
+| #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | `ab22d13` + review fix pending | standards/spec pass after one fix | NIP-44 107/107; Jest 991/991; Bun 991/991; lint, types, builds, commands, pack |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/deep-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/deep-cleanup-1-8-ledger.md
@@ -27,7 +27,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 - Agent briefs: Grok 4.5 is the only owner-approved delegated sidecar; `agent` authentication was unavailable at preflight, so no substitute subagent is used and Codex owns local execution/review
 - Review packets: created per ticket
 - Local CodeRabbit report: issue #112 round completed with five worthy fixes in `issue-112-coderabbit-local.md`
-- PR URLs: recorded per ticket after push
+- PR URLs: #120 for issue #112; later tickets pending
 
 ## Commands
 
@@ -60,7 +60,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 
 | Issue | Fixed point | Implementation owner | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
-| #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | `ab22d13` + review fix pending | standards/spec pass after one fix | NIP-44 107/107; Jest 991/991; Bun 991/991; lint, types, builds, commands, pack |
+| #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | `ab22d13`, `fa85df2`, `03e4eb5` | standards/spec pass after one fix; CodeRabbit 5/5 fixed | NIP-44 107/107; Jest 991/991; Bun 991/991; lint, types, builds, commands, pack |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/deep-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/deep-cleanup-1-8-ledger.md
@@ -1,0 +1,80 @@
+# Feature Dev Run Ledger: Deep Cleanup 1–8
+
+## Run
+
+- Run ID: `snstr-deep-cleanup-1-8-20260718`
+- Loop: eight sequential `feature-dev` runs
+- Target repo: `snstr`
+- Base branch: `staging`
+- Feature branches: one branch per approved ticket, rebased from the latest integrated `staging`
+- Human owner: plebdev
+- Started: 2026-07-18
+- Current status: umbrella spec and tickets published; issue #112 implementation starting
+- Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, single-context domain docs)
+
+## Goal
+
+Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, branch by branch, with each healthy slice integrated into `staging`: make NIP-44 legacy behavior explicit, deepen Relay, extract NIP-47 protocol machinery, deepen the Nostr facade, clarify ephemeral Relay ownership, consolidate security validation, centralize NIP-01 message types, and make package-manager policy canonical.
+
+## Durable Artifacts
+
+- CONTEXT updates: none currently required; existing Nostr Event, Relay, Subscription Filter, and NIP terms cover the work
+- ADRs: none currently required; public compatibility is preserved and each internal extraction is independently reversible
+- Prototype source branch, if any: none
+- Spec issue: #111 — Deepen core protocol modules and remove remaining maintenance drift
+- Tickets: #112–#119
+- Ticket sessions: created as each ticket starts
+- Agent briefs: Grok 4.5 is the only owner-approved delegated sidecar; `agent` authentication was unavailable at preflight, so no substitute subagent is used and Codex owns local execution/review
+- Review packets: created per ticket
+- Local CodeRabbit report: created per branch
+- PR URLs: recorded per ticket after push
+
+## Commands
+
+- Install: `npm ci`; compatibility lane `bun install --frozen-lockfile`
+- Typecheck: `npx tsc --noEmit -p tsconfig.json` and `npx tsc --noEmit -p examples/tsconfig.json`
+- Test: targeted Jest/Bun suites per ticket; `npm test -- --runInBand --detectOpenHandles`; `npm run test:bun`
+- Build: `npm run commands:verify && npm run lint && npm run build && npm run build:examples && npm run pack:verify`
+- Visual verification: not applicable
+
+## Ticket Ledger
+
+| Issue | Type | Status | Branch | Review | Verified |
+| --- | --- | --- | --- | --- | --- |
+| #112 NIP-44 legacy behavior | AFK | in progress | `feature/nip44-legacy-compat` | pending | no |
+| #118 authoritative protocol messages | AFK | ready | `feature/protocol-message-types` | pending | no |
+| #113 Relay event-store seam | AFK | blocked by #118 | `feature/relay-event-store` | pending | no |
+| #114 NIP-47 protocol machinery | AFK | blocked by #118 | `feature/nip47-protocol-codecs` | pending | no |
+| #115 Nostr relay registry | AFK | blocked by #113 | `feature/nostr-relay-registry` | pending | no |
+| #116 ephemeral Relay ownership | AFK | blocked by #113 | `feature/ephemeral-relay-ownership` | pending | no |
+| #117 security validation ownership | AFK | blocked by #113 and #115 | `feature/security-validation-ownership` | pending | no |
+| #119 package-manager policy | AFK | ready | `feature/package-manager-policy` | pending | no |
+
+## Parked HITL Slices
+
+| Issue | Why parked | Blocks | Required human action | Final PR decision |
+| --- | --- | --- | --- | --- |
+| None | — | — | — | — |
+
+## Issue Session Ledger
+
+| Issue | Fixed point | Implementation owner | Commit | Review result | Checks |
+| --- | --- | --- | --- | --- | --- |
+| #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | pending | pending | pending |
+
+## Alignment Decisions
+
+- The ranked audit list is the authoritative scope for cleanup items 1–8.
+- The owner's instruction grants approval for the public testing seams, eight-ticket granularity, dependency graph, and agent-performable AFK classification.
+- Each ticket uses a dedicated branch and PR, then integrates into `staging` before dependent work begins; this intentionally runs the Feature Dev loop back to back rather than putting all tickets on one feature branch.
+- Existing public interfaces are preserved unless authoritative NIP-44 evidence proves current legacy behavior incorrect or unsupported.
+- Grok is the exclusive delegated system. If unavailable, the Grok skill requires recording the limitation and local completion; no alternate subagent is substituted.
+- Production deployment and release promotion remain out of scope.
+
+## Open Questions
+
+- None.
+
+## Escalations
+
+- Grok preflight: the `agent` and Node CLIs exist, but `agent models` requires authentication. This does not block local work under the Grok skill fallback.

--- a/docs/agents/runs/deep-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/deep-cleanup-1-8-ledger.md
@@ -26,7 +26,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 - Ticket sessions: created as each ticket starts
 - Agent briefs: Grok 4.5 is the only owner-approved delegated sidecar; `agent` authentication was unavailable at preflight, so no substitute subagent is used and Codex owns local execution/review
 - Review packets: created per ticket
-- Local CodeRabbit report: created per branch
+- Local CodeRabbit report: issue #112 round completed with five worthy fixes in `issue-112-coderabbit-local.md`
 - PR URLs: recorded per ticket after push
 
 ## Commands
@@ -41,7 +41,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 
 | Issue | Type | Status | Branch | Review | Verified |
 | --- | --- | --- | --- | --- | --- |
-| #112 NIP-44 legacy behavior | AFK | local review passed | `feature/nip44-legacy-compat` | standards/spec pass after one fix | yes |
+| #112 NIP-44 legacy behavior | AFK | local CodeRabbit fixes verified | `feature/nip44-legacy-compat` | standards/spec pass; CodeRabbit 5 fixed | yes |
 | #118 authoritative protocol messages | AFK | ready | `feature/protocol-message-types` | pending | no |
 | #113 Relay event-store seam | AFK | blocked by #118 | `feature/relay-event-store` | pending | no |
 | #114 NIP-47 protocol machinery | AFK | blocked by #118 | `feature/nip47-protocol-codecs` | pending | no |

--- a/docs/agents/runs/issue-112-coderabbit-local.md
+++ b/docs/agents/runs/issue-112-coderabbit-local.md
@@ -1,0 +1,33 @@
+# CodeRabbit Round: #112 Local Branch
+
+## Round
+
+- Scope: local
+- Round number: 1
+- Command or trigger: `coderabbit review --agent --type all --base staging`
+- Started: 2026-07-18
+- Completed: 2026-07-18
+- Availability: completed
+- Fallback review thread: none
+
+## Findings To Address
+
+| Finding | Severity | Decision | Notes |
+| --- | --- | --- | --- |
+| v2 nonce/AAD helpers accepted values longer than 32 bytes | minor | fixed | Both helpers now require exact 32-byte values; 31/33-byte regression tests added. |
+| Example README claimed rejection behavior the demo did not execute | minor | fixed | Demo now mutates a valid payload to versions 0, 1, and 3 and calls public decryption. |
+| Compatibility demo did not exercise non-v2 decryption | minor | fixed | Public `decryptNIP44` rejection is demonstrated for reserved, undefined, and unknown versions. |
+| Compliance output omitted unknown versions | minor | fixed | Summary now includes unknown versions. |
+| Basic demo wording omitted unknown versions | major | fixed as wording issue | Existing text already rejected v0/v1; wording now explicitly includes unknown versions. |
+
+## Findings Not Addressed
+
+| Finding | Reason |
+| --- | --- |
+| None | — |
+
+## Result
+
+- Continue: yes
+- Escalate: no
+- Notes: Focused NIP-44 tests 25/25, lint, root typecheck, examples build, and the real version-compatibility example passed after fixes. The pre-review integrated matrix was Jest 991/991 and Bun 991/991.

--- a/docs/agents/runs/issue-112-coderabbit-local.md
+++ b/docs/agents/runs/issue-112-coderabbit-local.md
@@ -31,3 +31,16 @@
 - Continue: yes
 - Escalate: no
 - Notes: Focused NIP-44 tests 25/25, lint, root typecheck, examples build, and the real version-compatibility example passed after fixes. The pre-review integrated matrix was Jest 991/991 and Bun 991/991.
+
+## Hosted PR Round
+
+- Scope: PR #120
+- Trigger: `@coderabbitai review`
+- Completed: 2026-07-18
+- Findings: 3
+
+| Finding | Severity | Decision | Notes |
+| --- | --- | --- | --- |
+| Main demo retained a contradictory v0/v1/v2 decryption claim | minor | fixed | The versioning summary now states the v2-only acceptance contract. |
+| Compatibility demo accepted any thrown error and did not fail on unexpected success | minor | fixed | The runnable example now requires the exact stable rejection message and throws on unrelated behavior. |
+| Example overview omitted unknown versions | minor | fixed | The overview now matches the reserved, undefined, and unknown rejection contract. |

--- a/docs/agents/runs/issue-112-review-packet.md
+++ b/docs/agents/runs/issue-112-review-packet.md
@@ -36,11 +36,11 @@ Check:
 ## Reviewer Output
 
 ```text
-STANDARDS_STATUS: pending
+STANDARDS_STATUS: pass
 STANDARDS_FINDINGS:
-- pending
+- None. The change removes speculative legacy branches and contradictory comments, keeps the public package-root NIP-44 interface stable, and follows repository TypeScript/test conventions.
 
-SPEC_STATUS: pending
+SPEC_STATUS: pass
 SPEC_FINDINGS:
-- pending
+- One partial gap was found and fixed: reserved/undefined version rejection is now asserted through public `decrypt` as well as `decodePayload`.
 ```

--- a/docs/agents/runs/issue-112-review-packet.md
+++ b/docs/agents/runs/issue-112-review-packet.md
@@ -1,0 +1,46 @@
+# Review Packet: #112 NIP-44 Legacy-Version Behavior
+
+## Issue
+
+- Issue: #112
+- Slice type: correctness/security compatibility cleanup
+- Acceptance criteria: authoritative version registry; public version tests; no placeholder compatibility; stable unsupported-version errors; full verification
+- Baseline: `df13432`
+- Current diff: `git diff df13432...HEAD`
+
+## Implementation Summary
+
+SNSTR now accepts the only defined NIP-44 algorithm version, v2, and reports reserved v0, undefined v1, future version bytes, and future non-base64 encodings as unsupported. Official v2 vector decryption can no longer be swallowed by a warning-only test path. Source and examples no longer claim nonexistent v0/v1 compatibility.
+
+## Implementation Evidence
+
+- `implement` session: `docs/agents/runs/issue-112-session.md`
+- `tdd` used: yes
+- Red test: reserved v0 tampering remained accepted at `decodePayload`
+- Green implementation: `decodePayload` requires v2 before extracting cryptographic fields; legacy passthrough decryptors and constants removed
+- Refactor: version dispatch and contradictory placeholder branches removed
+- Commands run: 107 focused NIP-44 tests; 991 Jest tests; 991 Bun tests; lint; command verification; root/examples typecheck; CJS/ESM build; examples build; package verification
+
+## Review Instructions
+
+Review only this issue's slice unless you find a severe cross-slice regression. Keep standards and spec findings separate.
+
+Check:
+
+- Acceptance criteria are met.
+- Tests verify behavior through public interfaces.
+- No implementation-only tests are masquerading as behavior tests.
+- No obvious incomplete work, TODO placeholders, or unrelated changes.
+- Relevant test, typecheck, build, or visual verification commands pass.
+
+## Reviewer Output
+
+```text
+STANDARDS_STATUS: pending
+STANDARDS_FINDINGS:
+- pending
+
+SPEC_STATUS: pending
+SPEC_FINDINGS:
+- pending
+```

--- a/docs/agents/runs/issue-112-session.md
+++ b/docs/agents/runs/issue-112-session.md
@@ -5,8 +5,8 @@
 - Issue: #112 — Make NIP-44 legacy-version behavior explicit and vector-tested
 - Fixed point before session: `df13432`
 - Implementation owner: current Codex orchestrator; Grok unavailable at authentication preflight
-- Commit: pending
-- Status: implementation and integrated verification complete; review pending
+- Commit: `ab22d13` plus review fix pending
+- Status: implementation, integrated verification, and local review complete
 
 ## Inputs
 
@@ -27,10 +27,10 @@
 ## Review
 
 - Review fixed point: `df13432`
-- Standards findings: pending
-- Spec findings: pending
-- Worthy fixes applied: pending
-- Findings ignored with reasons: pending
+- Standards findings: pass; no documented-standard violations or unresolved Fowler smells
+- Spec findings: one partial acceptance-criterion gap: reserved/undefined versions were asserted through `decodePayload`, but not through public `decrypt`
+- Worthy fixes applied: added public `decrypt` rejection assertions for tampered v0/v1 payloads
+- Findings ignored with reasons: none
 
 ## Risks
 

--- a/docs/agents/runs/issue-112-session.md
+++ b/docs/agents/runs/issue-112-session.md
@@ -5,7 +5,7 @@
 - Issue: #112 — Make NIP-44 legacy-version behavior explicit and vector-tested
 - Fixed point before session: `df13432`
 - Implementation owner: current Codex orchestrator; Grok unavailable at authentication preflight
-- Commit: `ab22d13`, `fa85df2`, plus CodeRabbit fix pending
+- Commits: `ab22d13`, `fa85df2`, `03e4eb5`
 - Status: implementation, integrated verification, and local review complete
 
 ## Inputs

--- a/docs/agents/runs/issue-112-session.md
+++ b/docs/agents/runs/issue-112-session.md
@@ -5,7 +5,7 @@
 - Issue: #112 — Make NIP-44 legacy-version behavior explicit and vector-tested
 - Fixed point before session: `df13432`
 - Implementation owner: current Codex orchestrator; Grok unavailable at authentication preflight
-- Commit: `ab22d13` plus review fix pending
+- Commit: `ab22d13`, `fa85df2`, plus CodeRabbit fix pending
 - Status: implementation, integrated verification, and local review complete
 
 ## Inputs
@@ -29,7 +29,7 @@
 - Review fixed point: `df13432`
 - Standards findings: pass; no documented-standard violations or unresolved Fowler smells
 - Spec findings: one partial acceptance-criterion gap: reserved/undefined versions were asserted through `decodePayload`, but not through public `decrypt`
-- Worthy fixes applied: added public `decrypt` rejection assertions for tampered v0/v1 payloads
+- Worthy fixes applied: added public `decrypt` rejection assertions for tampered v0/v1 payloads; exact 32-byte helper nonce enforcement; runnable public rejection demo and aligned documentation
 - Findings ignored with reasons: none
 
 ## Risks

--- a/docs/agents/runs/issue-112-session.md
+++ b/docs/agents/runs/issue-112-session.md
@@ -1,0 +1,37 @@
+# Issue Session: #112 NIP-44 Legacy-Version Behavior
+
+## Issue
+
+- Issue: #112 — Make NIP-44 legacy-version behavior explicit and vector-tested
+- Fixed point before session: `df13432`
+- Implementation owner: current Codex orchestrator; Grok unavailable at authentication preflight
+- Commit: pending
+- Status: implementation and integrated verification complete; review pending
+
+## Inputs
+
+- Spec issue: #111
+- Ticket: #112
+- Relevant glossary terms: Nostr Event, NIP
+- Relevant ADRs: none; ADR 0001 does not own NIP-44 payload decoding
+- Prototype answer and source branch, if any: none
+
+## Implementation
+
+- Public interface used: NIP-44 `encrypt`, `decodePayload`, and `decrypt`
+- Behaviors covered: v2 official vectors decrypt; reserved v0, undefined v1, future versions, and non-base64 future encodings report unsupported versions; v0/v1 encryption remains prohibited with accurate reasons
+- `tdd` used: yes; changed public decode expectations first and observed v0 decoding remain green before implementation
+- Commands run during implementation: focused official-vector and format-validation tests; all NIP-44 tests; root and example typechecks; example build
+- Full suite command: `npm test -- --runInBand --detectOpenHandles` and `npm run test:bun`
+
+## Review
+
+- Review fixed point: `df13432`
+- Standards findings: pending
+- Spec findings: pending
+- Worthy fixes applied: pending
+- Findings ignored with reasons: pending
+
+## Risks
+
+- This intentionally stops accepting payloads whose version byte was changed to reserved/undefined values while otherwise using the v2 layout. The authoritative NIP defines no v0/v1 decryption algorithm and requires unknown versions to be reported as unsupported.

--- a/examples/nip44/README.md
+++ b/examples/nip44/README.md
@@ -38,7 +38,7 @@ The [`nip44-version-compatibility.ts`](./nip44-version-compatibility.ts) example
 
 - Attempting to encrypt with NIP-44 versions 0 and 1 (which correctly results in errors as per NIP-44 spec).
 - Successful encryption with NIP-44 version 2 (the current standard).
-- Rejection of reserved version 0, undefined version 1, and unknown versions.
+- Public decryption rejection for reserved version 0, undefined version 1, and unknown versions.
 - Error handling for unsupported versions for encryption.
 
 ### Test Vector Verification

--- a/examples/nip44/README.md
+++ b/examples/nip44/README.md
@@ -9,7 +9,7 @@ This directory contains examples demonstrating how to use NIP-44 encrypted direc
 **Implementation Details**:
 - Uses ChaCha20 for encryption and HMAC-SHA256 for authentication
 - Includes a version byte to support future algorithm upgrades and backward compatibility
-- Supports decryption of messages encrypted with versions 0, 1, and 2
+- Accepts defined version 2 payloads and rejects reserved or undefined versions
 - Provides proper key derivation using HKDF
 - Implements message length hiding with a custom padding scheme
 - Uses secure 32-byte nonces
@@ -38,7 +38,7 @@ The [`nip44-version-compatibility.ts`](./nip44-version-compatibility.ts) example
 
 - Attempting to encrypt with NIP-44 versions 0 and 1 (which correctly results in errors as per NIP-44 spec).
 - Successful encryption with NIP-44 version 2 (the current standard).
-- Automatic decryption of messages from any supported version (0, 1, and 2).
+- Rejection of reserved version 0, undefined version 1, and unknown versions.
 - Error handling for unsupported versions for encryption.
 
 ### Test Vector Verification
@@ -84,7 +84,7 @@ npm run example:nip44:compliance
 ## Key Concepts
 
 - **Versioned Encryption**: NIP-44 includes a version byte in the payload for future protocol upgrades
-- **Backward Compatibility**: Support for decrypting messages encrypted with older versions (0, 1)
+- **Version Safety**: Reserved, undefined, and unknown versions are rejected before decryption
 - **Authenticated Encryption**: Uses HMAC-SHA256 to prevent message tampering
 - **Message Length Hiding**: Custom padding scheme to conceal the exact length of messages
 - **Proper Key Derivation**: Uses HKDF instead of raw ECDH output for better security
@@ -104,11 +104,11 @@ npm run example:nip44:compliance
 ## API Functions Used
 
 - `encrypt()`: Encrypt a message using NIP-44 with optional version specification
-- `decrypt()`: Decrypt a message using NIP-44 (automatically handles any supported version)
+- `decrypt()`: Decrypt a defined NIP-44 v2 message
 - `getSharedSecret()`: Get the shared secret between two keys
 - `generateKeypair()`: Generate a new Nostr keypair
 
 ## Related NIPs
 
 - [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md): Encrypted Direct Message (older, less secure method)
-- [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md): Basic Protocol (events and structure) 
+- [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md): Basic Protocol (events and structure)

--- a/examples/nip44/README.md
+++ b/examples/nip44/README.md
@@ -9,7 +9,7 @@ This directory contains examples demonstrating how to use NIP-44 encrypted direc
 **Implementation Details**:
 - Uses ChaCha20 for encryption and HMAC-SHA256 for authentication
 - Includes a version byte to support future algorithm upgrades and backward compatibility
-- Accepts defined version 2 payloads and rejects reserved or undefined versions
+- Accepts defined version 2 payloads and rejects reserved, undefined, or unknown versions
 - Provides proper key derivation using HKDF
 - Implements message length hiding with a custom padding scheme
 - Uses secure 32-byte nonces

--- a/examples/nip44/nip44-compliance-demo.ts
+++ b/examples/nip44/nip44-compliance-demo.ts
@@ -12,8 +12,6 @@
 
 import {
   decodePayload,
-  NONCE_SIZE_V0,
-  MAC_SIZE_V0,
   NONCE_SIZE_V2,
   MAC_SIZE_V2,
 } from "../../src/nip44";
@@ -28,9 +26,8 @@ function createMinimalValidPayload(
 ): string {
   const versionByte = new Uint8Array([version]);
 
-  // Use version-specific constants for nonce and MAC sizes
-  const nonceSize = version === 2 ? NONCE_SIZE_V2 : NONCE_SIZE_V0;
-  const macSize = version === 2 ? MAC_SIZE_V2 : MAC_SIZE_V0;
+  const nonceSize = NONCE_SIZE_V2;
+  const macSize = MAC_SIZE_V2;
 
   // Create non-zero nonce with version-specific size
   const nonce = new Uint8Array(nonceSize);
@@ -150,7 +147,7 @@ console.log("-".repeat(30));
 try {
   // Create a minimal valid payload: version(1) + nonce(32) + ciphertext(33) + mac(32) = 98 bytes
   // But we need 99 bytes minimum, so use 34 bytes ciphertext = 99 bytes total
-  const minLengthPayload = createMinimalValidPayload(0, 34); // Creates exactly 99 bytes when decoded
+  const minLengthPayload = createMinimalValidPayload(2, 34); // Creates exactly 99 bytes when decoded
   const result = decodePayload(minLengthPayload);
   console.log("✅ Accepted minimum length valid payload");
   console.log(
@@ -192,7 +189,7 @@ console.log("-".repeat(30));
 console.log("✅ # Prefix Detection: Implemented (NIP-44 Decryption Step 1)");
 console.log("✅ Base64 Length Validation: 132 to 87,472 characters");
 console.log("✅ Decoded Length Validation: 99 to 65,603 bytes");
-console.log("✅ Version Support: 0, 1, 2 (decryption only for 0 & 1)");
+console.log("✅ Version Support: v2; reserved and undefined versions rejected");
 console.log("✅ Error Messages: Clear and informative");
 
 console.log("\n🎉 All NIP-44 compliance checks passed!");

--- a/examples/nip44/nip44-compliance-demo.ts
+++ b/examples/nip44/nip44-compliance-demo.ts
@@ -189,7 +189,9 @@ console.log("-".repeat(30));
 console.log("✅ # Prefix Detection: Implemented (NIP-44 Decryption Step 1)");
 console.log("✅ Base64 Length Validation: 132 to 87,472 characters");
 console.log("✅ Decoded Length Validation: 99 to 65,603 bytes");
-console.log("✅ Version Support: v2; reserved and undefined versions rejected");
+console.log(
+  "✅ Version Support: v2; reserved, undefined, and unknown versions rejected",
+);
 console.log("✅ Error Messages: Clear and informative");
 
 console.log("\n🎉 All NIP-44 compliance checks passed!");

--- a/examples/nip44/nip44-demo.ts
+++ b/examples/nip44/nip44-demo.ts
@@ -203,7 +203,7 @@ async function main() {
     "- This library encrypts all new messages using NIP-44 Version 2.",
   );
   console.log(
-    "- It can successfully decrypt messages created with NIP-44 Version 0, 1, or 2.",
+    "- It decrypts Version 2 payloads and rejects reserved, undefined, and unknown versions.",
   );
   console.log(
     "- NIP-44 Specification: Clients MUST NOT encrypt new messages with Version 0 (Reserved) or Version 1 (Deprecated).",

--- a/examples/nip44/nip44-demo.ts
+++ b/examples/nip44/nip44-demo.ts
@@ -172,7 +172,7 @@ async function main() {
     "NIP-44 includes a version byte. This implementation encrypts with version 2 (current standard).",
   );
   console.log(
-    "Decryption works automatically with any supported version (0, 1, 2), ensuring backward compatibility.",
+    "Decryption accepts defined version 2 payloads and rejects reserved or undefined versions.",
   );
 
   const versionCompatMessage =
@@ -223,7 +223,7 @@ async function main() {
     "6. NIP-44 payload is versioned, allowing future encryption improvements",
   );
   console.log(
-    "7. NIP-44 supports multiple versions (0, 1, 2) for decryption, ensuring backward compatibility",
+    "7. NIP-44 rejects reserved, undefined, and unknown versions before decryption",
   );
 
   // Demonstrate secure constant-time comparison

--- a/examples/nip44/nip44-demo.ts
+++ b/examples/nip44/nip44-demo.ts
@@ -172,7 +172,7 @@ async function main() {
     "NIP-44 includes a version byte. This implementation encrypts with version 2 (current standard).",
   );
   console.log(
-    "Decryption accepts defined version 2 payloads and rejects reserved or undefined versions.",
+    "Decryption accepts defined version 2 payloads and rejects reserved, undefined, or unknown versions.",
   );
 
   const versionCompatMessage =

--- a/examples/nip44/nip44-version-compatibility.ts
+++ b/examples/nip44/nip44-version-compatibility.ts
@@ -66,12 +66,18 @@ async function main() {
         bobKeypair.privateKey,
         aliceKeypair.publicKey,
       );
-      console.log(
-        `❌ Error: Version ${unsupportedVersion} decryption unexpectedly succeeded`,
+      throw new Error(
+        `Version ${unsupportedVersion} decryption unexpectedly succeeded`,
       );
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const expectedError = `NIP-44: Unsupported version: ${unsupportedVersion}. This implementation supports version 2.`;
+      if (errorMessage !== expectedError) {
+        throw error;
+      }
       console.log(
-        `✅ Version ${unsupportedVersion} rejected: ${error instanceof Error ? error.message : String(error)}`,
+        `✅ Version ${unsupportedVersion} rejected: ${errorMessage}`,
       );
     }
   }

--- a/examples/nip44/nip44-version-compatibility.ts
+++ b/examples/nip44/nip44-version-compatibility.ts
@@ -55,6 +55,28 @@ async function main() {
   console.log(`Decrypted: "${decryptedV2}"`);
   console.log(`Successful decryption: ${message === decryptedV2}\n`);
 
+  console.log("Reserved, Undefined, and Unknown Decryption:");
+  console.log("------------------------------------------------");
+  for (const unsupportedVersion of [0, 1, 3]) {
+    const bytes = Buffer.from(encryptedV2, "base64");
+    bytes[0] = unsupportedVersion;
+    try {
+      decryptNIP44(
+        bytes.toString("base64"),
+        bobKeypair.privateKey,
+        aliceKeypair.publicKey,
+      );
+      console.log(
+        `❌ Error: Version ${unsupportedVersion} decryption unexpectedly succeeded`,
+      );
+    } catch (error) {
+      console.log(
+        `✅ Version ${unsupportedVersion} rejected: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  console.log("\n");
+
   // Demonstrate explicit v1 encryption
   console.log("Attempting Version 1 Encryption (should fail):");
   console.log("-----------------------------------------------");
@@ -162,7 +184,9 @@ async function main() {
   console.log("\nSummary:");
   console.log("--------");
   console.log("- Default encryption uses NIP-44 v2 (most secure)");
-  console.log("- Decryption accepts version 2 and rejects undefined versions");
+  console.log(
+    "- Decryption accepts version 2 and rejects reserved, undefined, and unknown versions",
+  );
   console.log(
     "- NIP-44 compliant clients MUST NOT encrypt new messages with versions 0 or 1.",
   );

--- a/examples/nip44/nip44-version-compatibility.ts
+++ b/examples/nip44/nip44-version-compatibility.ts
@@ -1,10 +1,11 @@
 /**
  * NIP-44 Version Compatibility Demo
  *
- * This example demonstrates how to use the NIP-44 version compatibility features:
- * - Encrypting with different versions (0, 1, 2)
- * - Automatic decryption of messages from any supported version
- * - Using version options for compatibility with older clients
+ * This example demonstrates NIP-44's version registry:
+ * - Version 2 is the only defined encryption algorithm
+ * - Version 0 is reserved
+ * - Version 1 is deprecated and undefined
+ * - Unknown versions are rejected before decryption
  */
 
 import { generateKeypair, encryptNIP44, decryptNIP44 } from "../../src";
@@ -114,15 +115,9 @@ async function main() {
   }
   console.log("\n");
 
-  // Cross-version compatibility test
-  console.log("Cross-Version Compatibility:");
+  console.log("Version 2 Interoperability:");
   console.log("---------------------------");
-  console.log(
-    "Testing if Alice and Bob can communicate with different versions",
-  );
-
-  // Alice uses v2, Bob uses v0
-  console.log("\nScenario 1: Alice (v2) → Bob");
+  console.log("\nAlice (v2) → Bob (v2)");
   const aliceMessage = "Hello Bob, I'm using NIP-44 v2!";
   const aliceToBob = encryptNIP44(
     aliceMessage,
@@ -139,14 +134,6 @@ async function main() {
   console.log(`Alice's message: "${aliceMessage}"`);
   console.log(`Bob decrypts: "${bobDecrypts}"`);
   console.log(`Successful: ${aliceMessage === bobDecrypts}`);
-
-  // Bob uses v0, Alice uses v2
-  console.log(
-    "\nScenario 2: Bob receiving a V0/V1 message (e.g., from an older client) and Alice (V2) decrypting it.",
-  );
-  console.log(
-    "  (Decryption of V0/V1 is supported, but sending V0/V1 is not. This scenario is covered by general decryption tests.)",
-  );
 
   // Demonstrate invalid version handling
   console.log("\nInvalid Version Handling:");
@@ -175,7 +162,7 @@ async function main() {
   console.log("\nSummary:");
   console.log("--------");
   console.log("- Default encryption uses NIP-44 v2 (most secure)");
-  console.log("- Decryption automatically works with versions 0, 1, and 2");
+  console.log("- Decryption accepts version 2 and rejects undefined versions");
   console.log(
     "- NIP-44 compliant clients MUST NOT encrypt new messages with versions 0 or 1.",
   );
@@ -186,7 +173,7 @@ async function main() {
     "- This implementation complies with NIP-44 requirement that clients:",
   );
   console.log("  * MUST include a version byte in encrypted payloads");
-  console.log("  * MUST be able to decrypt versions 0 and 1");
+  console.log("  * MUST report reserved or undefined versions as unsupported");
   console.log("  * MUST NOT encrypt with version 0 (Reserved)");
   console.log("  * MUST NOT encrypt with version 1 (Deprecated and undefined)");
 }

--- a/src/nip44/README.md
+++ b/src/nip44/README.md
@@ -12,7 +12,8 @@ NIP-44 replaces the older NIP-04 encryption with a more secure approach using Ch
 - Proper key derivation using HKDF
 - Message length hiding via a custom padding scheme
 - Secure nonce handling with 32-byte nonces
-- **Full version compatibility** supporting decryption of v0, v1, and v2 messages
+- Strict version handling that accepts defined v2 payloads and rejects reserved,
+  undefined, or unknown versions
 
 ## Basic Usage
 
@@ -72,7 +73,9 @@ Decrypts a message using NIP-44 encryption.
 - Returns: Decrypted message
 - Throws: Error if decryption fails (wrong keys, tampered message, etc.)
 
-**Note**: This implementation automatically detects and handles payload versions 0, 1, and 2, providing seamless backward compatibility.
+**Note**: This implementation accepts version 2 payloads. Version 0 is reserved,
+version 1 is deprecated and undefined, and every other version is reported as
+unsupported.
 
 ### `getNIP44SharedSecret(privateKey, publicKey)`
 
@@ -98,40 +101,39 @@ Performs constant-time comparison of two byte arrays to prevent timing attacks.
 
 This function is used internally to validate MACs securely, but is also exposed for use in other security-critical comparisons. Using constant-time comparison is important when comparing sensitive values like MACs, signatures, or hashes to prevent timing side-channel attacks.
 
-## Version Compatibility
+## Version Handling
 
-This implementation follows the NIP-44 specification requirement that clients:
+This implementation follows the NIP-44 version registry:
 - **MUST** include a version byte in encrypted payloads
-- **MUST** be able to decrypt versions 0 and 1
-- **MUST NOT** encrypt with version 0 ("Reserved")
-- **MUST NOT** encrypt with version 1 ("Deprecated and undefined")
+- Treat version 0 as reserved
+- Treat version 1 as deprecated and undefined
+- Use version 2 for the currently defined encryption algorithm
+- Report any version other than 2 as unsupported
 
 ### Version Support
 
 | Version | Encryption | Decryption | Notes |
 |---------|------------|------------|-------|
-| 0 | ❌ Not Supported | ✅ Supported | Per NIP-44: "Reserved. Implementations MUST NOT encrypt with this version." Decryption is supported. |
-| 1 | ❌ Not Supported | ✅ Supported | Per NIP-44: "Deprecated and undefined. Implementations MUST NOT encrypt with this version." Decryption is supported. |
+| 0 | ❌ Not Supported | ❌ Not Supported | Reserved; no algorithm is defined. |
+| 1 | ❌ Not Supported | ❌ Not Supported | Deprecated and undefined; no algorithm is defined. |
 | 2 | ✅ Supported (Default) | ✅ Supported | Current version, used by default for all encryption. |
 
 ### Default Behavior
 
 - **Encryption**: All messages are encrypted with NIP-44 version 2 (the current standard).
-- **Decryption**: Automatically detects and handles versions 0, 1, and 2
-
-**Note on V0/V1 Decryption Compatibility:**
-NIP-44 (Section: Decryption, Point 4) specifies that for decrypting versions 0 and 1: *"Implementations MUST be able to decrypt versions 0 and 1 for compatibility, **using the same algorithms as above** [i.e., version 2's algorithms] with the respective version byte. The `message_nonce` is 32 bytes, `mac` is 32 bytes. Clients MAY refuse to decrypt messages with these versions."*
-This implementation adheres to this directive by applying the NIP-44 v2 cryptographic pipeline (including key derivation with the "nip44-v2" salt, ChaCha20, and HMAC-SHA256) when attempting to decrypt payloads marked as v0 or v1. Therefore, successful decryption of v0/v1 payloads implies they were constructed in a manner compatible with the v2 cryptographic scheme, as guided by the NIP-44 decryption instructions.
+- **Decryption**: Rejects reserved, undefined, and unknown versions before key
+  derivation or decryption.
 
 ### Version Differences
 
-Currently, all versions use the same cryptographic primitives:
+Version 2 uses these cryptographic primitives:
 - ChaCha20 for encryption
 - HMAC-SHA256 for authentication
 - 32-byte nonces
 - 32-byte MAC tags
 
-The primary difference is the version byte in the payload, which enables future protocol upgrades.
+The version byte enables future protocol upgrades without assigning algorithms
+to reserved or undefined versions.
 
 ## Differences from NIP-04
 
@@ -149,8 +151,6 @@ This implementation follows the NIP-44 v2 specification exactly, with careful at
 ### Key Constants
 
 - `CURRENT_VERSION = 2` - Current NIP-44 version for encryption
-- `MIN_SUPPORTED_VERSION = 0` - Minimum supported version for decryption
-- `MAX_SUPPORTED_VERSION = 2` - Maximum supported version for decryption
 - `NONCE_SIZE_V2 = 32` - 32-byte nonce as required by NIP-44 v2
 - `KEY_SIZE = 32` - 32-byte key for ChaCha20
 - `MAC_SIZE_V2 = 32` - 32-byte MAC from HMAC-SHA256
@@ -194,9 +194,9 @@ This implementation follows the NIP-44 v2 specification exactly, with careful at
    - Validate decoded payload length (99 to 65,603 bytes)
 
 2. **Parse Payload** (NIP-44 spec section "Decryption" step 2)
-   - Decode base64 
-   - Extract version byte, validate it's between 0-2
-   - Extract nonce, ciphertext, and MAC based on version-specific sizes
+   - Decode base64
+   - Extract the version byte and require the defined version 2
+   - Extract the v2 nonce, ciphertext, and MAC
 
 3. **Key Derivation** (Same as encryption)
    - Calculate the same conversation key and message keys
@@ -247,7 +247,7 @@ This implementation has been thoroughly validated against the official [NIP-44 t
 - End-to-end encryption/decryption validation with various message lengths
 - Edge case handling (minimum and maximum message sizes)
 - Error handling for invalid inputs and tampered messages
-- Version compatibility tests across versions 0, 1, and 2
+- Version handling tests for v2 plus reserved, undefined, and unknown versions
 
 The official test vectors provide cryptographic certainty that our implementation correctly follows the NIP-44 specification and will interoperate with other compliant implementations.
 
@@ -312,7 +312,7 @@ This implementation has been validated against the [official NIP-44 test vectors
 
 Passing these test vectors ensures that this implementation correctly handles:
 - Key derivation according to the NIP-44 specification
-- Encryption and decryption across all supported versions (v0, v1, v2)
+- Version 2 encryption/decryption and unsupported-version rejection
 - Message authentication and padding as specified
 
 ## Implementation Details
@@ -343,4 +343,4 @@ The implementation properly handles x-only public keys (the standard for Nostr) 
 3. Constructing the correct compressed format (with 02/03 prefix) for ECDH operations
 4. Performing constant-time operations to avoid timing side-channels
 
-This approach ensures compatibility with Nostr's x-only public key format while maintaining the security properties required by the NIP-44 specification. 
+This approach ensures compatibility with Nostr's x-only public key format while maintaining the security properties required by the NIP-44 specification.

--- a/src/nip44/index.ts
+++ b/src/nip44/index.ts
@@ -14,29 +14,8 @@ import { chacha20 } from "@noble/ciphers/chacha";
 // const KEY_SIZE = 32; // 32-byte key for ChaCha20
 // const MAC_SIZE = 32; // HMAC-SHA256 produces 32-byte tags
 
-// Current supported version for encryption
 const CURRENT_VERSION = 2;
-// Minimum supported version for decryption
-const MIN_SUPPORTED_VERSION = 0;
-// Maximum supported version for decryption (for future extensibility)
-const MAX_SUPPORTED_VERSION = 2;
-
-// NIP-44 Version-specific constants
-// Per NIP-44 specification (Decryption, point 4):
-// "Implementations MUST be able to decrypt versions 0 and 1 for compatibility,
-// using the same algorithms as above [i.e., version 2's algorithms] with the respective version byte.
-// The `message_nonce` is 32 bytes, `mac` is 32 bytes."
-//
-// This confirms that all versions (0, 1, 2) use:
-// - 32-byte nonces
-// - 32-byte MAC tags
-// - Same cryptographic algorithms (ChaCha20, HMAC-SHA256, HKDF with "nip44-v2" salt)
-export const NONCE_SIZE_V0 = 32;
-export const NONCE_SIZE_V1 = 32;
 export const NONCE_SIZE_V2 = 32;
-
-export const MAC_SIZE_V0 = 32;
-export const MAC_SIZE_V1 = 32;
 export const MAC_SIZE_V2 = 32;
 
 const KEY_SIZE = 32; // 32-byte key for ChaCha20 (consistent across versions)
@@ -508,12 +487,9 @@ export function getMessageKeys(
     );
   }
 
-  if (nonce.length < NONCE_SIZE_V0) {
-    // Assuming V0 has the smallest possible nonce, check against it.
-    // This check might need refinement if V0/V1 nonces are smaller and still valid inputs here.
-    // However, getMessageKeys is currently only called by encrypt/decrypt which would use version-specific nonce sizes.
+  if (nonce.length < NONCE_SIZE_V2) {
     throw new Error(
-      `NIP-44: Nonce too short for key derivation. Min expected: ${NONCE_SIZE_V0}, got: ${nonce.length}`,
+      `NIP-44: Nonce too short for key derivation. Min expected: ${NONCE_SIZE_V2}, got: ${nonce.length}`,
     );
   }
 
@@ -564,11 +540,9 @@ export function hmacWithAAD(
   message: Uint8Array,
   aad: Uint8Array, // aad is the NIP-44 nonce (e.g. 32 bytes for v2)
 ): Uint8Array {
-  if (aad.length < NONCE_SIZE_V0) {
-    // Allow for potentially smaller nonces from older versions.
-    // This check needs to be correct for the SMALLEST valid nonce size.
+  if (aad.length < NONCE_SIZE_V2) {
     throw new Error(
-      `NIP-44: AAD (nonce) too short. Min expected: ${NONCE_SIZE_V0} bytes, got: ${aad.length}`,
+      `NIP-44: AAD (nonce) too short. Min expected: ${NONCE_SIZE_V2} bytes, got: ${aad.length}`,
     );
   }
 
@@ -694,32 +668,6 @@ function encryptV2(
   return base64Encode(payload);
 }
 
-// Placeholder for NIP-44 v1 encryption -- REMOVED as per NIP-44 spec (MUST NOT encrypt with v1)
-/*
-function encryptV1(
-  plaintext: string,
-  privateKey: string,
-  publicKey: string,
-  nonce?: Uint8Array,
-): string {
-  // ... (original implementation removed) ...
-  throw new Error("NIP-44: Encryption with version 1 is not permitted by the NIP-44 specification.");
-}
-*/
-
-// Placeholder for NIP-44 v0 encryption -- REMOVED as per NIP-44 spec (MUST NOT encrypt with v0)
-/*
-function encryptV0(
-  plaintext: string,
-  privateKey: string,
-  publicKey: string,
-  nonce?: Uint8Array,
-): string {
-  // ... (original implementation removed) ...
-  throw new Error("NIP-44: Encryption with version 0 is not permitted by the NIP-44 specification.");
-}
-*/
-
 /**
  * Encrypt a message using NIP-44 v2 (ChaCha20 + HMAC-SHA256)
  *
@@ -756,28 +704,17 @@ export function encrypt(
   // NIP-44 spec (version 2): This is the current and recommended version for encryption.
   if (versionToEncryptWith === 0) {
     throw new Error(
-      "NIP-44: Encryption with version 0 is not permitted by the NIP-44 specification. Only decryption is supported for v0.",
+      "NIP-44: Encryption with version 0 is not permitted because the version is reserved.",
     );
   }
   if (versionToEncryptWith === 1) {
     throw new Error(
-      "NIP-44: Encryption with version 1 is not permitted by the NIP-44 specification. Only decryption is supported for v1.",
+      "NIP-44: Encryption with version 1 is not permitted because the version is deprecated and undefined.",
     );
   }
   if (versionToEncryptWith !== CURRENT_VERSION) {
-    // Currently CURRENT_VERSION is 2
-    // This condition will catch any other non-current versions if CURRENT_VERSION changes
-    // or if a version > 2 is somehow passed and not caught by MAX_SUPPORTED_VERSION check.
     throw new Error(
       `NIP-44: Unsupported encryption version: ${versionToEncryptWith}. Only version ${CURRENT_VERSION} is supported for encryption.`,
-    );
-  }
-
-  // Further check if it's in the decryptable range just in case (MAX_SUPPORTED_VERSION for future extensibility).
-  // MIN_SUPPORTED_VERSION for encryption is effectively CURRENT_VERSION due to above checks.
-  if (versionToEncryptWith > MAX_SUPPORTED_VERSION) {
-    throw new Error(
-      `NIP-44: Encryption version ${versionToEncryptWith} is outside the maximum supported range [${MIN_SUPPORTED_VERSION}-${MAX_SUPPORTED_VERSION}].`,
     );
   }
 
@@ -874,23 +811,16 @@ export function decodePayload(payload: string): {
   }
   const version = data[0];
 
-  // Validate version is in supported range for decryption
-  if (version < MIN_SUPPORTED_VERSION || version > MAX_SUPPORTED_VERSION) {
+  // NIP-44 defines only v2. Version 0 is reserved and version 1 is deprecated
+  // and undefined, so both must be treated like any other unknown version.
+  if (version !== CURRENT_VERSION) {
     throw new Error(
-      `NIP-44: Unsupported version: ${version}. This implementation supports versions ${MIN_SUPPORTED_VERSION}-${MAX_SUPPORTED_VERSION}.`,
+      `NIP-44: Unsupported version: ${version}. This implementation supports version ${CURRENT_VERSION}.`,
     );
   }
 
-  // Determine nonce and MAC sizes based on version
-  const nonceSize =
-    version === 0
-      ? NONCE_SIZE_V0
-      : version === 1
-        ? NONCE_SIZE_V1
-        : NONCE_SIZE_V2;
-
-  const macSize =
-    version === 0 ? MAC_SIZE_V0 : version === 1 ? MAC_SIZE_V1 : MAC_SIZE_V2;
+  const nonceSize = NONCE_SIZE_V2;
+  const macSize = MAC_SIZE_V2;
 
   // Verify minimum payload length for the detected version
   const minVersionedPayloadSize = VERSION_BYTE_SIZE + nonceSize + 1 + macSize; // version + nonce + min_ciphertext (1 byte) + mac
@@ -953,70 +883,6 @@ function decryptV2(
   return unpad(padded);
 }
 
-// Placeholder for NIP-44 v1 decryption
-// TODO: Implement actual NIP-44 v1 decryption logic
-// NIP-44 v1 Decryption: Implementations MUST be able to decrypt this version if they can decrypt v2.
-// It is assumed that v1 decryption uses the same underlying crypto as v2, but with version byte 1.
-// The primary difference is that the conversation key KDF uses the "nip44-v2" salt,
-// as v1 spec for KDF is undefined and NIP-44 mandates v1 decryption.
-// NIP-44 (Decryption, point 2) mandates that v1 payloads be decrypted using the same
-// algorithms as v2, including the "nip44-v2" KDF salt and 32-byte nonce/MAC.
-// This function adheres to that by utilizing decryptV2.
-function decryptV1(
-  encryptedData: Uint8Array,
-  nonce: Uint8Array,
-  mac: Uint8Array,
-  privateKey: string,
-  publicKey: string,
-): string {
-  // For now, V1 uses V2 logic as a placeholder.
-  // This needs to be replaced with actual V1 specification if different.
-  // The NIP-44 spec says "Implementations MUST be able to decrypt versions 0 and 1"
-  // but doesn't detail if their algorithms differ from v2 beyond version byte.
-  // Assuming key derivation ("nip44-v2" salt in getSharedSecret) and crypto primitives are the same unless specified.
-  // console.warn("NIP-44: decryptV1 is using V2 logic as a placeholder. Verify V1 specification.");
-  // NIP-44 specifies using v2 algorithms for v1 decryption.
-  try {
-    return decryptV2(encryptedData, nonce, mac, privateKey, publicKey);
-  } catch (error) {
-    if (error instanceof Error && error.message.includes("NIP-44 (v2)")) {
-      throw new Error(error.message.replace("NIP-44 (v2)", "NIP-44 (v1)"));
-    }
-    throw error;
-  }
-}
-
-// Placeholder for NIP-44 v0 decryption
-// TODO: Implement actual NIP-44 v0 decryption logic
-// NIP-44 v0 Decryption: Implementations MUST be able to decrypt this version if they can decrypt v2.
-// It is assumed that v0 decryption uses the same underlying crypto as v2, but with version byte 0.
-// The primary difference is that the conversation key KDF uses the "nip44-v2" salt,
-// as v0 spec for KDF is undefined and NIP-44 mandates v0 decryption.
-// NIP-44 (Decryption, point 2) mandates that v0 payloads be decrypted using the same
-// algorithms as v2, including the "nip44-v2" KDF salt and 32-byte nonce/MAC.
-// This function adheres to that by utilizing decryptV2.
-function decryptV0(
-  encryptedData: Uint8Array,
-  nonce: Uint8Array,
-  mac: Uint8Array,
-  privateKey: string,
-  publicKey: string,
-): string {
-  // For now, V0 uses V2 logic as a placeholder.
-  // This needs to be replaced with actual V0 specification.
-  // There's no official NIP for v0, it was an early experimental version.
-  // console.warn("NIP-44: decryptV0 is using V2 logic as a placeholder. Verify V0 specification if possible.");
-  // NIP-44 specifies using v2 algorithms for v0 decryption.
-  try {
-    return decryptV2(encryptedData, nonce, mac, privateKey, publicKey);
-  } catch (error) {
-    if (error instanceof Error && error.message.includes("NIP-44 (v2)")) {
-      throw new Error(error.message.replace("NIP-44 (v2)", "NIP-44 (v0)"));
-    }
-    throw error;
-  }
-}
-
 /**
  * Decrypt a message using NIP-44 (ChaCha20 + HMAC-SHA256)
  *
@@ -1044,23 +910,12 @@ export function decrypt(
   try {
     // Decode and extract the payload components
     const {
-      version,
       nonce,
       ciphertext: encryptedData,
       mac,
     } = decodePayload(ciphertext);
 
-    // Call the appropriate version-specific decrypt function
-    if (version === 0) {
-      return decryptV0(encryptedData, nonce, mac, privateKey, publicKey);
-    } else if (version === 1) {
-      return decryptV1(encryptedData, nonce, mac, privateKey, publicKey);
-    } else if (version === 2) {
-      return decryptV2(encryptedData, nonce, mac, privateKey, publicKey);
-    } else {
-      // This case should ideally be caught by decodePayload's version check
-      throw new Error(`NIP-44: Unexpected version ${version} after decoding.`);
-    }
+    return decryptV2(encryptedData, nonce, mac, privateKey, publicKey);
   } catch (error) {
     // Enhance error messages for better debugging
     if (error instanceof Error) {

--- a/src/nip44/index.ts
+++ b/src/nip44/index.ts
@@ -487,9 +487,9 @@ export function getMessageKeys(
     );
   }
 
-  if (nonce.length < NONCE_SIZE_V2) {
+  if (nonce.length !== NONCE_SIZE_V2) {
     throw new Error(
-      `NIP-44: Nonce too short for key derivation. Min expected: ${NONCE_SIZE_V2}, got: ${nonce.length}`,
+      `NIP-44: Nonce must be ${NONCE_SIZE_V2} bytes for key derivation, got: ${nonce.length}`,
     );
   }
 
@@ -540,9 +540,9 @@ export function hmacWithAAD(
   message: Uint8Array,
   aad: Uint8Array, // aad is the NIP-44 nonce (e.g. 32 bytes for v2)
 ): Uint8Array {
-  if (aad.length < NONCE_SIZE_V2) {
+  if (aad.length !== NONCE_SIZE_V2) {
     throw new Error(
-      `NIP-44: AAD (nonce) too short. Min expected: ${NONCE_SIZE_V2} bytes, got: ${aad.length}`,
+      `NIP-44: AAD (nonce) must be ${NONCE_SIZE_V2} bytes, got: ${aad.length}`,
     );
   }
 

--- a/tests/nip44/nip44-format-validation.test.ts
+++ b/tests/nip44/nip44-format-validation.test.ts
@@ -3,8 +3,8 @@ import {
   isValidPublicKeyPoint,
   isValidPrivateKey,
   decodePayload,
-  NONCE_SIZE_V0,
-  MAC_SIZE_V0,
+  NONCE_SIZE_V2,
+  MAC_SIZE_V2,
 } from "../../src/nip44";
 
 describe("NIP-44 Format Validation", () => {
@@ -299,11 +299,13 @@ describe("NIP-44 decodePayload compliance tests", () => {
       // Generate a valid base64 string that's exactly 132 characters
       const minLengthPayload = "A".repeat(132);
 
-      // This should pass length validation and successfully decode (version 0 is supported for decryption)
-      const result = decodePayload(minLengthPayload);
-      expect(result.version).toBe(0);
-      expect(result.nonce).toHaveLength(NONCE_SIZE_V0);
-      expect(result.mac).toHaveLength(MAC_SIZE_V0);
+      // Use the only defined version so this test isolates the length boundary.
+      const bytes = Buffer.from(minLengthPayload, "base64");
+      bytes[0] = 2;
+      const result = decodePayload(bytes.toString("base64"));
+      expect(result.version).toBe(2);
+      expect(result.nonce).toHaveLength(NONCE_SIZE_V2);
+      expect(result.mac).toHaveLength(MAC_SIZE_V2);
       expect(result.ciphertext.length).toBeGreaterThan(0);
     });
 
@@ -345,11 +347,12 @@ describe("NIP-44 decodePayload compliance tests", () => {
       // Create a valid base64 that decodes to exactly 99 bytes
       const minDecodedPayload = Buffer.alloc(99).toString("base64");
 
-      // This should pass length validation and successfully decode (version 0 is supported for decryption)
-      const result = decodePayload(minDecodedPayload);
-      expect(result.version).toBe(0);
-      expect(result.nonce).toHaveLength(NONCE_SIZE_V0);
-      expect(result.mac).toHaveLength(MAC_SIZE_V0);
+      const bytes = Buffer.from(minDecodedPayload, "base64");
+      bytes[0] = 2;
+      const result = decodePayload(bytes.toString("base64"));
+      expect(result.version).toBe(2);
+      expect(result.nonce).toHaveLength(NONCE_SIZE_V2);
+      expect(result.mac).toHaveLength(MAC_SIZE_V2);
       expect(result.ciphertext.length).toBeGreaterThan(0);
     });
 
@@ -357,11 +360,12 @@ describe("NIP-44 decodePayload compliance tests", () => {
       // Create a valid base64 that decodes to exactly 65,603 bytes
       const maxDecodedPayload = Buffer.alloc(65603).toString("base64");
 
-      // This should pass length validation and successfully decode (version 0 is supported for decryption)
-      const result = decodePayload(maxDecodedPayload);
-      expect(result.version).toBe(0);
-      expect(result.nonce).toHaveLength(NONCE_SIZE_V0);
-      expect(result.mac).toHaveLength(MAC_SIZE_V0);
+      const bytes = Buffer.from(maxDecodedPayload, "base64");
+      bytes[0] = 2;
+      const result = decodePayload(bytes.toString("base64"));
+      expect(result.version).toBe(2);
+      expect(result.nonce).toHaveLength(NONCE_SIZE_V2);
+      expect(result.mac).toHaveLength(MAC_SIZE_V2);
       expect(result.ciphertext.length).toBeGreaterThan(0);
     });
   });

--- a/tests/nip44/nip44-official-vectors.test.ts
+++ b/tests/nip44/nip44-official-vectors.test.ts
@@ -105,14 +105,14 @@ describe("NIP-44 implementation against official test vectors", () => {
         expect(() => {
           encrypt(plaintext, sec1, pub2, undefined, { version: 0 });
         }).toThrowError(
-          "NIP-44: Encryption with version 0 is not permitted by the NIP-44 specification. Only decryption is supported for v0.",
+          "NIP-44: Encryption with version 0 is not permitted because the version is reserved.",
         );
 
         // Test V1 encryption (should fail)
         expect(() => {
           encrypt(plaintext, sec1, pub2, undefined, { version: 1 });
         }).toThrowError(
-          "NIP-44: Encryption with version 1 is not permitted by the NIP-44 specification. Only decryption is supported for v1.",
+          "NIP-44: Encryption with version 1 is not permitted because the version is deprecated and undefined.",
         );
 
         // Test V2 encryption (should succeed)
@@ -160,18 +160,8 @@ describe("NIP-44 implementation against official test vectors", () => {
         // Calculate public key
         const pub1 = getPublicKeyHex(sec1);
 
-        try {
-          // Try to decrypt the test vector payload
-          const decrypted = decrypt(payload, sec2, pub1);
-          expect(decrypted).toBe(plaintext);
-        } catch (error) {
-          // Log the error but don't fail the test, as there may be subtle
-          // differences in how MACs were generated in reference implementation
-          console.warn(
-            `⚠️ Failed to decrypt payload for plaintext: "${plaintext}"`,
-            error,
-          );
-        }
+        const decrypted = decrypt(payload, sec2, pub1);
+        expect(decrypted).toBe(plaintext);
       }
     });
   });
@@ -234,7 +224,7 @@ describe("NIP-44 implementation against official test vectors", () => {
     const pub2 = getPublicKeyHex(testVectorBase.sec2); // Derive pub2 correctly
     const plaintext = testVectorBase.plaintext;
 
-    test("should correctly decode payloads with version 0, 1, 2", () => {
+    test("should decode v2 and reject reserved or undefined versions", () => {
       // Test V2 payload decoding (original logic)
       const encryptedV2ForDecode = encrypt(plaintext, sec1, pub2, undefined, {
         version: 2,
@@ -245,16 +235,14 @@ describe("NIP-44 implementation against official test vectors", () => {
       expect(decodedV2.mac.length).toBe(32); // MAC_SIZE_V2
       expect(decodedV2.ciphertext.length).toBeGreaterThan(0);
 
-      // Test V0 payload decoding by tampering a V2 payload's version byte
+      // NIP-44 reserves v0 and leaves v1 deprecated and undefined.
       let v2Buffer = Buffer.from(encryptedV2ForDecode, "base64");
       if (v2Buffer.length > 0) {
         v2Buffer[0] = 0; // Set version to 0
         const tamperedV0Payload = v2Buffer.toString("base64");
-        const decodedV0 = decodePayload(tamperedV0Payload);
-        expect(decodedV0.version).toBe(0);
-        expect(decodedV0.nonce.length).toBe(32); // NONCE_SIZE_V0 (assuming 32)
-        expect(decodedV0.mac.length).toBe(32); // MAC_SIZE_V0 (assuming 32)
-        expect(decodedV0.ciphertext.length).toBeGreaterThan(0);
+        expect(() => decodePayload(tamperedV0Payload)).toThrow(
+          "NIP-44: Unsupported version: 0. This implementation supports version 2.",
+        );
       } else {
         throw new Error(
           "Failed to create a V2 payload for V0 tampering in decode test",
@@ -276,11 +264,9 @@ describe("NIP-44 implementation against official test vectors", () => {
       if (v2Buffer.length > 0) {
         v2Buffer[0] = 1; // Set version to 1
         const tamperedV1Payload = v2Buffer.toString("base64");
-        const decodedV1 = decodePayload(tamperedV1Payload);
-        expect(decodedV1.version).toBe(1);
-        expect(decodedV1.nonce.length).toBe(32); // NONCE_SIZE_V1 (assuming 32)
-        expect(decodedV1.mac.length).toBe(32); // MAC_SIZE_V1 (assuming 32)
-        expect(decodedV1.ciphertext.length).toBeGreaterThan(0);
+        expect(() => decodePayload(tamperedV1Payload)).toThrow(
+          "NIP-44: Unsupported version: 1. This implementation supports version 2.",
+        );
       } else {
         throw new Error(
           "Failed to create a V2 payload for V1 tampering in decode test",

--- a/tests/nip44/nip44-official-vectors.test.ts
+++ b/tests/nip44/nip44-official-vectors.test.ts
@@ -221,6 +221,8 @@ describe("NIP-44 implementation against official test vectors", () => {
   describe("decodePayload version handling", () => {
     const testVectorBase = testVectors.v2.valid.encrypt_decrypt[0];
     const sec1 = testVectorBase.sec1;
+    const sec2 = testVectorBase.sec2;
+    const pub1 = getPublicKeyHex(sec1);
     const pub2 = getPublicKeyHex(testVectorBase.sec2); // Derive pub2 correctly
     const plaintext = testVectorBase.plaintext;
 
@@ -241,6 +243,9 @@ describe("NIP-44 implementation against official test vectors", () => {
         v2Buffer[0] = 0; // Set version to 0
         const tamperedV0Payload = v2Buffer.toString("base64");
         expect(() => decodePayload(tamperedV0Payload)).toThrow(
+          "NIP-44: Unsupported version: 0. This implementation supports version 2.",
+        );
+        expect(() => decrypt(tamperedV0Payload, sec2, pub1)).toThrow(
           "NIP-44: Unsupported version: 0. This implementation supports version 2.",
         );
       } else {
@@ -265,6 +270,9 @@ describe("NIP-44 implementation against official test vectors", () => {
         v2Buffer[0] = 1; // Set version to 1
         const tamperedV1Payload = v2Buffer.toString("base64");
         expect(() => decodePayload(tamperedV1Payload)).toThrow(
+          "NIP-44: Unsupported version: 1. This implementation supports version 2.",
+        );
+        expect(() => decrypt(tamperedV1Payload, sec2, pub1)).toThrow(
           "NIP-44: Unsupported version: 1. This implementation supports version 2.",
         );
       } else {

--- a/tests/nip44/nip44-padding-hmac.test.ts
+++ b/tests/nip44/nip44-padding-hmac.test.ts
@@ -182,6 +182,21 @@ describe("NIP-44 Padding Implementation", () => {
 });
 
 describe("NIP-44 HMAC Implementation", () => {
+  test("should reject message-key and AAD nonces that are not exactly 32 bytes", () => {
+    const conversationKey = new Uint8Array(32);
+    const hmacKey = new Uint8Array(32);
+    const message = new Uint8Array([1]);
+
+    for (const invalidLength of [31, 33]) {
+      expect(() =>
+        getMessageKeys(conversationKey, new Uint8Array(invalidLength)),
+      ).toThrow(`Nonce must be 32 bytes for key derivation, got: ${invalidLength}`);
+      expect(() =>
+        hmacWithAAD(hmacKey, message, new Uint8Array(invalidLength)),
+      ).toThrow(`AAD (nonce) must be 32 bytes, got: ${invalidLength}`);
+    }
+  });
+
   test("should derive correct message keys from conversation key and nonce", () => {
     // Test vector from NIP-44 official vectors for message key derivation
     const vectors = testVectors.v2.valid.get_message_keys.keys;


### PR DESCRIPTION
## Summary

- require the only defined NIP-44 algorithm version, v2, during payload decoding
- reject reserved v0, undefined v1, and future versions before cryptographic processing
- remove placeholder legacy decryptors and false compatibility documentation
- require exact 32-byte v2 nonce/AAD values
- make official vector failures fatal and add public rejection coverage/examples

## Spec and ticket

- Parent spec: #111
- Implements: #112

## Verification

- NIP-44: 107/107 before review; focused post-review 25/25
- Jest: 72/72 suites, 991/991 tests with `--detectOpenHandles`
- Bun: 72/72 files, 991/991 tests
- `npm run commands:verify`
- `npm run lint`
- root and examples TypeScript checks
- CJS/ESM build and examples build
- package verification: 16 targets, 304 packed files, 49 web modules
- real `example:nip44:version-compat` execution

## Review

- Local standards/spec review passed after adding public `decrypt` rejection assertions.
- Local CodeRabbit completed with five findings; all were fixed and rechecked.
- Grok 4.5 was unavailable because the local `agent` CLI requires authentication; per the Grok skill, no substitute subagent was used.

## Risk

Payloads marked v0 or v1 that previously passed through the v2 algorithm are now rejected. This is intentional: the authoritative NIP reserves v0, leaves v1 deprecated and undefined, and defines only v2.

Closes #112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * NIP-44 encryption and decryption now support version 2 only.
  * Reserved, undefined, and unknown versions are rejected before decryption.
  * Payload nonce and authentication data sizes are validated strictly.

* **Documentation**
  * Updated NIP-44 guides, examples, demos, and compliance notes to reflect version 2-only support.
  * Added documentation covering cleanup tracking, review outcomes, and version-handling decisions.

* **Tests**
  * Expanded coverage for unsupported versions, boundary lengths, and public decryption rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->