### PR TITLE
Centralize NIP-01 protocol message types

### DIFF
--- a/docs/agents/runs/deep-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/deep-cleanup-1-8-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, rebased from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: issue #112 implementation and integrated verification complete; local CodeRabbit gate pending
+- Current status: issue #112 merged into `staging`; issue #118 implementation in progress
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, single-context domain docs)
 
 ## Goal
@@ -27,7 +27,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 - Agent briefs: Grok 4.5 is the only owner-approved delegated sidecar; `agent` authentication was unavailable at preflight, so no substitute subagent is used and Codex owns local execution/review
 - Review packets: created per ticket
 - Local CodeRabbit report: issue #112 round completed with five worthy fixes in `issue-112-coderabbit-local.md`
-- PR URLs: #120 for issue #112; later tickets pending
+- PR URLs: #120 for issue #112 (merged); later tickets pending
 
 ## Commands
 
@@ -41,8 +41,8 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 
 | Issue | Type | Status | Branch | Review | Verified |
 | --- | --- | --- | --- | --- | --- |
-| #112 NIP-44 legacy behavior | AFK | local CodeRabbit fixes verified | `feature/nip44-legacy-compat` | standards/spec pass; CodeRabbit 5 fixed | yes |
-| #118 authoritative protocol messages | AFK | ready | `feature/protocol-message-types` | pending | no |
+| #112 NIP-44 legacy behavior | AFK | merged into `staging` | `feature/nip44-legacy-compat` | standards/spec pass; local CodeRabbit 5 fixed; hosted CodeRabbit 3 fixed | yes |
+| #118 authoritative protocol messages | AFK | implementation and local review verified | `feature/protocol-message-types` | standards/spec pass; local CodeRabbit 4 fixed, 1 evidence-based skip | Jest 994/994; Bun full; post-review focused 85/85; commands, lint, types, builds, pack |
 | #113 Relay event-store seam | AFK | blocked by #118 | `feature/relay-event-store` | pending | no |
 | #114 NIP-47 protocol machinery | AFK | blocked by #118 | `feature/nip47-protocol-codecs` | pending | no |
 | #115 Nostr relay registry | AFK | blocked by #113 | `feature/nostr-relay-registry` | pending | no |
@@ -60,7 +60,8 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 
 | Issue | Fixed point | Implementation owner | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
-| #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | `ab22d13`, `fa85df2`, `03e4eb5` | standards/spec pass after one fix; CodeRabbit 5/5 fixed | NIP-44 107/107; Jest 991/991; Bun 991/991; lint, types, builds, commands, pack |
+| #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | PR #120, merge `c7cb99f` | standards/spec pass after one fix; local CodeRabbit 5/5 and hosted CodeRabbit 3/3 fixed | NIP-44 107/107; Jest 991/991; Bun 991/991; hosted Node 16/18/20 + Bun; lint, types, builds, commands, pack |
+| #118 | `c7cb99f` | current Codex orchestrator; Grok unavailable at auth preflight | pending | standards/spec pass; local CodeRabbit 4 fixed, 1 skipped with type evidence | targeted 60/60; Jest 994/994; Bun full; post-review focused 85/85; commands, lint, types, builds, pack |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/issue-118-coderabbit-local.md
+++ b/docs/agents/runs/issue-118-coderabbit-local.md
@@ -37,3 +37,4 @@
 | Public direction-specific aliases were missing from the type inventory | fixed | All four EVENT/AUTH direction aliases are documented. |
 
 - Post-hosted-review verification: lint and strict typecheck pass; filter, protocol type, and export-policy suites pass 20/20, including a raw-WebSocket malformed REQ regression test.
+- CI portability follow-up: the first raw socket test bypassed the repository's in-memory transport under Bun. It now sends through the connected Relay test seam; the filter suite passes 13/13 in both Jest and Bun.

--- a/docs/agents/runs/issue-118-coderabbit-local.md
+++ b/docs/agents/runs/issue-118-coderabbit-local.md
@@ -23,3 +23,17 @@
 - Worthy findings fixed: 4
 - Findings skipped with evidence: 1
 - Post-fix verification: lint and strict typecheck pass; focused protocol, Relay, ephemeral Relay, filter, and export-policy suites pass 85/85
