### PR TITLE
refactor: extract Relay event store

### DIFF
--- a/docs/agents/runs/deep-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/deep-cleanup-1-8-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, rebased from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: issue #112 merged into `staging`; issue #118 implementation in progress
+- Current status: issues #112 and #118 merged into `staging`; issue #113 implementation in progress
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, single-context domain docs)
 
 ## Goal
@@ -27,7 +27,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 - Agent briefs: Grok 4.5 is the only owner-approved delegated sidecar; `agent` authentication was unavailable at preflight, so no substitute subagent is used and Codex owns local execution/review
 - Review packets: created per ticket
 - Local CodeRabbit report: issue #112 round completed with five worthy fixes in `issue-112-coderabbit-local.md`
-- PR URLs: #120 for issue #112 (merged); later tickets pending
+- PR URLs: #120 for issue #112 (merged), #121 for issue #118 (merged); later tickets pending
 
 ## Commands
 
@@ -42,8 +42,8 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 | Issue | Type | Status | Branch | Review | Verified |
 | --- | --- | --- | --- | --- | --- |
 | #112 NIP-44 legacy behavior | AFK | merged into `staging` | `feature/nip44-legacy-compat` | standards/spec pass; local CodeRabbit 5 fixed; hosted CodeRabbit 3 fixed | yes |
-| #118 authoritative protocol messages | AFK | implementation and local review verified | `feature/protocol-message-types` | standards/spec pass; local CodeRabbit 4 fixed, 1 evidence-based skip | Jest 994/994; Bun full; post-review focused 85/85; commands, lint, types, builds, pack |
-| #113 Relay event-store seam | AFK | blocked by #118 | `feature/relay-event-store` | pending | no |
+| #118 authoritative protocol messages | AFK | merged into `staging` | `feature/protocol-message-types` | standards/spec pass; local CodeRabbit 4 fixed, 1 evidence-based skip; hosted 2 fixed | Jest 994/994; Bun full; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
+| #113 Relay event-store seam | AFK | implementation, local review, and full matrix verified | `feature/relay-event-store` | standards/spec pass; local CodeRabbit 4 fixed | focused Jest/Bun 80/80; full Jest/Bun 1013/1013; commands, lint, types, builds, pack |
 | #114 NIP-47 protocol machinery | AFK | blocked by #118 | `feature/nip47-protocol-codecs` | pending | no |
 | #115 Nostr relay registry | AFK | blocked by #113 | `feature/nostr-relay-registry` | pending | no |
 | #116 ephemeral Relay ownership | AFK | blocked by #113 | `feature/ephemeral-relay-ownership` | pending | no |
@@ -61,7 +61,8 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 | Issue | Fixed point | Implementation owner | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
 | #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | PR #120, merge `c7cb99f` | standards/spec pass after one fix; local CodeRabbit 5/5 and hosted CodeRabbit 3/3 fixed | NIP-44 107/107; Jest 991/991; Bun 991/991; hosted Node 16/18/20 + Bun; lint, types, builds, commands, pack |
-| #118 | `c7cb99f` | current Codex orchestrator; Grok unavailable at auth preflight | pending | standards/spec pass; local CodeRabbit 4 fixed, 1 skipped with type evidence | targeted 60/60; Jest 994/994; Bun full; post-review focused 85/85; commands, lint, types, builds, pack |
+| #118 | `c7cb99f` | current Codex orchestrator; Grok unavailable at auth preflight | PR #121, merge `8c36233` | standards/spec pass; local CodeRabbit 4 fixed, 1 skipped with type evidence; hosted 2/2 fixed | Jest 994/994; Bun full; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
+| #113 | `8c36233` | current Codex orchestrator; Grok unavailable at auth preflight | pending | standards/spec pass; local CodeRabbit 4/4 fixed | focused Relay/store Jest and Bun 80/80; full Jest/Bun 1013/1013; commands, lint, types, builds, pack |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/issue-113-coderabbit-local.md
+++ b/docs/agents/runs/issue-113-coderabbit-local.md
@@ -1,0 +1,24 @@
+# CodeRabbit Round: #113 Local Branch
+
+## Round
+
+- Scope: local
+- Round number: 1
+- Command: `coderabbit review --agent --type all --base staging`
+- Completed: 2026-07-18
+- Findings: 4
+
+## Decisions
+
+| Finding | Decision | Notes |
+| --- | --- | --- |
+| Disconnect cleanup occurred after the no-socket early return, and late validation could repopulate retained state | fixed | Common teardown now precedes the early return; validation results are accepted only for the same still-active subscription. |
+| Bulk addressable reads did not refresh matching entries' LRU timestamps | fixed | Both bulk queries use one collection path that refreshes only matching addresses. |
+| Capacity options accepted zero, non-finite, fractional, negative, and unsafe values | fixed | All five capacities require positive safe integers and retain defaults when omitted. |
+| Deterministic coverage omitted invalid capacities, per-pubkey kind eviction, and bulk-read LRU refresh | fixed | Focused store tests now cover all three policy paths. |
+
+## Result
+
+- Worthy findings fixed: 4
+- Findings skipped: 0
+- Post-fix verification: lint and strict typecheck pass; focused Relay/store/order/addressability suites pass 80/80 in both Jest and Bun

--- a/docs/agents/runs/issue-113-review-packet.md
+++ b/docs/agents/runs/issue-113-review-packet.md
@@ -1,0 +1,50 @@
+# Review Packet: #113 Relay Event Store
+
+## Fixed Point
+
+- Base: `staging` at `8c36233`
+- Branch: `feature/relay-event-store`
+- Issue: #113
+
+## Change Story
+
+- A focused internal `RelayEventStore` owns event buffers, sorting, capacity, LRU eviction, and replaceable/addressable retention.
+- Relay retains network lifecycle, validation, subscription state, EOSE coordination, timers, and callback delivery.
+- Existing private storage maps and eviction algorithms are removed from Relay.
+- Ordering tests call the authoritative policy rather than duplicating its comparator.
+- Deterministic unit tests cover buffer ordering/capacity/LRU, replaceable tie-breaking, address keys/capacity, misses, and clearing.
+
+## Compatibility
+
+- Public Relay methods and constructor options are unchanged.
+- Valid event delivery and EOSE ordering remain covered through Relay integration tests.
+- Storage lookup methods retain their public signatures.
+- The internal store is not part of the package export surface.
+
+## Review Axes
+
+### Standards
+
+- The extracted module owns a cohesive policy rather than merely moving helper functions.
+- Relay depends on a small retention API and no longer owns maps, capacity counters, or eviction loops.
+- Clock and eviction diagnostics are injected at the deterministic boundary.
+
+### Specification
+
+- Buffered delivery is newest-first, then lowest event ID.
+- Replaceable and addressable timestamp ties retain the lowest event ID.
+- Addressable identity is kind, pubkey, and `d` tag.
+- Public delivery, EOSE, and storage tests remain green.
+
+## Verification
+
+- Focused Jest/Bun after local review: 80/80 each
+- Lint and strict typecheck: pass
+- Jest: 74 suites, 1013/1013
+- Bun: 1013/1013
+- Commands, lint, root/examples typechecks, CJS/ESM build, examples build, and pack verification: pass
+- Local CodeRabbit: 4/4 findings fixed; hosted review pending
+
+## Known Tooling Limitation
+
+- Grok could not be delegated because the required `agent` CLI is unauthenticated. Per the Grok skill, no substitute subagent was used.