+
+## Hosted PR Round
+
+- Scope: PR #121
+- Trigger: `@coderabbit full review`
+- Completed: 2026-07-18
+- Findings: 2
+
+| Finding | Decision | Notes |
+| --- | --- | --- |
+| Invalid REQ filters were reported as generic parse failures | fixed | `SecurityValidationError` now maps to the stable `invalid: REQ filters` NOTICE. |
+| Public direction-specific aliases were missing from the type inventory | fixed | All four EVENT/AUTH direction aliases are documented. |
+
+- Post-hosted-review verification: lint and strict typecheck pass; filter, protocol type, and export-policy suites pass 20/20, including a raw-WebSocket malformed REQ regression test.

--- a/docs/agents/runs/issue-118-coderabbit-local.md
+++ b/docs/agents/runs/issue-118-coderabbit-local.md
@@ -1,0 +1,25 @@
+# CodeRabbit Round: #118 Local Branch
+
+## Round
+
+- Scope: local
+- Round number: 1
+- Command: `coderabbit review --agent --type all --base staging`
+- Completed: 2026-07-18
+- Findings: 5
+
+## Decisions
+
+| Finding | Decision | Notes |
+| --- | --- | --- |
+| Session acceptance map still said full verification was pending | fixed | Status now matches the completed matrix. |
+| Review packet and other run artifacts had inconsistent verification status | fixed | Session and ledger now report the same completed results. |
+| Ledger still described #118 as pending / targeted-only | fixed | Both #118 ledger rows now contain the full verified matrix. |
+| Main Relay uses `Filter[]` while the wire tuple uses `NostrFilter[]` | skipped | `Filter` is intentionally the public extensible subtype of `NostrFilter`; strict TypeScript proves it is assignable, while changing subscription storage would remove custom-filter support. |
+| Ephemeral Relay asserted attacker-controlled REQ filters as trusted | fixed | REQ subscription ids are narrowed and filters now pass through the existing security validator before `_onreq`. |
+
+## Result
+
+- Worthy findings fixed: 4
+- Findings skipped with evidence: 1
+- Post-fix verification: lint and strict typecheck pass; focused protocol, Relay, ephemeral Relay, filter, and export-policy suites pass 85/85

--- a/docs/agents/runs/issue-118-review-packet.md
+++ b/docs/agents/runs/issue-118-review-packet.md
@@ -1,0 +1,49 @@
+# Review Packet: #118 Authoritative Protocol Messages
+
+## Fixed Point
+
+- Base: `staging` at `c7cb99f`
+- Branch: `feature/protocol-message-types`
+- Issue: #118
+
+## Change Story
+
+- `src/types/protocol.ts` is the single owner of supported client/Relay wire tuples.
+- Direction-specific unions prevent client and Relay producers from emitting opposite-direction shapes.
+- Main Relay subscription, unsubscription, publication, and authentication messages consume canonical client types.
+- Ephemeral Relay output consumes the canonical Relay union; its duplicate EVENT alias is removed.
+- Protocol types are exposed from the package root as type-only exports, preserving Node/web runtime parity.
+- Current NIP-01 `CLOSED` is included because runtime support already existed even though the ticket list omitted it.
+
+## Compatibility
+
+- Existing individual tuple type names remain available.
+- JSON tuple serialization is unchanged and explicitly tested.
+- No runtime export was added.
+- Valid wire parsing and serialization are unchanged; malformed ephemeral Relay REQ filters now use the existing validation boundary instead of an unchecked assertion.
+
+## Review Axes
+
+### Standards
+
+- Canonical type ownership is deep enough to remove producer-side tuple duplication.
+- Direction-specific names make ownership and valid use clear.
+- Type-only root exports avoid accidental runtime API expansion.
+
+### Specification
+
+- Current NIP-01 client tuples: EVENT, REQ, CLOSE.
+- Current NIP-01 Relay tuples: EVENT, OK, EOSE, CLOSED, NOTICE.
+- Current NIP-42 AUTH is covered in both directions.
+- All ticket acceptance criteria have an implementation and verification seam.
+
+## Verification
+
+- Targeted protocol/Relay: 60/60
+- Jest: 73 suites, 994/994
+- Bun: pass
+- Commands, lint, root/examples typechecks, CJS/ESM build, examples build, pack verification: pass
+
+## Known Tooling Limitation
+
+- Grok could not be delegated because the required `agent` CLI is unauthenticated. Per the Grok skill, no substitute subagent was used.

--- a/docs/agents/runs/issue-118-session.md
+++ b/docs/agents/runs/issue-118-session.md
@@ -1,0 +1,34 @@
+# Issue Session: #118 Authoritative Protocol Messages
+
+## Scope
+
+- Fixed point: `c7cb99f` (`staging` after PR #120)
+- Branch: `feature/protocol-message-types`
+- Issue: #118
+- Owner: current Codex orchestrator; Grok unavailable because `agent` authentication is required
+
+## Acceptance Map
+
+| Acceptance criterion | Implementation / verification seam |
+| --- | --- |
+| One canonical owner for EVENT, REQ, CLOSE, OK, EOSE, NOTICE, and AUTH tuples | `src/types/protocol.ts`; current NIP-01 `CLOSED` support is included as well |
+| Main and ephemeral Relay consume canonical definitions | `src/nip01/relay.ts`, `src/utils/ephemeral-relay.ts` |
+| Remove stale local aliases and comments | `ClientMessage` and `NostrRelayEventMessage` removed |
+| Preserve runtime behavior and compile-time coverage | direction-specific tuple assertions and serialization tests |
+| Full verification matrix | completed; see verification results below |
+
+## Decisions
+
+- Keep the existing individual public tuple names for compatibility.
+- Add direction-specific `NostrClientMessage` and `NostrRelayMessage` unions so producers cannot accidentally emit a tuple belonging to the opposite side.
+- Re-export the authoritative protocol module from the package root.
+- Preserve JSON parsing and serialization behavior; this ticket changes type ownership, not wire semantics.
+- Include the existing runtime-supported `CLOSED` tuple, which current NIP-01 defines but the ticket list omitted.
+
+## Verification
+
+- `npx tsc --noEmit`: pass
+- Targeted protocol and Relay suites: 60/60 pass
+- Full Jest: 73 suites, 994/994 pass
+- Full Bun: pass
+- Commands, lint, root/examples typecheck, CJS/ESM build, examples build, and pack verification: pass

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,24 @@ export type {
 
 // Export types
 export * from "./types/nostr";
+export type {
+  NostrClientToServerEventMessage,
+  NostrServerToClientEventMessage,
+  NostrEventMessage,
+  NostrReqMessage,
+  NostrCloseMessage,
+  NostrOkMessage,
+  NostrEoseMessage,
+  NostrClosedMessage,
+  NostrNoticeMessage,
+  NostrRelayAuthMessage,
+  NostrClientAuthMessage,
+  NostrAuthMessage,
+  NostrClientMessage,
+  NostrRelayMessage,
+  NostrMessage,
+  RelayConnectionOptions,
+} from "./types/protocol";
 
 // Export utilities
 export {

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -16,7 +16,12 @@ import {
   ParsedOkReason,
   SubscriptionOptions,
 } from "../types/nostr";
-import { RelayConnectionOptions } from "../types/protocol";
+import {
+  NostrClientMessage,
+  NostrCloseMessage,
+  NostrReqMessage,
+  RelayConnectionOptions,
+} from "../types/protocol";
 import { NostrValidationError, validateRelayIngressEvent } from "./validation";
 import { Logger, LogLevel } from "../utils/logger";
 import {
@@ -43,12 +48,6 @@ type WebSocketLike = {
   close(code?: number, reason?: string): void;
   terminate?: () => void;
 };
-
-type ClientMessage =
-  | ["EVENT", NostrEvent]
-  | ["AUTH", NostrEvent]
-  | ["REQ", string, ...Filter[]]
-  | ["CLOSE", string];
 
 const WS_READY_STATE = {
   CONNECTING: 0,
@@ -683,7 +682,7 @@ export class Relay {
   }
 
   private async sendClientMessage(
-    message: ClientMessage,
+    message: NostrClientMessage,
     options: PublishOptions = {},
     ackEventId?: string,
   ): Promise<PublishResponse> {
@@ -873,8 +872,8 @@ export class Relay {
     this.eventBuffers.set(id, []); // Initialize an empty event buffer for this subscription
 
     if (this.connected && this.ws) {
-      const message = JSON.stringify(["REQ", id, ...filters]);
-      this.ws.send(message);
+      const message: NostrReqMessage = ["REQ", id, ...filters];
+      this.ws.send(JSON.stringify(message));
     }
 
     return id;
@@ -893,8 +892,8 @@ export class Relay {
     this.pendingValidationCounts.delete(id);
 
     if (this.connected && this.ws) {
-      const message = JSON.stringify(["CLOSE", id]);
-      this.ws.send(message);
+      const message: NostrCloseMessage = ["CLOSE", id];
+      this.ws.send(JSON.stringify(message));
     }
   }
 

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -35,13 +35,16 @@ Contains the fundamental types for Nostr events and communication:
 
 Contains types for the Nostr protocol messages and communication:
 
-- **`NostrEventMessage`**: ["EVENT", subscription_id, event] message format
+- **`NostrEventMessage`**: Client EVENT publication or Relay subscription EVENT tuple
 - **`NostrReqMessage`**: ["REQ", subscription_id, ...filters] message format
 - **`NostrCloseMessage`**: ["CLOSE", subscription_id] message format
 - **`NostrOkMessage`**: ["OK", event_id, success, message] message format
 - **`NostrEoseMessage`**: ["EOSE", subscription_id] message format
+- **`NostrClosedMessage`**: ["CLOSED", subscription_id, message] message format
 - **`NostrNoticeMessage`**: ["NOTICE", message] message format
-- **`NostrAuthMessage`**: ["AUTH", challenge] message format (NIP-42)
+- **`NostrAuthMessage`**: Relay challenge or client authentication EVENT tuple (NIP-42)
+- **`NostrClientMessage`**: Union of tuples sent from clients to relays
+- **`NostrRelayMessage`**: Union of tuples sent from relays to clients
 - **`NostrMessage`**: Union type of all message types
 - **`RelayConnectionOptions`**: Options for configuring relay connections
 
@@ -456,4 +459,4 @@ The types in this directory implement these NIPs:
 - **[NIP-11](https://github.com/nostr-protocol/nips/blob/master/11.md)**: Relay information document
 - **[NIP-16](https://github.com/nostr-protocol/nips/blob/master/16.md)**: Ephemeral events
 - **[NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md)**: Authentication of clients to relays 
-- **[NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md)**: Search capability 
+- **[NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md)**: Search capability

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -36,6 +36,8 @@ Contains the fundamental types for Nostr events and communication:
 Contains types for the Nostr protocol messages and communication:
 
 - **`NostrEventMessage`**: Client EVENT publication or Relay subscription EVENT tuple
+- **`NostrClientToServerEventMessage`**: Client EVENT publication tuple
+- **`NostrServerToClientEventMessage`**: Relay EVENT delivery tuple
 - **`NostrReqMessage`**: ["REQ", subscription_id, ...filters] message format
 - **`NostrCloseMessage`**: ["CLOSE", subscription_id] message format
 - **`NostrOkMessage`**: ["OK", event_id, success, message] message format
@@ -43,6 +45,8 @@ Contains types for the Nostr protocol messages and communication:
 - **`NostrClosedMessage`**: ["CLOSED", subscription_id, message] message format
 - **`NostrNoticeMessage`**: ["NOTICE", message] message format
 - **`NostrAuthMessage`**: Relay challenge or client authentication EVENT tuple (NIP-42)
+- **`NostrRelayAuthMessage`**: Relay AUTH challenge tuple
+- **`NostrClientAuthMessage`**: Client AUTH response EVENT tuple
 - **`NostrClientMessage`**: Union of tuples sent from clients to relays
 - **`NostrRelayMessage`**: Union of tuples sent from relays to clients
 - **`NostrMessage`**: Union type of all message types

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,5 +1,4 @@
 import { NostrEvent, NostrFilter } from "./nostr";
-// RelayEvent is now imported in relay.ts directly from nostr.ts
 
 /**
  * Message types for Nostr protocol communications as defined in NIP-01
@@ -32,20 +31,38 @@ export type NostrEoseMessage = ["EOSE", string];
 /** NOTICE message: A human-readable message from a relay to a client */
 export type NostrNoticeMessage = ["NOTICE", string];
 
-/** AUTH message: A relay requesting client authentication (NIP-42) */
-export type NostrAuthMessage =
-  | ["AUTH", string] // relay ➜ client (challenge)
-  | ["AUTH", NostrEvent]; // client ➜ relay   (response)
+/** CLOSED message: A relay indicating that a subscription ended */
+export type NostrClosedMessage = ["CLOSED", string, string];
 
-/** Union type of all possible message types */
-export type NostrMessage =
-  | NostrEventMessage
+/** AUTH message: A relay requesting client authentication (NIP-42) */
+export type NostrRelayAuthMessage = ["AUTH", string];
+
+/** AUTH message: A client responding to a relay challenge (NIP-42) */
+export type NostrClientAuthMessage = ["AUTH", NostrEvent];
+
+/** Union type for AUTH messages in either direction */
+export type NostrAuthMessage =
+  | NostrRelayAuthMessage
+  | NostrClientAuthMessage;
+
+/** Messages sent from a Nostr client to a relay */
+export type NostrClientMessage =
+  | NostrClientToServerEventMessage
   | NostrReqMessage
   | NostrCloseMessage
+  | NostrClientAuthMessage;
+
+/** Messages sent from a Nostr relay to a client */
+export type NostrRelayMessage =
+  | NostrServerToClientEventMessage
   | NostrOkMessage
   | NostrEoseMessage
+  | NostrClosedMessage
   | NostrNoticeMessage
-  | NostrAuthMessage;
+  | NostrRelayAuthMessage;
+
+/** Union type of all possible message types */
+export type NostrMessage = NostrClientMessage | NostrRelayMessage;
 
 /**
  * Error type for Nostr protocol message parsing errors
@@ -60,8 +77,6 @@ export class NostrMessageParseError extends Error {
     this.data = data;
   }
 }
-
-// Export RelayEvent from nostr.ts instead of redefining it here
 
 /**
  * Interface for relay connection options

--- a/src/utils/ephemeral-relay.ts
+++ b/src/utils/ephemeral-relay.ts
@@ -2,7 +2,7 @@ import EventEmitter from "events";
 import { WebSocket, WebSocketServer } from "ws";
 import { NostrEvent, NostrFilter } from "../types/nostr";
 import {
-  NostrMessage,
+  NostrRelayMessage,
   NostrOkMessage,
   NostrEoseMessage,
 } from "../types/protocol";
@@ -10,6 +10,7 @@ import { validateEvent } from "../nip01/event";
 import { isValidPublicKeyPoint } from "../nip44";
 import {
   validateArrayAccess,
+  validateFilters,
   safeArrayAccess,
   SecurityValidationError,
 } from "./security-validator";
@@ -88,15 +89,6 @@ function createNonThrowingDiagnosticLogger(
 
 /* ================ [ Interfaces ] ================ */
 
-// Using NostrFilter from types/nostr.ts
-type EventFilter = NostrFilter;
-
-// Using NostrEvent from types/nostr.ts
-type SignedEvent = NostrEvent;
-
-// Extended type for relay events that adds a subscription id in the middle
-type NostrRelayEventMessage = ["EVENT", string, NostrEvent];
-
 /** Optional lifecycle settings for the public ephemeral Relay. */
 export interface NostrRelayOptions {
   /** Seconds between cache purges. */
@@ -106,7 +98,7 @@ export interface NostrRelayOptions {
 }
 
 interface Subscription {
-  filters: EventFilter[];
+  filters: NostrFilter[];
   instance: ClientSession;
   sub_id: string;
 }
@@ -123,7 +115,7 @@ export class NostrRelay {
 
   private _wss: WebSocketServer | null;
   private _inMemoryServer: InMemoryWebSocketServer | null = null;
-  private _cache: SignedEvent[];
+  private _cache: NostrEvent[];
   private _closePromise: Promise<void> | null = null;
   private _purgeTimer: NodeJS.Timeout | null = null;
   private _actualPort: number | null = null;
@@ -475,7 +467,7 @@ export class NostrRelay {
     });
   }
 
-  store(event: SignedEvent) {
+  store(event: NostrEvent) {
     const isSimpleReplaceable =
       event.kind === 0 ||
       event.kind === 3 ||
@@ -762,7 +754,7 @@ class ClientSession {
                   "invalid: EVENT message missing params",
                 ]);
               }
-              return this._onevent(parsed[1] as SignedEvent);
+              return this._onevent(parsed[1] as NostrEvent);
 
             case "REQ":
               if (parsed.length < 2) {
@@ -773,8 +765,14 @@ class ClientSession {
                 ]);
               }
               {
-                const sub_id = parsed[1] as string;
-                const filters = parsed.slice(2) as EventFilter[];
+                const sub_id = parsed[1];
+                if (typeof sub_id !== "string") {
+                  return this.send([
+                    "NOTICE",
+                    "invalid: REQ subscription id must be a string",
+                  ]);
+                }
+                const filters = validateFilters(parsed.slice(2));
                 return this._onreq(sub_id, filters);
               }
 
@@ -824,7 +822,7 @@ class ClientSession {
     this.log.info("socket encountered an error:\n\n", err);
   }
 
-  async _onevent(event: SignedEvent) {
+  async _onevent(event: NostrEvent) {
     try {
       // Special handling for NIP-46 events (kind 24133)
       if (event.kind === 24133) {
@@ -881,11 +879,14 @@ class ClientSession {
                 const uidParts = uid.split("/");
                 if (validateArrayAccess(uidParts, 1)) {
                   const subId = safeArrayAccess(uidParts, 1);
+                  if (typeof subId !== "string") {
+                    continue;
+                  }
                   sub.instance.send([
                     "EVENT",
                     subId,
                     event,
-                  ] as NostrRelayEventMessage);
+                  ]);
                   break;
                 }
               } catch (error) {
@@ -947,7 +948,7 @@ class ClientSession {
         for (const filter of filters) {
           if (match_filter(event, filter)) {
             instance.log.client(`event matched subscription: ${sub_id}`);
-            instance.send(["EVENT", sub_id, event] as NostrRelayEventMessage);
+            instance.send(["EVENT", sub_id, event]);
           }
         }
       }
@@ -956,7 +957,7 @@ class ClientSession {
     }
   }
 
-  _onreq(sub_id: string, filters: EventFilter[]): void {
+  _onreq(sub_id: string, filters: NostrFilter[]): void {
     if (filters.length === 0) {
       this.log.client("request has no filters");
       return;
@@ -980,7 +981,7 @@ class ClientSession {
 
         // Check if event matches filter
         if (match_filter(event, filter)) {
-          this.send(["EVENT", sub_id, event] as NostrRelayEventMessage);
+          this.send(["EVENT", sub_id, event]);
           count++;
           this.log.client(`event matched in cache: ${event.id}`);
           this.log.client(`event matched subscription: ${sub_id}`);
@@ -1017,7 +1018,7 @@ class ClientSession {
     };
   }
 
-  addSub(sub_id: string, ...filters: EventFilter[]) {
+  addSub(sub_id: string, ...filters: NostrFilter[]) {
     const uid = `${this.sid}/${sub_id}`;
     this.relay.subs.set(uid, { filters, instance: this, sub_id });
     this._subs.add(sub_id);
@@ -1033,7 +1034,7 @@ class ClientSession {
     }
   }
 
-  send(message: NostrMessage | NostrRelayEventMessage) {
+  send(message: NostrRelayMessage) {
     try {
       if (this.socket.readyState === WebSocket.OPEN) {
         this.socket.send(JSON.stringify(message));
@@ -1044,7 +1045,7 @@ class ClientSession {
   }
 
   // Method to validate NIP-46 events
-  async validateNIP46Event(event: SignedEvent): Promise<boolean> {
+  async validateNIP46Event(event: NostrEvent): Promise<boolean> {
     // Check required fields exist with proper types
     if (!isValidPublicKeyPoint(event.pubkey)) {
       this.log.debug("NIP-46 validation failed: invalid pubkey");
@@ -1135,7 +1136,7 @@ class ClientSession {
 
 /* ================ [ Methods ] ================ */
 
-function match_filter(event: SignedEvent, filter: EventFilter = {}): boolean {
+function match_filter(event: NostrEvent, filter: NostrFilter = {}): boolean {
   const { authors, ids, kinds, since, until, search, ...rest } = filter;
 
   // Extract all tag filters from rest

--- a/src/utils/ephemeral-relay.ts
+++ b/src/utils/ephemeral-relay.ts
@@ -772,7 +772,15 @@ class ClientSession {
                     "invalid: REQ subscription id must be a string",
                   ]);
                 }
-                const filters = validateFilters(parsed.slice(2));
+                let filters: NostrFilter[];
+                try {
+                  filters = validateFilters(parsed.slice(2));
+                } catch (error) {
+                  if (error instanceof SecurityValidationError) {
+                    return this.send(["NOTICE", "invalid: REQ filters"]);
+                  }
+                  throw error;
+                }
                 return this._onreq(sub_id, filters);
               }
 

--- a/tests/nip01/relay/filters.test.ts
+++ b/tests/nip01/relay/filters.test.ts
@@ -14,6 +14,7 @@ import { NostrRelay } from "../../../src/utils/ephemeral-relay";
 import { createSignedEvent } from "../../../src/nip01/event";
 import { generateKeypair } from "../../../src/utils/crypto";
 import { testUtils } from "../../types";
+import { WebSocket } from "ws";
 
 // Helper function to wait for events
 const waitForEvents = (
@@ -62,6 +63,25 @@ describe("Enhanced NostrFilter Types", () => {
 
   // Test 1: Type validation for filters with new tag types
   describe("Filter Type Validation", () => {
+    test("rejects malformed REQ filters with a stable NOTICE", async () => {
+      const socket = new WebSocket(ephemeralRelay.url);
+      await new Promise<void>((resolve, reject) => {
+        socket.once("open", resolve);
+        socket.once("error", reject);
+      });
+
+      const response = new Promise<unknown>((resolve) => {
+        socket.once("message", (data) => resolve(JSON.parse(data.toString())));
+      });
+      socket.send(JSON.stringify(["REQ", "invalid-filter", { kinds: "1" }]));
+
+      await expect(response).resolves.toEqual([
+        "NOTICE",
+        "invalid: REQ filters",
+      ]);
+      socket.close();
+    });
+
     test("should accept filters with all defined tag types", () => {
       // This test verifies TypeScript accepts the expanded type definition
       // Create a filter with all the standard tag types

--- a/tests/nip01/relay/filters.test.ts
+++ b/tests/nip01/relay/filters.test.ts
@@ -8,13 +8,13 @@ import {
   Filter,
   NostrEvent,
   NostrKind,
+  RelayEvent,
 } from "../../../src/types/nostr";
 import { Relay } from "../../../src/nip01/relay";
 import { NostrRelay } from "../../../src/utils/ephemeral-relay";
 import { createSignedEvent } from "../../../src/nip01/event";
 import { generateKeypair } from "../../../src/utils/crypto";
-import { testUtils } from "../../types";
-import { WebSocket } from "ws";
+import { asTestRelay, testUtils } from "../../types";
 
 // Helper function to wait for events
 const waitForEvents = (
@@ -64,22 +64,21 @@ describe("Enhanced NostrFilter Types", () => {
   // Test 1: Type validation for filters with new tag types
   describe("Filter Type Validation", () => {
     test("rejects malformed REQ filters with a stable NOTICE", async () => {
-      const socket = new WebSocket(ephemeralRelay.url);
-      await new Promise<void>((resolve, reject) => {
-        socket.once("open", resolve);
-        socket.once("error", reject);
+      const notice = new Promise<string>((resolve) => {
+        const handler = (_relayUrl: string, message: string) => {
+          relay.off(RelayEvent.Notice, handler);
+          resolve(message);
+        };
+        relay.on(RelayEvent.Notice, handler);
       });
 
-      const response = new Promise<unknown>((resolve) => {
-        socket.once("message", (data) => resolve(JSON.parse(data.toString())));
-      });
-      socket.send(JSON.stringify(["REQ", "invalid-filter", { kinds: "1" }]));
+      const socket = asTestRelay(relay).ws;
+      expect(socket).not.toBeNull();
+      socket?.send(
+        JSON.stringify(["REQ", "invalid-filter", { kinds: "1" }]),
+      );
 
-      await expect(response).resolves.toEqual([
-        "NOTICE",
-        "invalid: REQ filters",
-      ]);
-      socket.close();
+      await expect(notice).resolves.toBe("invalid: REQ filters");
     });
 
     test("should accept filters with all defined tag types", () => {

--- a/tests/types/protocol-message-types.test.ts
+++ b/tests/types/protocol-message-types.test.ts
@@ -1,0 +1,74 @@
+import type {
+  NostrClientMessage,
+  NostrEvent,
+  NostrMessage,
+  NostrRelayMessage,
+} from "../../src";
+
+const event = {
+  id: "0".repeat(64),
+  pubkey: "1".repeat(64),
+  created_at: 1,
+  kind: 1,
+  tags: [],
+  content: "test",
+  sig: "2".repeat(128),
+} satisfies NostrEvent;
+
+const clientMessages = [
+  ["EVENT", event],
+  ["REQ", "subscription", { kinds: [1] }],
+  ["CLOSE", "subscription"],
+  ["AUTH", event],
+] satisfies NostrClientMessage[];
+
+const relayMessages = [
+  ["EVENT", "subscription", event],
+  ["OK", event.id, true, ""],
+  ["EOSE", "subscription"],
+  ["CLOSED", "subscription", "error: unavailable"],
+  ["NOTICE", "maintenance"],
+  ["AUTH", "challenge"],
+] satisfies NostrRelayMessage[];
+
+// These assertions make directionality part of the compile-time contract.
+// @ts-expect-error Relay EVENT messages require a subscription identifier.
+const invalidRelayEvent: NostrRelayMessage = ["EVENT", event];
+// @ts-expect-error Client AUTH messages carry an event rather than a challenge.
+const invalidClientAuth: NostrClientMessage = ["AUTH", "challenge"];
+
+describe("canonical NIP-01 protocol message types", () => {
+  it("covers every supported client and relay wire tuple", () => {
+    const messages: NostrMessage[] = [...clientMessages, ...relayMessages];
+
+    expect(messages.map(([verb]) => verb)).toEqual([
+      "EVENT",
+      "REQ",
+      "CLOSE",
+      "AUTH",
+      "EVENT",
+      "OK",
+      "EOSE",
+      "CLOSED",
+      "NOTICE",
+      "AUTH",
+    ]);
+  });
+
+  it("preserves JSON tuple serialization", () => {
+    expect(JSON.parse(JSON.stringify(clientMessages[1]))).toEqual([
+      "REQ",
+      "subscription",
+      { kinds: [1] },
+    ]);
+    expect(JSON.parse(JSON.stringify(relayMessages[1]))).toEqual([
+      "OK",
+      event.id,
+      true,
+      "",
+    ]);
+  });
+});
+
+void invalidRelayEvent;
+void invalidClientAuth;


### PR DESCRIPTION
Closes #118

## Summary
- make `src/types/protocol.ts` authoritative for direction-specific client and Relay wire tuples
- migrate the main Relay and ephemeral Relay away from duplicate local message aliases
- expose protocol tuples as type-only root exports and cover serialization/directionality at compile time
- include current NIP-01 `CLOSED` and validate ephemeral Relay REQ filters at ingress

## Verification
- Jest: 73 suites, 994/994 tests
- Bun: full suite passed
- post-review focused protocol/Relay/export suites: 85/85
- commands, lint, root/examples typechecks, CJS/ESM builds, examples build, and pack verification passed

## Review
- standards/spec review passed
- local CodeRabbit: 4 findings fixed, 1 skipped with strict-type evidence
- Grok delegation unavailable because the required CLI is unauthenticated; no substitute subagent used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded protocol typings with `CLOSED` and direction-specific authentication messages.
  * Re-exported protocol message/transport types for public TypeScript use.
* **Refactor**
  * Updated relay and ephemeral relay internals to rely on canonical protocol message types, with stricter runtime request/filter handling.
* **Documentation**
  * Added review/session run documentation describing the protocol changes and verification results.
* **Tests**
  * Added type + runtime Jest coverage for supported message tuples, JSON round-tripping, and invalid directionality cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->