--- a/docs/agents/runs/issue-113-session.md
+++ b/docs/agents/runs/issue-113-session.md
@@ -1,0 +1,34 @@
+# Issue Session: #113 Relay Event Store
+
+## Scope
+
+- Fixed point: `8c36233` (`staging` after PR #121)
+- Branch: `feature/relay-event-store`
+- Issue: #113
+- Owner: current Codex orchestrator; Grok unavailable because `agent` authentication is required
+
+## Acceptance Map
+
+| Acceptance criterion | Implementation / verification seam |
+| --- | --- |
+| Preserve public Relay behavior and EOSE/order/storage semantics | existing Relay integration suites plus focused store tests |
+| One owner for limits, eviction, replacement, addressability, and ordering | `src/nip01/relayEventStore.ts` |
+| Remove storage implementation detail from Relay | Relay holds one store and delegates retention decisions |
+| Exercise public behavior and deterministic module behavior | existing public Relay tests and `relayEventStore.test.ts` |
+| Full verification matrix | completed; see verification results below |
+
+## Decisions
+
+- Keep connection lifecycle, validation coordination, EOSE state, timers, subscriptions, and callback delivery in `Relay`.
+- Move only deterministic buffering and retained-event policy into the internal store.
+- Inject the clock and eviction observer so capacity behavior is deterministic and directly testable.
+- Apply NIP-01's lower-ID tie-break to replaceable events as well as addressable events.
+- Do not export the internal store from the package entrypoints.
+
+## Verification
+
+- Strict typecheck and lint: pass
+- Focused Relay, ordering, addressability, and store suites after review: Jest 80/80 and Bun 80/80
+- Full Jest: 74 suites, 1013/1013 pass
+- Full Bun: 1013/1013 pass
+- Commands, lint, root/examples typecheck, CJS/ESM build, examples build, and pack verification: pass

--- a/src/nip01/relay.ts
+++ b/src/nip01/relay.ts
@@ -24,11 +24,7 @@ import {
 } from "../types/protocol";
 import { NostrValidationError, validateRelayIngressEvent } from "./validation";
 import { Logger, LogLevel } from "../utils/logger";
-import {
-  SECURITY_LIMITS,
-  getSecureRandom,
-  secureRandomHex,
-} from "../utils/security-validator";
+import { getSecureRandom, secureRandomHex } from "../utils/security-validator";
 import { maybeUnref } from "../utils/timers";
 import {
   BivariantHandler,
@@ -37,6 +33,7 @@ import {
   ErrorEventLike,
   MessageEventLike,
 } from "../utils/websocket-types";
+import { RelayEventStore } from "./relayEventStore";
 
 type WebSocketLike = {
   readyState: number;
@@ -78,11 +75,9 @@ export class Relay {
   } | null = null;
   private connectionTimeout = 10000; // Default timeout of 10 seconds
   private logger: Logger;
-  // Event buffers with memory limits
-  private eventBuffers: Map<string, NostrEvent[]> = new Map();
-  private eventBufferAccessTimes: Map<string, number> = new Map(); // For LRU eviction
-  private maxEventBuffers = SECURITY_LIMITS.MAX_RELAY_EVENT_BUFFERS;
-  private maxEventsPerBuffer = SECURITY_LIMITS.MAX_EVENTS_PER_BUFFER;
+  private readonly eventStore = new RelayEventStore({
+    onEviction: (message) => this.logger.debug(message),
+  });
   private bufferFlushInterval: NodeJS.Timeout | null = null;
   private bufferFlushDelay = 50; // ms to wait before flushing event buffer
   // Reconnection parameters
@@ -93,17 +88,6 @@ export class Relay {
   private maxReconnectDelay = 30000; // Maximum delay between reconnect attempts (ms)
   private maxFutureTimestampDrift = 60 * 60; // Maximum accepted future event timestamp drift (s)
   private maxPastTimestampDrift = 0; // Maximum accepted past event timestamp drift (s); 0 disables this check
-  // Track replaceable and addressable events according to NIP-01 with memory limits
-  private replaceableEvents: Map<string, Map<number, NostrEvent>> = new Map();
-  private replaceableEventAccessTimes: Map<string, number> = new Map(); // For LRU eviction
-  private maxReplaceableEventPubkeys =
-    SECURITY_LIMITS.MAX_REPLACEABLE_EVENT_PUBKEYS;
-  private maxReplaceableEventsPerPubkey =
-    SECURITY_LIMITS.MAX_REPLACEABLE_EVENTS_PER_PUBKEY;
-
-  private addressableEvents: Map<string, NostrEvent> = new Map();
-  private addressableEventAccessTimes: Map<string, number> = new Map(); // For LRU eviction
-  private maxAddressableEvents = SECURITY_LIMITS.MAX_ADDRESSABLE_EVENTS;
   private pendingValidationCounts: Map<string, number> = new Map();
   private pendingEoseSubscriptions: Set<string> = new Set();
 
@@ -388,33 +372,20 @@ export class Relay {
 
     // Cancel any scheduled reconnection
     this.cancelReconnect();
+    this.subscriptions.clear();
+    this.eventStore.clear();
+    this.pendingValidationCounts.clear();
+    this.pendingEoseSubscriptions.clear();
+    this.clearBufferFlush();
 
     if (!this.ws) {
       this.connected = false;
-      this.clearBufferFlush();
       return;
     }
 
     try {
       // Detach handlers first so any late socket events don't fire callbacks after teardown.
       this.detachSocketHandlers(this.ws);
-
-      // Clear all subscriptions to prevent further processing
-      this.subscriptions.clear();
-
-      // Clear event buffers and access times
-      this.eventBuffers.clear();
-      this.eventBufferAccessTimes.clear();
-
-      // Clear replaceable event storage and access times
-      this.replaceableEvents.clear();
-      this.replaceableEventAccessTimes.clear();
-
-      // Clear addressable event storage and access times
-      this.addressableEvents.clear();
-      this.addressableEventAccessTimes.clear();
-
-      this.clearBufferFlush(); // Clear the buffer flush interval
 
       // Close the WebSocket if it's open or connecting
       if (
@@ -869,7 +840,7 @@ export class Relay {
     }
 
     this.subscriptions.set(id, subscription);
-    this.eventBuffers.set(id, []); // Initialize an empty event buffer for this subscription
+    this.eventStore.initializeBuffer(id);
 
     if (this.connected && this.ws) {
       const message: NostrReqMessage = ["REQ", id, ...filters];
@@ -886,8 +857,7 @@ export class Relay {
       clearTimeout(subscription.eoseTimer);
     }
     this.subscriptions.delete(id);
-    this.eventBuffers.delete(id); // Clean up the event buffer for this subscription
-    this.eventBufferAccessTimes.delete(id); // Clean up the access time tracking
+    this.eventStore.deleteBuffer(id);
     this.pendingEoseSubscriptions.delete(id);
     this.pendingValidationCounts.delete(id);
 
@@ -915,10 +885,18 @@ export class Relay {
           break;
         }
 
+        const subscriptionAtIngress = this.subscriptions.get(subscriptionId);
+        if (!subscriptionAtIngress) break;
+
         this.incrementPendingValidation(subscriptionId);
 
         this.validateInboundEvent(event)
           .then((validatedEvent) => {
+            if (
+              this.subscriptions.get(subscriptionId) !== subscriptionAtIngress
+            ) {
+              return;
+            }
             this.processValidatedEvent(validatedEvent, subscriptionId);
           })
           .catch((error) => {
@@ -1020,6 +998,9 @@ export class Relay {
     event: NostrEvent,
     subscriptionId: string,
   ): void {
+    const subscription = this.subscriptions.get(subscriptionId);
+    if (!subscription) return;
+
     // Process replaceable events (kinds 0, 3, 10000-19999)
     if (
       event.kind === 0 ||
@@ -1033,12 +1014,8 @@ export class Relay {
       this.processAddressableEvent(event);
     }
 
-    const subscription = this.subscriptions.get(subscriptionId);
-    if (subscription) {
-      // Use the proper buffer management method that enforces memory limits and LRU eviction
-      this.addToEventBuffer(subscriptionId, event);
-      this.maybeFinalizeEOSE(subscriptionId);
-    }
+    this.addToEventBuffer(subscriptionId, event);
+    this.maybeFinalizeEOSE(subscriptionId);
   }
 
   private validateInboundEvent(event: unknown): Promise<NostrEvent> {
@@ -1160,7 +1137,7 @@ export class Relay {
    * Flush all event buffers for all subscriptions
    */
   private flushAllBuffers(): void {
-    for (const subscriptionId of this.eventBuffers.keys()) {
+    for (const subscriptionId of this.eventStore.bufferIds()) {
       this.flushSubscriptionBuffer(subscriptionId);
     }
   }
@@ -1217,25 +1194,16 @@ export class Relay {
    * Flush the event buffer for a specific subscription
    */
   private flushSubscriptionBuffer(subscriptionId: string): void {
-    const buffer = this.eventBuffers.get(subscriptionId);
-    if (!buffer || buffer.length === 0) return;
+    const events = this.eventStore.drainBuffer(subscriptionId);
+    if (events.length === 0) return;
 
     const subscription = this.subscriptions.get(subscriptionId);
     if (!subscription) {
-      // If the subscription has been removed, clear the buffer
-      this.eventBuffers.delete(subscriptionId);
       return;
     }
 
-    // Sort the events according to NIP-01: newest first, then by lexical order of ID if same timestamp
-    const sortedEvents = this.sortEvents(buffer);
-
-    // Remove the buffer from the map instead of keeping an empty array
-    this.eventBuffers.delete(subscriptionId);
-    this.eventBufferAccessTimes.delete(subscriptionId);
-
     // Process all events
-    for (const event of sortedEvents) {
+    for (const event of events) {
       try {
         subscription.onEvent(event);
       } catch (error) {
@@ -1247,189 +1215,19 @@ export class Relay {
     }
   }
 
-  /**
-   * Sort events according to NIP-01 specification:
-   * 1. created_at timestamp (descending - newer events first)
-   * 2. event id (lexical ascending) if timestamps are the same
-   */
-  private sortEvents(events: NostrEvent[]): NostrEvent[] {
-    return [...events].sort((a, b) => {
-      // Sort by created_at (descending - newer events first)
-      if (a.created_at !== b.created_at) {
-        return b.created_at - a.created_at;
-      }
-      // If created_at is the same, sort by id (ascending lexical order)
-      // This ensures lower IDs win when timestamps match, consistent with NIP-01 replaceable/addressable events.
-      return a.id.localeCompare(b.id);
-    });
-  }
-
   // Add event to buffer with memory limits
   private addToEventBuffer(subscriptionId: string, event: NostrEvent): void {
-    // Update access time for LRU
-    this.eventBufferAccessTimes.set(subscriptionId, Date.now());
-
-    // Ensure we don't exceed max number of buffers
-    if (
-      !this.eventBuffers.has(subscriptionId) &&
-      this.eventBuffers.size >= this.maxEventBuffers
-    ) {
-      this.evictOldestEventBuffer();
-    }
-
-    // Get or create buffer
-    if (!this.eventBuffers.has(subscriptionId)) {
-      this.eventBuffers.set(subscriptionId, []);
-    }
-
-    const buffer = this.eventBuffers.get(subscriptionId)!;
-
-    // Ensure we don't exceed max events per buffer
-    if (buffer.length >= this.maxEventsPerBuffer) {
-      buffer.shift(); // Remove oldest event
-    }
-
-    buffer.push(event);
-  }
-
-  // Evict oldest accessed event buffer
-  private evictOldestEventBuffer(): void {
-    let oldestTime = Infinity;
-    let oldestId = "";
-
-    for (const [id, time] of this.eventBufferAccessTimes) {
-      if (time < oldestTime) {
-        oldestTime = time;
-        oldestId = id;
-      }
-    }
-
-    if (oldestId) {
-      this.eventBuffers.delete(oldestId);
-      this.eventBufferAccessTimes.delete(oldestId);
-      this.logger.debug(`Evicted event buffer for subscription: ${oldestId}`);
-    }
+    this.eventStore.addToBuffer(subscriptionId, event);
   }
 
   // Process replaceable event with memory limits
   private processReplaceableEvent(event: NostrEvent): void {
-    const pubkey = event.pubkey;
-
-    // Update access time for LRU
-    this.replaceableEventAccessTimes.set(pubkey, Date.now());
-
-    // Ensure we don't exceed max pubkeys
-    if (
-      !this.replaceableEvents.has(pubkey) &&
-      this.replaceableEvents.size >= this.maxReplaceableEventPubkeys
-    ) {
-      this.evictOldestReplaceablePubkey();
-    }
-
-    // Get or create pubkey map
-    if (!this.replaceableEvents.has(pubkey)) {
-      this.replaceableEvents.set(pubkey, new Map());
-    }
-
-    const kindMap = this.replaceableEvents.get(pubkey)!;
-    const existingEvent = kindMap.get(event.kind);
-
-    // Only store if newer or first of this kind
-    if (!existingEvent || event.created_at > existingEvent.created_at) {
-      // Ensure we don't exceed max events per pubkey
-      if (
-        kindMap.size >= this.maxReplaceableEventsPerPubkey &&
-        !kindMap.has(event.kind)
-      ) {
-        // Remove oldest event by created_at
-        let oldestKind = -1;
-        let oldestTime = Infinity;
-        for (const [kind, evt] of kindMap) {
-          if (evt.created_at < oldestTime) {
-            oldestTime = evt.created_at;
-            oldestKind = kind;
-          }
-        }
-        if (oldestKind !== -1) {
-          kindMap.delete(oldestKind);
-          this.logger.debug(
-            `Evicted replaceable event kind ${oldestKind} for pubkey: ${pubkey}`,
-          );
-        }
-      }
-
-      kindMap.set(event.kind, event);
-    }
-  }
-
-  // Evict oldest accessed replaceable event pubkey
-  private evictOldestReplaceablePubkey(): void {
-    let oldestTime = Infinity;
-    let oldestPubkey = "";
-
-    for (const [pubkey, time] of this.replaceableEventAccessTimes) {
-      if (time < oldestTime) {
-        oldestTime = time;
-        oldestPubkey = pubkey;
-      }
-    }
-
-    if (oldestPubkey) {
-      this.replaceableEvents.delete(oldestPubkey);
-      this.replaceableEventAccessTimes.delete(oldestPubkey);
-      this.logger.debug(
-        `Evicted replaceable events for pubkey: ${oldestPubkey}`,
-      );
-    }
+    this.eventStore.storeReplaceable(event);
   }
 
   // Process addressable event with memory limits
   private processAddressableEvent(event: NostrEvent): void {
-    const dTag = event.tags.find((tag) => tag[0] === "d");
-    const dValue = dTag ? dTag[1] : "";
-    const addressId = `${event.kind}:${event.pubkey}:${dValue}`;
-
-    // Update access time for LRU
-    this.addressableEventAccessTimes.set(addressId, Date.now());
-
-    // Ensure we don't exceed max addressable events
-    if (
-      !this.addressableEvents.has(addressId) &&
-      this.addressableEvents.size >= this.maxAddressableEvents
-    ) {
-      this.evictOldestAddressableEvent();
-    }
-
-    const existingEvent = this.addressableEvents.get(addressId);
-
-    // Only store if newer, first, or tie-breaker with smaller ID
-    if (
-      !existingEvent ||
-      event.created_at > existingEvent.created_at ||
-      (event.created_at === existingEvent.created_at &&
-        event.id < existingEvent.id)
-    ) {
-      this.addressableEvents.set(addressId, event);
-    }
-  }
-
-  // Evict oldest accessed addressable event
-  private evictOldestAddressableEvent(): void {
-    let oldestTime = Infinity;
-    let oldestId = "";
-
-    for (const [id, time] of this.addressableEventAccessTimes) {
-      if (time < oldestTime) {
-        oldestTime = time;
-        oldestId = id;
-      }
-    }
-
-    if (oldestId) {
-      this.addressableEvents.delete(oldestId);
-      this.addressableEventAccessTimes.delete(oldestId);
-      this.logger.debug(`Evicted addressable event: ${oldestId}`);
-    }
+    this.eventStore.storeAddressable(event);
   }
 
   // Update getLatestReplaceableEvent to use access tracking
@@ -1437,11 +1235,7 @@ export class Relay {
     pubkey: string,
     kind: number,
   ): NostrEvent | undefined {
-    // Update access time
-    this.replaceableEventAccessTimes.set(pubkey, Date.now());
-
-    const kindMap = this.replaceableEvents.get(pubkey);
-    return kindMap?.get(kind);
+    return this.eventStore.getReplaceable(pubkey, kind);
   }
 
   // Update getLatestAddressableEvent to use access tracking
@@ -1450,12 +1244,7 @@ export class Relay {
     pubkey: string,
     dTagValue: string = "",
   ): NostrEvent | undefined {
-    const addressId = `${kind}:${pubkey}:${dTagValue}`;
-
-    // Update access time
-    this.addressableEventAccessTimes.set(addressId, Date.now());
-
-    return this.addressableEvents.get(addressId);
+    return this.eventStore.getAddressable(kind, pubkey, dTagValue);
   }
 
   /**
@@ -1465,9 +1254,7 @@ export class Relay {
    * @returns Array of addressable events
    */
   public getAddressableEventsByPubkey(pubkey: string): NostrEvent[] {
-    return Array.from(this.addressableEvents.values()).filter(
-      (event) => event.pubkey === pubkey,
-    );
+    return this.eventStore.getAddressableByPubkey(pubkey);
   }
 
   /**
@@ -1477,9 +1264,7 @@ export class Relay {
    * @returns Array of addressable events
    */
   public getAddressableEventsByKind(kind: number): NostrEvent[] {
-    return Array.from(this.addressableEvents.values()).filter(
-      (event) => event.kind === kind,
-    );
+    return this.eventStore.getAddressableByKind(kind);
   }
 
   // Helper function to parse NIP-20 prefixes from OK messages

--- a/src/nip01/relayEventStore.ts
+++ b/src/nip01/relayEventStore.ts
@@ -1,0 +1,280 @@
+import { NostrEvent } from "../types/nostr";
+import { SECURITY_LIMITS } from "../utils/security-validator";
+
+export interface RelayEventStoreOptions {
+  maxEventBuffers?: number;
+  maxEventsPerBuffer?: number;
+  maxReplaceableEventPubkeys?: number;
+  maxReplaceableEventsPerPubkey?: number;
+  maxAddressableEvents?: number;
+  now?: () => number;
+  onEviction?: (message: string) => void;
+}
+
+/**
+ * Owns deterministic, in-memory Relay buffering and replaceable/addressable
+ * event retention policy. Connection lifecycle and callback delivery remain in
+ * Relay; this module only decides what is retained and in which order.
+ */
+export class RelayEventStore {
+  private readonly eventBuffers = new Map<string, NostrEvent[]>();
+  private readonly eventBufferAccessTimes = new Map<string, number>();
+  private readonly replaceableEvents = new Map<
+    string,
+    Map<number, NostrEvent>
+  >();
+  private readonly replaceableEventAccessTimes = new Map<string, number>();
+  private readonly addressableEvents = new Map<string, NostrEvent>();
+  private readonly addressableEventAccessTimes = new Map<string, number>();
+
+  private readonly maxEventBuffers: number;
+  private readonly maxEventsPerBuffer: number;
+  private readonly maxReplaceableEventPubkeys: number;
+  private readonly maxReplaceableEventsPerPubkey: number;
+  private readonly maxAddressableEvents: number;
+  private readonly now: () => number;
+  private readonly onEviction: (message: string) => void;
+
+  constructor(options: RelayEventStoreOptions = {}) {
+    this.maxEventBuffers = RelayEventStore.capacity(
+      "maxEventBuffers",
+      options.maxEventBuffers,
+      SECURITY_LIMITS.MAX_RELAY_EVENT_BUFFERS,
+    );
+    this.maxEventsPerBuffer = RelayEventStore.capacity(
+      "maxEventsPerBuffer",
+      options.maxEventsPerBuffer,
+      SECURITY_LIMITS.MAX_EVENTS_PER_BUFFER,
+    );
+    this.maxReplaceableEventPubkeys = RelayEventStore.capacity(
+      "maxReplaceableEventPubkeys",
+      options.maxReplaceableEventPubkeys,
+      SECURITY_LIMITS.MAX_REPLACEABLE_EVENT_PUBKEYS,
+    );
+    this.maxReplaceableEventsPerPubkey = RelayEventStore.capacity(
+      "maxReplaceableEventsPerPubkey",
+      options.maxReplaceableEventsPerPubkey,
+      SECURITY_LIMITS.MAX_REPLACEABLE_EVENTS_PER_PUBKEY,
+    );
+    this.maxAddressableEvents = RelayEventStore.capacity(
+      "maxAddressableEvents",
+      options.maxAddressableEvents,
+      SECURITY_LIMITS.MAX_ADDRESSABLE_EVENTS,
+    );
+    this.now = options.now ?? Date.now;
+    this.onEviction = options.onEviction ?? (() => {});
+  }
+
+  clear(): void {
+    this.eventBuffers.clear();
+    this.eventBufferAccessTimes.clear();
+    this.replaceableEvents.clear();
+    this.replaceableEventAccessTimes.clear();
+    this.addressableEvents.clear();
+    this.addressableEventAccessTimes.clear();
+  }
+
+  initializeBuffer(subscriptionId: string): void {
+    if (this.eventBuffers.has(subscriptionId)) return;
+    this.ensureBufferCapacity();
+    this.eventBuffers.set(subscriptionId, []);
+    this.eventBufferAccessTimes.set(subscriptionId, this.now());
+  }
+
+  deleteBuffer(subscriptionId: string): void {
+    this.eventBuffers.delete(subscriptionId);
+    this.eventBufferAccessTimes.delete(subscriptionId);
+  }
+
+  bufferIds(): IterableIterator<string> {
+    return this.eventBuffers.keys();
+  }
+
+  addToBuffer(subscriptionId: string, event: NostrEvent): void {
+    this.initializeBuffer(subscriptionId);
+    this.eventBufferAccessTimes.set(subscriptionId, this.now());
+    const buffer = this.eventBuffers.get(subscriptionId)!;
+    if (buffer.length >= this.maxEventsPerBuffer) {
+      buffer.shift();
+    }
+    buffer.push(event);
+  }
+
+  drainBuffer(subscriptionId: string): NostrEvent[] {
+    const buffer = this.eventBuffers.get(subscriptionId);
+    if (!buffer || buffer.length === 0) return [];
+    this.deleteBuffer(subscriptionId);
+    return RelayEventStore.sortEvents(buffer);
+  }
+
+  static sortEvents(events: readonly NostrEvent[]): NostrEvent[] {
+    return [...events].sort((a, b) => {
+      if (a.created_at !== b.created_at) {
+        return b.created_at - a.created_at;
+      }
+      return a.id.localeCompare(b.id);
+    });
+  }
+
+  storeReplaceable(event: NostrEvent): void {
+    const pubkey = event.pubkey;
+    if (
+      !this.replaceableEvents.has(pubkey) &&
+      this.replaceableEvents.size >= this.maxReplaceableEventPubkeys
+    ) {
+      this.evictOldestReplaceablePubkey();
+    }
+    this.replaceableEventAccessTimes.set(pubkey, this.now());
+
+    let kindMap = this.replaceableEvents.get(pubkey);
+    if (!kindMap) {
+      kindMap = new Map();
+      this.replaceableEvents.set(pubkey, kindMap);
+    }
+    const existing = kindMap.get(event.kind);
+    if (existing && !RelayEventStore.shouldReplace(existing, event)) return;
+
+    if (
+      !kindMap.has(event.kind) &&
+      kindMap.size >= this.maxReplaceableEventsPerPubkey
+    ) {
+      const oldest = [...kindMap.entries()].sort(
+        ([kindA, eventA], [kindB, eventB]) =>
+          eventA.created_at - eventB.created_at ||
+          eventB.id.localeCompare(eventA.id) ||
+          kindA - kindB,
+      )[0];
+      if (oldest) {
+        kindMap.delete(oldest[0]);
+        this.onEviction(
+          `Evicted replaceable event kind ${oldest[0]} for pubkey: ${pubkey}`,
+        );
+      }
+    }
+    kindMap.set(event.kind, event);
+  }
+
+  getReplaceable(pubkey: string, kind: number): NostrEvent | undefined {
+    const event = this.replaceableEvents.get(pubkey)?.get(kind);
+    if (event) {
+      this.replaceableEventAccessTimes.set(pubkey, this.now());
+    }
+    return event;
+  }
+
+  storeAddressable(event: NostrEvent): void {
+    const address = RelayEventStore.addressFor(event);
+    if (
+      !this.addressableEvents.has(address) &&
+      this.addressableEvents.size >= this.maxAddressableEvents
+    ) {
+      this.evictOldestAddressableEvent();
+    }
+    this.addressableEventAccessTimes.set(address, this.now());
+    const existing = this.addressableEvents.get(address);
+    if (!existing || RelayEventStore.shouldReplace(existing, event)) {
+      this.addressableEvents.set(address, event);
+    }
+  }
+
+  getAddressable(
+    kind: number,
+    pubkey: string,
+    dTagValue = "",
+  ): NostrEvent | undefined {
+    const address = `${kind}:${pubkey}:${dTagValue}`;
+    const event = this.addressableEvents.get(address);
+    if (event) {
+      this.addressableEventAccessTimes.set(address, this.now());
+    }
+    return event;
+  }
+
+  getAddressableByPubkey(pubkey: string): NostrEvent[] {
+    return this.collectAddressable((event) => event.pubkey === pubkey);
+  }
+
+  getAddressableByKind(kind: number): NostrEvent[] {
+    return this.collectAddressable((event) => event.kind === kind);
+  }
+
+  private collectAddressable(
+    matches: (event: NostrEvent) => boolean,
+  ): NostrEvent[] {
+    const events: NostrEvent[] = [];
+    for (const [address, event] of this.addressableEvents) {
+      if (matches(event)) {
+        this.addressableEventAccessTimes.set(address, this.now());
+        events.push(event);
+      }
+    }
+    return events;
+  }
+
+  private static capacity(
+    name: string,
+    value: number | undefined,
+    fallback: number,
+  ): number {
+    const capacity = value ?? fallback;
+    if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+      throw new RangeError(`${name} must be a positive safe integer`);
+    }
+    return capacity;
+  }
+
+  private static shouldReplace(
+    existing: NostrEvent,
+    candidate: NostrEvent,
+  ): boolean {
+    return (
+      candidate.created_at > existing.created_at ||
+      (candidate.created_at === existing.created_at &&
+        candidate.id < existing.id)
+    );
+  }
+
+  private static addressFor(event: NostrEvent): string {
+    const dValue = event.tags.find((tag) => tag[0] === "d")?.[1] ?? "";
+    return `${event.kind}:${event.pubkey}:${dValue}`;
+  }
+
+  private ensureBufferCapacity(): void {
+    if (this.eventBuffers.size < this.maxEventBuffers) return;
+    const oldest = this.oldestAccess(this.eventBufferAccessTimes);
+    if (oldest) {
+      this.deleteBuffer(oldest);
+      this.onEviction(`Evicted event buffer for subscription: ${oldest}`);
+    }
+  }
+
+  private evictOldestReplaceablePubkey(): void {
+    const oldest = this.oldestAccess(this.replaceableEventAccessTimes);
+    if (oldest) {
+      this.replaceableEvents.delete(oldest);
+      this.replaceableEventAccessTimes.delete(oldest);
+      this.onEviction(`Evicted replaceable events for pubkey: ${oldest}`);
+    }
+  }
+
+  private evictOldestAddressableEvent(): void {
+    const oldest = this.oldestAccess(this.addressableEventAccessTimes);
+    if (oldest) {
+      this.addressableEvents.delete(oldest);
+      this.addressableEventAccessTimes.delete(oldest);
+      this.onEviction(`Evicted addressable event: ${oldest}`);
+    }
+  }
+
+  private oldestAccess(accessTimes: ReadonlyMap<string, number>): string {
+    let oldestKey = "";
+    let oldestTime = Infinity;
+    for (const [key, time] of accessTimes) {
+      if (time < oldestTime || (time === oldestTime && key < oldestKey)) {
+        oldestKey = key;
+        oldestTime = time;
+      }
+    }
+    return oldestKey;
+  }
+}

--- a/tests/nip01/event/addressable-events.test.ts
+++ b/tests/nip01/event/addressable-events.test.ts
@@ -71,8 +71,8 @@ describe("Addressable Events (NIP-01 §7.1)", () => {
 
   test("Different d-tag values create separate addressable events", async () => {
     // Process events with same pubkey and kind but different d-tag values
-    testRelay.processValidatedEvent(testEvents.event1, "sub1");
-    testRelay.processValidatedEvent(testEvents.event2, "sub1");
+    testRelay.eventStore.storeAddressable(testEvents.event1);
+    testRelay.eventStore.storeAddressable(testEvents.event2);
 
     // Get latest events for each d-tag value
     const latest1 = relay.getLatestAddressableEvent(
@@ -96,10 +96,10 @@ describe("Addressable Events (NIP-01 §7.1)", () => {
 
   test("Newer event with same d-tag replaces older one", async () => {
     // Process original event
-    testRelay.processValidatedEvent(testEvents.event1, "sub1");
+    testRelay.eventStore.storeAddressable(testEvents.event1);
 
     // Process newer event with same d-tag
-    testRelay.processValidatedEvent(testEvents.event3, "sub1");
+    testRelay.eventStore.storeAddressable(testEvents.event3);
 
     // Get latest event
     const latest = relay.getLatestAddressableEvent(
@@ -115,8 +115,8 @@ describe("Addressable Events (NIP-01 §7.1)", () => {
 
   test("Different kinds with same d-tag are stored separately", async () => {
     // Process events with same pubkey and d-tag but different kinds
-    testRelay.processValidatedEvent(testEvents.event1, "sub1");
-    testRelay.processValidatedEvent(testEvents.event4, "sub1");
+    testRelay.eventStore.storeAddressable(testEvents.event1);
+    testRelay.eventStore.storeAddressable(testEvents.event4);
 
     // Get latest events for each kind
     const latest1 = relay.getLatestAddressableEvent(

--- a/tests/nip01/event/event-ordering-integration.test.ts
+++ b/tests/nip01/event/event-ordering-integration.test.ts
@@ -5,6 +5,7 @@
 
 import { Relay } from "../../../src/nip01/relay";
 import { NostrEvent } from "../../../src/types/nostr";
+import { RelayEventStore } from "../../../src/nip01/relayEventStore";
 import {
   useWebSocketImplementation,
   resetWebSocketImplementation,
@@ -40,9 +41,8 @@ describe("Relay Event Ordering Integration", () => {
   // Type assertion function to access private members for testing
   const asTestable = (r: Relay) =>
     r as unknown as {
-      sortEvents: (events: NostrEvent[]) => NostrEvent[];
       flushSubscriptionBuffer: (subscriptionId: string) => void;
-      eventBuffers: Map<string, NostrEvent[]>;
+      eventStore: RelayEventStore;
     };
 
   beforeEach(() => {
@@ -74,7 +74,6 @@ describe("Relay Event Ordering Integration", () => {
 
     // Expose private methods for testing
     const testable = asTestable(relay);
-    testable.sortEvents = testable.sortEvents.bind(relay);
     testable.flushSubscriptionBuffer =
       testable.flushSubscriptionBuffer.bind(relay);
   });
@@ -147,12 +146,10 @@ describe("Relay Event Ordering Integration", () => {
     };
 
     // Manually add events to the buffer
-    asTestable(relay).eventBuffers.set(subscriptionId, [
-      event1,
-      event3,
-      event4,
-      event2,
-    ]);
+    const store = asTestable(relay).eventStore;
+    for (const event of [event1, event3, event4, event2]) {
+      store.addToBuffer(subscriptionId, event);
+    }
 
     // Directly call flushSubscriptionBuffer
     asTestable(relay).flushSubscriptionBuffer(subscriptionId);
@@ -216,7 +213,9 @@ describe("Relay Event Ordering Integration", () => {
     };
 
     // Manually add events to the buffer
-    asTestable(relay).eventBuffers.set(subscriptionId, [event1, event2]);
+    const store = asTestable(relay).eventStore;
+    store.addToBuffer(subscriptionId, event1);
+    store.addToBuffer(subscriptionId, event2);
 
     // Simulate receiving EOSE
     mockSocketInstance.onmessage?.({
@@ -262,7 +261,7 @@ describe("Relay Event Ordering Integration", () => {
     };
 
     // Manually add events to the buffer
-    asTestable(relay).eventBuffers.set(subscriptionId, [event]);
+    asTestable(relay).eventStore.addToBuffer(subscriptionId, event);
 
     // Directly call flushSubscriptionBuffer
     asTestable(relay).flushSubscriptionBuffer(subscriptionId);

--- a/tests/nip01/event/event-ordering.test.ts
+++ b/tests/nip01/event/event-ordering.test.ts
@@ -4,25 +4,15 @@
  * 1. By created_at timestamp (newest first)
  * 2. By event ID (lexically) when timestamps are the same
  *
- * Note: The integration test for the relay's buffer mechanism is in
- * event-ordering-integration.test.ts but requires additional work to properly
- * mock the WebSocket connections.
+ * The integration test for Relay buffer delivery lives in
+ * event-ordering-integration.test.ts.
  */
 
 import { NostrEvent } from "../../../src/types/nostr";
+import { RelayEventStore } from "../../../src/nip01/relayEventStore";
 
 describe("Event ordering", () => {
-  // Simple implementation of the sorting function based on NIP-01 spec
-  function sortEvents(events: NostrEvent[]): NostrEvent[] {
-    return [...events].sort((a, b) => {
-      // Sort by created_at (descending - newer events first)
-      if (a.created_at !== b.created_at) {
-        return b.created_at - a.created_at;
-      }
-      // If created_at is the same, sort by id (ascending lexical order)
-      return a.id.localeCompare(b.id);
-    });
-  }
+  const sortEvents = RelayEventStore.sortEvents;
 
   test("should order events by created_at (newest first)", () => {
     // Create test events with different timestamps

--- a/tests/nip01/relay/relay.test.ts
+++ b/tests/nip01/relay/relay.test.ts
@@ -119,6 +119,26 @@ describe("Relay", () => {
   });
 
   describe("Connection Management", () => {
+    test("disconnect clears retained state even without an active socket", () => {
+      const relay = new Relay("wss://example.com");
+      const internals = asTestRelay(relay);
+      const subscriptionId = relay.subscribe([{}], jest.fn());
+      internals.eventStore.addToBuffer(subscriptionId, {
+        id: "buffered",
+        pubkey: "pubkey",
+        created_at: 1,
+        kind: 1,
+        tags: [],
+        content: "",
+        sig: "sig",
+      });
+
+      relay.disconnect();
+
+      expect(internals.subscriptions.size).toBe(0);
+      expect([...internals.eventStore.bufferIds()]).toEqual([]);
+    });
+
     test("should connect to ephemeral relay", async () => {
       const relay = new Relay(ephemeralRelay.url);
 
@@ -1059,6 +1079,32 @@ describe("Relay", () => {
 
       expect(onEvent).toHaveBeenCalledTimes(1);
       expect(onEvent).toHaveBeenCalledWith(event);
+    });
+
+    test("should discard validation results after the subscription is removed", async () => {
+      const onEvent = jest.fn();
+      const subscriptionId = relay.subscribe([{ kinds: [30001] }], onEvent);
+      const event = await createSignedRelayEvent({
+        kind: 30001,
+        tags: [["d", "late"]],
+      });
+      let resolveValidation!: (validated: NostrEvent) => void;
+      const validation = new Promise<NostrEvent>((resolve) => {
+        resolveValidation = resolve;
+      });
+      const internals = asTestRelay(relay);
+      internals.validateInboundEvent = jest.fn(() => validation);
+
+      internals.handleMessage(["EVENT", subscriptionId, event]);
+      relay.unsubscribe(subscriptionId);
+      resolveValidation(event);
+      await validation;
+      await Promise.resolve();
+
+      expect(onEvent).not.toHaveBeenCalled();
+      expect(
+        relay.getLatestAddressableEvent(30001, event.pubkey, "late"),
+      ).toBeUndefined();
     });
 
     test("should reject malformed inbound EVENT messages", async () => {

--- a/tests/nip01/relay/relayEventStore.test.ts
+++ b/tests/nip01/relay/relayEventStore.test.ts
@@ -1,0 +1,213 @@
+import { RelayEventStore } from "../../../src/nip01/relayEventStore";
+import { NostrEvent } from "../../../src/types/nostr";
+
+function event(
+  id: string,
+  createdAt: number,
+  overrides: Partial<NostrEvent> = {},
+): NostrEvent {
+  return {
+    id,
+    pubkey: "pubkey",
+    created_at: createdAt,
+    kind: 1,
+    tags: [],
+    content: id,
+    sig: "sig",
+    ...overrides,
+  };
+}
+
+describe("RelayEventStore", () => {
+  test.each([
+    ["maxEventBuffers", 0],
+    ["maxEventsPerBuffer", -1],
+    ["maxReplaceableEventPubkeys", Number.NaN],
+    ["maxReplaceableEventsPerPubkey", Number.POSITIVE_INFINITY],
+    ["maxAddressableEvents", 1.5],
+    ["maxAddressableEvents", Number.MAX_SAFE_INTEGER + 1],
+  ] as const)("rejects invalid %s capacity %s", (option, value) => {
+    expect(
+      () => new RelayEventStore({ [option]: value }),
+    ).toThrow(`${option} must be a positive safe integer`);
+  });
+
+  test("drains buffered events in NIP-01 order", () => {
+    const store = new RelayEventStore();
+    store.addToBuffer("sub", event("d", 2));
+    store.addToBuffer("sub", event("b", 3));
+    store.addToBuffer("sub", event("a", 3));
+    store.addToBuffer("sub", event("c", 1));
+
+    expect(store.drainBuffer("sub").map(({ id }) => id)).toEqual([
+      "a",
+      "b",
+      "d",
+      "c",
+    ]);
+    expect(store.drainBuffer("sub")).toEqual([]);
+  });
+
+  test("enforces per-buffer capacity by retaining the newest arrivals", () => {
+    const store = new RelayEventStore({ maxEventsPerBuffer: 2 });
+    store.addToBuffer("sub", event("first", 3));
+    store.addToBuffer("sub", event("second", 2));
+    store.addToBuffer("sub", event("third", 1));
+
+    expect(store.drainBuffer("sub").map(({ id }) => id)).toEqual([
+      "second",
+      "third",
+    ]);
+  });
+
+  test("evicts the least-recently-used subscription buffer deterministically", () => {
+    let now = 0;
+    const evictions: string[] = [];
+    const store = new RelayEventStore({
+      maxEventBuffers: 2,
+      now: () => now++,
+      onEviction: (message) => evictions.push(message),
+    });
+    store.addToBuffer("old", event("old", 1));
+    store.addToBuffer("kept", event("kept", 1));
+    store.addToBuffer("new", event("new", 1));
+
+    expect([...store.bufferIds()]).toEqual(["kept", "new"]);
+    expect(evictions).toEqual([
+      "Evicted event buffer for subscription: old",
+    ]);
+  });
+
+  test("uses the lower event id when replaceable timestamps tie", () => {
+    const store = new RelayEventStore();
+    store.storeReplaceable(event("z", 10, { kind: 0 }));
+    store.storeReplaceable(event("a", 10, { kind: 0 }));
+    store.storeReplaceable(event("m", 10, { kind: 0 }));
+
+    expect(store.getReplaceable("pubkey", 0)?.id).toBe("a");
+  });
+
+  test("bounds replaceable pubkeys and ignores misses for LRU accounting", () => {
+    let now = 0;
+    const store = new RelayEventStore({
+      maxReplaceableEventPubkeys: 1,
+      now: () => now++,
+    });
+    store.storeReplaceable(event("first", 1, { kind: 0, pubkey: "first" }));
+    expect(store.getReplaceable("missing", 0)).toBeUndefined();
+    store.storeReplaceable(event("second", 2, { kind: 0, pubkey: "second" }));
+
+    expect(store.getReplaceable("first", 0)).toBeUndefined();
+    expect(store.getReplaceable("second", 0)?.id).toBe("second");
+  });
+
+  test("bounds replaceable kinds per pubkey by oldest event time", () => {
+    const store = new RelayEventStore({
+      maxReplaceableEventsPerPubkey: 2,
+    });
+    store.storeReplaceable(event("old", 1, { kind: 0 }));
+    store.storeReplaceable(event("kept", 2, { kind: 3 }));
+    store.storeReplaceable(event("new", 3, { kind: 10000 }));
+
+    expect(store.getReplaceable("pubkey", 0)).toBeUndefined();
+    expect(store.getReplaceable("pubkey", 3)?.id).toBe("kept");
+    expect(store.getReplaceable("pubkey", 10000)?.id).toBe("new");
+  });
+
+  test("keys addressable events by kind, pubkey, and d tag", () => {
+    const store = new RelayEventStore();
+    store.storeAddressable(
+      event("old", 1, { kind: 30001, tags: [["d", "profile"]] }),
+    );
+    store.storeAddressable(
+      event("new", 2, { kind: 30001, tags: [["d", "profile"]] }),
+    );
+    store.storeAddressable(
+      event("other", 1, { kind: 30001, tags: [["d", "other"]] }),
+    );
+
+    expect(store.getAddressable(30001, "pubkey", "profile")?.id).toBe(
+      "new",
+    );
+    expect(store.getAddressableByPubkey("pubkey")).toHaveLength(2);
+    expect(store.getAddressableByKind(30001)).toHaveLength(2);
+  });
+
+  test("bounds addressable storage and ignores misses for LRU accounting", () => {
+    let now = 0;
+    const store = new RelayEventStore({
+      maxAddressableEvents: 1,
+      now: () => now++,
+    });
+    store.storeAddressable(
+      event("first", 1, { kind: 30000, tags: [["d", "first"]] }),
+    );
+    expect(store.getAddressable(30000, "pubkey", "missing")).toBeUndefined();
+    store.storeAddressable(
+      event("second", 2, { kind: 30000, tags: [["d", "second"]] }),
+    );
+
+    expect(store.getAddressableByKind(30000).map(({ id }) => id)).toEqual([
+      "second",
+    ]);
+  });
+
+  test("bulk addressable reads refresh only matching LRU entries", () => {
+    let now = 0;
+    const store = new RelayEventStore({
+      maxAddressableEvents: 3,
+      now: () => now++,
+    });
+    store.storeAddressable(
+      event("match-pubkey", 1, {
+        kind: 30000,
+        pubkey: "match",
+        tags: [["d", "one"]],
+      }),
+    );
+    store.storeAddressable(
+      event("match-kind", 1, {
+        kind: 30001,
+        pubkey: "other",
+        tags: [["d", "two"]],
+      }),
+    );
+    store.storeAddressable(
+      event("untouched", 1, {
+        kind: 30002,
+        pubkey: "other",
+        tags: [["d", "three"]],
+      }),
+    );
+
+    expect(store.getAddressableByPubkey("match")).toHaveLength(1);
+    expect(store.getAddressableByKind(30001)).toHaveLength(1);
+    store.storeAddressable(
+      event("new", 2, {
+        kind: 30003,
+        pubkey: "new",
+        tags: [["d", "four"]],
+      }),
+    );
+
+    expect(store.getAddressableByKind(30002)).toEqual([]);
+    expect(store.getAddressableByKind(30000)).toHaveLength(1);
+    expect(store.getAddressableByKind(30001)).toHaveLength(1);
+    expect(store.getAddressableByKind(30003)).toHaveLength(1);
+  });
+
+  test("clears buffering and retained event state together", () => {
+    const store = new RelayEventStore();
+    store.addToBuffer("sub", event("buffered", 1));
+    store.storeReplaceable(event("replaceable", 1, { kind: 0 }));
+    store.storeAddressable(
+      event("addressable", 1, { kind: 30000, tags: [["d", "d"]] }),
+    );
+
+    store.clear();
+
+    expect([...store.bufferIds()]).toEqual([]);
+    expect(store.getReplaceable("pubkey", 0)).toBeUndefined();
+    expect(store.getAddressable(30000, "pubkey", "d")).toBeUndefined();
+  });
+});

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -11,6 +11,7 @@ import {
 import type { RelayConnectionOptions } from "../../src/types/protocol";
 import { NostrRelay } from "../../src/utils/ephemeral-relay";
 import { normalizeRelayUrl as normalizeRelayUrlUtil } from "../../src/utils/relayUrl";
+import { RelayEventStore } from "../../src/nip01/relayEventStore";
 
 /**
  * Interface for mocking a Relay in tests
@@ -94,13 +95,13 @@ export interface RelayTestAccess {
 
   // Private internal state
   subscriptions: Map<string, Subscription>;
-  eventBuffers: Map<string, NostrEvent[]>;
+  eventStore: RelayEventStore;
   pendingValidationCounts: Map<string, number>;
   status: string;
 
   // Private internal methods
   handleMessage(message: string[] | unknown[]): void;
-  processValidatedEvent(event: NostrEvent, subscriptionId: string): void;
+  validateInboundEvent(event: unknown): Promise<NostrEvent>;
   processReplaceableEvent(event: NostrEvent): void;
   processAddressableEvent(event: NostrEvent): void;
   flushSubscriptionBuffer(subscriptionId: string): void;


### PR DESCRIPTION
Closes #113

## Summary
- extract Relay buffering, ordering, capacity, LRU, and replaceable/addressable retention into one internal `RelayEventStore`
- keep socket lifecycle, validation, subscriptions, EOSE coordination, and callback delivery in `Relay`
- make teardown atomic even without an active socket and discard async validation results after unsubscribe
- add deterministic unit and Relay integration coverage for ordering, capacity, eviction, replacement, and lifecycle races

## Verification
- focused Jest and Bun: 80/80 each
- full Jest and Bun: 1013/1013 each
- commands validation, lint, root/examples typechecks
- CJS/ESM builds, examples build, pack verification
- local CodeRabbit: 4/4 findings fixed

## Delegation note
The owner-required Grok `agent` CLI was present but unauthenticated, so no substitute delegated subagent was used; implementation and local review were completed directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved relay event buffering and retention, including capacity limits, ordering, and least-recently-used eviction.
  * Enhanced handling of replaceable and addressable events, with deterministic replacement and lookup behavior.
  * Improved cleanup when disconnecting and prevented events from being delivered after a subscription is removed.

* **Tests**
  * Added comprehensive coverage for event storage, ordering, eviction, cleanup, and validation scenarios.

* **Documentation**
  * Added review and verification records for the relay event storage work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->