### PR TITLE
refactor: extract NIP-47 protocol machinery

### DIFF
--- a/docs/agents/runs/deep-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/deep-cleanup-1-8-ledger.md
@@ -44,7 +44,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 | #112 NIP-44 legacy behavior | AFK | merged into `staging` | `feature/nip44-legacy-compat` | standards/spec pass; local CodeRabbit 5 fixed; hosted CodeRabbit 3 fixed | yes |
 | #118 authoritative protocol messages | AFK | merged into `staging` | `feature/protocol-message-types` | standards/spec pass; local CodeRabbit 4 fixed, 1 evidence-based skip; hosted 2 fixed | Jest 994/994; Bun full; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
 | #113 Relay event-store seam | AFK | merged into `staging` | `feature/relay-event-store` | standards/spec pass; local CodeRabbit 4 fixed; hosted clean | focused Jest/Bun 80/80; full Jest/Bun 1013/1013; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
-| #114 NIP-47 protocol machinery | AFK | implementation, local review, and full matrix verified | `feature/nip47-protocol-codecs` | standards/spec pass; local CodeRabbit 2 fixed, 7 compatibility skips | focused 70/70; full Jest/Bun 1021/1021; commands, lint, types, builds, pack |
+| #114 NIP-47 protocol machinery | AFK | hosted review fixes verified; hosted matrix rerunning | `feature/nip47-protocol-codecs` | standards/spec pass; local CodeRabbit 2 fixed, 7 compatibility skips; hosted 3 fixed | focused 71/71; pre-hosted-fix full Jest/Bun 1021/1021; commands, lint, types, builds, pack |
 | #115 Nostr relay registry | AFK | blocked by #113 | `feature/nostr-relay-registry` | pending | no |
 | #116 ephemeral Relay ownership | AFK | blocked by #113 | `feature/ephemeral-relay-ownership` | pending | no |
 | #117 security validation ownership | AFK | blocked by #113 and #115 | `feature/security-validation-ownership` | pending | no |
@@ -63,7 +63,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 | #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | PR #120, merge `c7cb99f` | standards/spec pass after one fix; local CodeRabbit 5/5 and hosted CodeRabbit 3/3 fixed | NIP-44 107/107; Jest 991/991; Bun 991/991; hosted Node 16/18/20 + Bun; lint, types, builds, commands, pack |
 | #118 | `c7cb99f` | current Codex orchestrator; Grok unavailable at auth preflight | PR #121, merge `8c36233` | standards/spec pass; local CodeRabbit 4 fixed, 1 skipped with type evidence; hosted 2/2 fixed | Jest 994/994; Bun full; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
 | #113 | `8c36233` | current Codex orchestrator; Grok unavailable at auth preflight | PR #122, merge `da7361e` | standards/spec pass; local CodeRabbit 4/4 fixed; hosted clean | focused Relay/store Jest and Bun 80/80; full Jest/Bun 1013/1013; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
-| #114 | `da7361e` | current Codex orchestrator; Grok unavailable at auth preflight | pending | standards/spec pass; local CodeRabbit 2 fixed, 7 skipped to preserve public compatibility | focused NIP-47 70/70; full Jest/Bun 1021/1021; commands, lint, types, builds, pack |
+| #114 | `da7361e` | current Codex orchestrator; Grok unavailable at auth preflight | PR #123 pending | standards/spec pass; local CodeRabbit 2 fixed, 7 skipped to preserve public compatibility; hosted 3 fixed | focused NIP-47 71/71; pre-hosted-fix full Jest/Bun 1021/1021; commands, lint, types, builds, pack; hosted rerun pending |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/deep-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/deep-cleanup-1-8-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, rebased from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: issues #112 and #118 merged into `staging`; issue #113 implementation in progress
+- Current status: issues #112, #118, and #113 merged into `staging`; issue #114 implementation in progress
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, single-context domain docs)
 
 ## Goal
@@ -27,7 +27,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 - Agent briefs: Grok 4.5 is the only owner-approved delegated sidecar; `agent` authentication was unavailable at preflight, so no substitute subagent is used and Codex owns local execution/review
 - Review packets: created per ticket
 - Local CodeRabbit report: issue #112 round completed with five worthy fixes in `issue-112-coderabbit-local.md`
-- PR URLs: #120 for issue #112 (merged), #121 for issue #118 (merged); later tickets pending
+- PR URLs: #120 for issue #112, #121 for issue #118, #122 for issue #113 (all merged); later tickets pending
 
 ## Commands
 
@@ -43,8 +43,8 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 | --- | --- | --- | --- | --- | --- |
 | #112 NIP-44 legacy behavior | AFK | merged into `staging` | `feature/nip44-legacy-compat` | standards/spec pass; local CodeRabbit 5 fixed; hosted CodeRabbit 3 fixed | yes |
 | #118 authoritative protocol messages | AFK | merged into `staging` | `feature/protocol-message-types` | standards/spec pass; local CodeRabbit 4 fixed, 1 evidence-based skip; hosted 2 fixed | Jest 994/994; Bun full; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
-| #113 Relay event-store seam | AFK | implementation, local review, and full matrix verified | `feature/relay-event-store` | standards/spec pass; local CodeRabbit 4 fixed | focused Jest/Bun 80/80; full Jest/Bun 1013/1013; commands, lint, types, builds, pack |
-| #114 NIP-47 protocol machinery | AFK | blocked by #118 | `feature/nip47-protocol-codecs` | pending | no |
+| #113 Relay event-store seam | AFK | merged into `staging` | `feature/relay-event-store` | standards/spec pass; local CodeRabbit 4 fixed; hosted clean | focused Jest/Bun 80/80; full Jest/Bun 1013/1013; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
+| #114 NIP-47 protocol machinery | AFK | implementation, local review, and full matrix verified | `feature/nip47-protocol-codecs` | standards/spec pass; local CodeRabbit 2 fixed, 7 compatibility skips | focused 70/70; full Jest/Bun 1021/1021; commands, lint, types, builds, pack |
 | #115 Nostr relay registry | AFK | blocked by #113 | `feature/nostr-relay-registry` | pending | no |
 | #116 ephemeral Relay ownership | AFK | blocked by #113 | `feature/ephemeral-relay-ownership` | pending | no |
 | #117 security validation ownership | AFK | blocked by #113 and #115 | `feature/security-validation-ownership` | pending | no |
@@ -62,7 +62,8 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 | --- | --- | --- | --- | --- | --- |
 | #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | PR #120, merge `c7cb99f` | standards/spec pass after one fix; local CodeRabbit 5/5 and hosted CodeRabbit 3/3 fixed | NIP-44 107/107; Jest 991/991; Bun 991/991; hosted Node 16/18/20 + Bun; lint, types, builds, commands, pack |
 | #118 | `c7cb99f` | current Codex orchestrator; Grok unavailable at auth preflight | PR #121, merge `8c36233` | standards/spec pass; local CodeRabbit 4 fixed, 1 skipped with type evidence; hosted 2/2 fixed | Jest 994/994; Bun full; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
-| #113 | `8c36233` | current Codex orchestrator; Grok unavailable at auth preflight | pending | standards/spec pass; local CodeRabbit 4/4 fixed | focused Relay/store Jest and Bun 80/80; full Jest/Bun 1013/1013; commands, lint, types, builds, pack |
+| #113 | `8c36233` | current Codex orchestrator; Grok unavailable at auth preflight | PR #122, merge `da7361e` | standards/spec pass; local CodeRabbit 4/4 fixed; hosted clean | focused Relay/store Jest and Bun 80/80; full Jest/Bun 1013/1013; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
+| #114 | `da7361e` | current Codex orchestrator; Grok unavailable at auth preflight | pending | standards/spec pass; local CodeRabbit 2 fixed, 7 skipped to preserve public compatibility | focused NIP-47 70/70; full Jest/Bun 1021/1021; commands, lint, types, builds, pack |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/issue-114-coderabbit-hosted.md
+++ b/docs/agents/runs/issue-114-coderabbit-hosted.md
@@ -1,0 +1,26 @@
+# CodeRabbit Round: #114 Hosted PR
+
+## Round
+
+- Scope: PR #123
+- Command: `@coderabbit full review`
+- Completed: 2026-07-18
+- Inline findings: 7
+
+## Decisions
+
+| Finding | Decision | Notes |
+| --- | --- | --- |
+| Parser accepted relay-less NWC URLs | fixed | Parse and generate now share the required-relay invariant. |
+| Malformed request envelopes became INTERNAL_ERROR | fixed | Typed parse errors now map to INVALID_REQUEST with UNKNOWN correlation. |
+| Invalid secondary lookup identifier reached the wallet | fixed | Both optional identifiers are validated when present. |
+| Normalize all unknown methods to UNKNOWN | skipped | Existing public behavior correlates unsupported-method errors to the supplied method. |
+| Require make-invoice description | skipped | Existing runtime intentionally accepts omission despite the stricter TypeScript wallet interface. |
+| Add broad sanitization and redact wallet exceptions | deferred | Material behavior/security policy change belongs to #117. |
+| Exhaustively cover every branch | partially addressed | Added regression tests for every hosted fix; existing public suite covers all methods and encryption/lifecycle behavior. |
+
+## Result
+
+- Hosted fixes: 3
+- Evidence-based skips/deferments: 4
+- Post-fix focused verification: lint, strict typecheck, and NIP-47 71/71 pass

--- a/docs/agents/runs/issue-114-coderabbit-local.md
+++ b/docs/agents/runs/issue-114-coderabbit-local.md
@@ -1,0 +1,26 @@
+# CodeRabbit Round: #114 Local Branch
+
+## Round
+
+- Scope: local
+- Command: `coderabbit review --agent --type all --base staging`
+- Completed: 2026-07-18
+- Findings: 9
+
+## Decisions
+
+| Finding group | Decision | Notes |
+| --- | --- | --- |
+| Malformed response JSON bypassed the supplied client error factory | fixed | Syntax errors now become the caller's protocol error type. |
+| Request params accepted arrays | fixed | The canonical request parser now requires a non-array object. |
+| Require relays and canonical 32-byte URL keys | skipped | Changes existing `parseNWCURL` acceptance and public behavior; belongs in #117 if approved. |
+| Sanitize arbitrary wallet errors | skipped | Existing service intentionally preserves wallet error codes, messages, and data. |
+| Override wallet-reported GET_INFO methods | skipped | Existing service preserves wallet info and adds only encryption capabilities. |
+| Tighten amount, description, and all parameter bounds | skipped | Changes established accepted inputs; security policy is tracked by #117. |
+| Map unknown wire methods to `UNKNOWN` | skipped | Existing behavior returns INVALID_REQUEST correlated to the supplied method. |
+
+## Result
+
+- Worthy findings fixed: 2
+- Evidence-based compatibility/scope skips: 7
+- Post-review verification: focused 70/70; full Jest/Bun 1021/1021; all types, builds, commands, and pack checks pass

--- a/docs/agents/runs/issue-114-review-packet.md
+++ b/docs/agents/runs/issue-114-review-packet.md
@@ -15,11 +15,12 @@
 
 ## Verification
 
-- Focused NIP-47: 8 suites, 70/70
+- Focused NIP-47 after hosted review: 8 suites, 71/71
 - Full Jest: 76 suites, 1021/1021
 - Full Bun: 1021/1021
 - Commands, lint, root/examples typechecks, CJS/ESM build, examples build, and pack verification: pass
 - Local CodeRabbit: 2 findings fixed; 7 compatibility/security-scope suggestions skipped with evidence
+- Hosted CodeRabbit: relay-less URLs, malformed-envelope error mapping, and invalid secondary lookup identifiers fixed; broader security/behavior changes deferred to #117 or skipped for compatibility
 
 ## Known Tooling Limitation
 

--- a/docs/agents/runs/issue-114-review-packet.md
+++ b/docs/agents/runs/issue-114-review-packet.md
@@ -1,0 +1,26 @@
+# Review Packet: #114 NIP-47 Protocol Machinery
+
+## Fixed Point
+
+- Base: `staging` at `da7361e`
+- Branch: `feature/nip47-protocol-codecs`
+- Issue: #114
+
+## Change Story
+
+- One internal codec owns NWC URLs, request JSON parsing, response JSON parsing, and response envelope validation.
+- One internal dispatcher owns supported-method gating, method parameter guards, wallet invocation, response envelopes, and compatible error mapping.
+- Stateful client/service classes retain encryption negotiation, event handling, request correlation, timeouts, relays, and notifications.
+- Direct codec/dispatcher tests supplement the unchanged public integration suite.
+
+## Verification
+
+- Focused NIP-47: 8 suites, 70/70
+- Full Jest: 76 suites, 1021/1021
+- Full Bun: 1021/1021
+- Commands, lint, root/examples typechecks, CJS/ESM build, examples build, and pack verification: pass
+- Local CodeRabbit: 2 findings fixed; 7 compatibility/security-scope suggestions skipped with evidence
+
+## Known Tooling Limitation
+
+- Grok could not be delegated because the required `agent` CLI is unauthenticated. Per the Grok skill, no substitute subagent was used.

--- a/docs/agents/runs/issue-114-session.md
+++ b/docs/agents/runs/issue-114-session.md
@@ -15,7 +15,7 @@
 | Client and service delegate pure protocol work | client delegates URL/response codecs; service delegates request parsing and dispatch |
 | Exhaustive compatible dispatch | `src/nip47/requestDispatcher.ts` plus direct tests |
 | Preserve lifecycle and encryption negotiation | existing public NIP-47 and NIP-44 integration suites |
-| Full verification | focused 70/70; full Jest/Bun 1021/1021; commands, types, builds, pack |
+| Full verification | post-hosted-review focused 71/71; pre-hosted-review full Jest/Bun 1021/1021; commands, types, builds, pack; hosted rerun pending |
 
 ## Decisions
 

--- a/docs/agents/runs/issue-114-session.md
+++ b/docs/agents/runs/issue-114-session.md
@@ -1,0 +1,24 @@
+# Issue Session: #114 NIP-47 Protocol Machinery
+
+## Scope
+
+- Fixed point: `da7361e` (`staging` after PR #122)
+- Branch: `feature/nip47-protocol-codecs`
+- Issue: #114
+- Owner: current Codex orchestrator; Grok unavailable because `agent` authentication is required
+
+## Acceptance Map
+
+| Acceptance criterion | Implementation / verification seam |
+| --- | --- |
+| Canonical URL and wire validation owners | `src/nip47/protocol.ts` |
+| Client and service delegate pure protocol work | client delegates URL/response codecs; service delegates request parsing and dispatch |
+| Exhaustive compatible dispatch | `src/nip47/requestDispatcher.ts` plus direct tests |
+| Preserve lifecycle and encryption negotiation | existing public NIP-47 and NIP-44 integration suites |
+| Full verification | focused 70/70; full Jest/Bun 1021/1021; commands, types, builds, pack |
+
+## Decisions
+
+- Keep relays, encryption, correlation, timeouts, TTL state, and publishing in the client/service.
+- Preserve historical loose public parameter acceptance and wallet error propagation; stricter security policy belongs to #117.
+- Keep the codec and dispatcher internal rather than expanding the package export surface.

--- a/src/nip47/client.ts
+++ b/src/nip47/client.ts
@@ -33,73 +33,14 @@ import {
 import { SecurityValidationError } from "../utils/security-validator";
 import { Logger, LogLevel } from "../utils/logger";
 import type { DiagnosticLogger } from "../utils/logger";
+import {
+  generateNWCURL,
+  parseNIP47Response,
+  parseNWCURL,
+  validateNIP47Response,
+} from "./protocol";
 
-/**
- * Parse a NWC URL into connection options
- *
- * Handles URLs like: nostr+walletconnect://pubkey?relay=wss://relay.example.com&secret=xxx
- * Uses the URL class for robust parsing of relay URLs that contain "://"
- */
-export function parseNWCURL(url: string): NIP47ConnectionOptions {
-  if (!url.startsWith("nostr+walletconnect://")) {
-    throw new Error("Invalid NWC URL format");
-  }
-
-  // Use URL class for robust parsing - replace custom protocol with https temporarily
-  // This handles relay URLs containing "://" correctly (e.g., wss://relay.example.com)
-  const tempUrl = url.replace("nostr+walletconnect://", "https://nwc.temp/");
-  let parsed: URL;
-
-  try {
-    parsed = new URL(tempUrl);
-  } catch {
-    throw new Error("Invalid NWC URL format: malformed URL structure");
-  }
-
-  // Extract pubkey from pathname (remove leading slash)
-  const pubkey = parsed.pathname.slice(1);
-  if (!pubkey) {
-    throw new Error("Missing pubkey in NWC URL");
-  }
-
-  // Parse query parameters using the URL's searchParams
-  const relays: string[] = [];
-  parsed.searchParams.getAll("relay").forEach((relay) => relays.push(relay));
-
-  const secret = parsed.searchParams.get("secret");
-  if (!secret) {
-    throw new Error("Missing secret in NWC URL");
-  }
-
-  return {
-    pubkey,
-    secret,
-    relays,
-  };
-}
-
-/**
- * Generate a NWC URL from connection options
- */
-export function generateNWCURL(options: NIP47ConnectionOptions): string {
-  if (!options.pubkey) {
-    throw new Error("Missing pubkey in connection options");
-  }
-
-  if (!options.secret) {
-    throw new Error("Missing secret in connection options");
-  }
-
-  if (!options.relays || options.relays.length === 0) {
-    throw new Error("At least one relay must be specified");
-  }
-
-  const params = new URLSearchParams();
-  options.relays.forEach((relay) => params.append("relay", relay));
-  params.append("secret", options.secret);
-
-  return `nostr+walletconnect://${options.pubkey}?${params.toString()}`;
-}
+export { generateNWCURL, parseNWCURL };
 
 /**
  * Retry configuration
@@ -511,94 +452,11 @@ export class NostrWalletConnectClient {
    * Validate that a response follows the NIP-47 specification structure
    */
   private validateResponse(response: unknown): NIP47Response {
-    // First check if response is an object
-    if (!response || typeof response !== "object") {
-      throw new NIP47ClientError(
-        "Invalid response: not an object",
-        NIP47ErrorCode.INVALID_REQUEST,
-      );
-    }
-
-    // Cast to a more specific type for property access
-    const resp = response as Record<string, unknown>;
-
-    // Check if result_type exists and is a string
-    if (!resp.result_type || typeof resp.result_type !== "string") {
-      throw new NIP47ClientError(
-        "Invalid response: missing or invalid result_type",
-        NIP47ErrorCode.INVALID_REQUEST,
-      );
-    }
-
-    // Verify result_type is a known NIP47Method
-    if (!Object.values(NIP47Method).includes(resp.result_type as NIP47Method)) {
-      throw new NIP47ClientError(
-        `Invalid response: unknown result_type '${resp.result_type}'`,
-        NIP47ErrorCode.INVALID_REQUEST,
-      );
-    }
-
-    // Check error field - per NIP-47 spec it should be null on success, but some
-    // wallet implementations omit it entirely. Default to null if not present.
-    const hasErrorField = "error" in resp;
-    const errorValue = hasErrorField ? resp.error : null;
-
-    // If error is not null, validate its structure
-    if (errorValue !== null) {
-      if (typeof errorValue !== "object") {
-        throw new NIP47ClientError(
-          "Invalid response: error field must be an object or null",
-          NIP47ErrorCode.INVALID_REQUEST,
-        );
-      }
-
-      const error = errorValue as Record<string, unknown>;
-
-      // Check error has code and message
-      if (!error.code || typeof error.code !== "string") {
-        throw new NIP47ClientError(
-          "Invalid response: error must have a code field",
-          NIP47ErrorCode.INVALID_REQUEST,
-        );
-      }
-
-      if (!error.message || typeof error.message !== "string") {
-        throw new NIP47ClientError(
-          "Invalid response: error must have a message field",
-          NIP47ErrorCode.INVALID_REQUEST,
-        );
-      }
-
-      // When there's an error, result should be null
-      if (resp.result !== null) {
-        throw new NIP47ClientError(
-          "Invalid response: when error is present, result must be null",
-          NIP47ErrorCode.INVALID_REQUEST,
-        );
-      }
-    }
-
-    // If no error, result should be defined and not null
-    if (
-      errorValue === null &&
-      (resp.result === null || resp.result === undefined)
-    ) {
-      throw new NIP47ClientError(
-        "Invalid response: when error is null, result must be defined and not null",
-        NIP47ErrorCode.INVALID_REQUEST,
-      );
-    }
-
-    // Normalize missing error field to null to keep runtime data aligned with
-    // the NIP47Response type contract and spec semantics.
-    if (!hasErrorField) {
-      return {
-        ...(response as Omit<NIP47Response, "error">),
-        error: null,
-      };
-    }
-
-    return response as NIP47Response;
+    return validateNIP47Response(
+      response,
+      (message) =>
+        new NIP47ClientError(message, NIP47ErrorCode.INVALID_REQUEST),
+    );
   }
 
   /**
@@ -659,19 +517,18 @@ export class NostrWalletConnectClient {
         );
       }
 
-      const response = JSON.parse(decrypted);
-
-      // Validate response structure
-      this.validateResponse(response);
-
-      this.logger.debug(
-        `Validated response of type: ${(response as NIP47Response).result_type}`,
+      const response = parseNIP47Response(
+        decrypted,
+        (message) =>
+          new NIP47ClientError(message, NIP47ErrorCode.INVALID_REQUEST),
       );
+
+      this.logger.debug(`Validated response of type: ${response.result_type}`);
 
       this.logger.debug("Correlated response with a pending request");
 
       // Resolve the pending request
-      pendingRequest.resolve(response as NIP47Response);
+      pendingRequest.resolve(response);
       this.pendingRequests.delete(requestId);
       this.logger.debug("Pending request resolved successfully");
     } catch (error) {

--- a/src/nip47/protocol.ts
+++ b/src/nip47/protocol.ts
@@ -23,8 +23,12 @@ export function parseNWCURL(url: string): NIP47ConnectionOptions {
   if (!pubkey) throw new Error("Missing pubkey in NWC URL");
   const secret = parsed.searchParams.get("secret");
   if (!secret) throw new Error("Missing secret in NWC URL");
+  const relays = parsed.searchParams.getAll("relay");
+  if (relays.length === 0) {
+    throw new Error("At least one relay must be specified");
+  }
 
-  return { pubkey, secret, relays: parsed.searchParams.getAll("relay") };
+  return { pubkey, secret, relays };
 }
 
 export function generateNWCURL(options: NIP47ConnectionOptions): string {
@@ -89,21 +93,37 @@ export function validateNIP47Response(
       } as NIP47Response);
 }
 
+export class NIP47RequestParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NIP47RequestParseError";
+  }
+}
+
 export function parseNIP47Request(content: string): NIP47Request {
-  const request: unknown = JSON.parse(content);
+  let request: unknown;
+  try {
+    request = JSON.parse(content);
+  } catch {
+    throw new NIP47RequestParseError("Invalid request: malformed JSON");
+  }
   if (!request || typeof request !== "object") {
-    throw new Error("Invalid request: not an object");
+    throw new NIP47RequestParseError("Invalid request: not an object");
   }
   const value = request as Record<string, unknown>;
   if (typeof value.method !== "string" || !value.method) {
-    throw new Error("Invalid request: missing or invalid method");
+    throw new NIP47RequestParseError(
+      "Invalid request: missing or invalid method",
+    );
   }
   if (
     !value.params ||
     typeof value.params !== "object" ||
     Array.isArray(value.params)
   ) {
-    throw new Error("Invalid request: missing or invalid params");
+    throw new NIP47RequestParseError(
+      "Invalid request: missing or invalid params",
+    );
   }
   return request as NIP47Request;
 }

--- a/src/nip47/protocol.ts
+++ b/src/nip47/protocol.ts
@@ -1,0 +1,123 @@
+import {
+  NIP47ConnectionOptions,
+  NIP47Method,
+  NIP47Request,
+  NIP47Response,
+} from "./types";
+
+export function parseNWCURL(url: string): NIP47ConnectionOptions {
+  if (!url.startsWith("nostr+walletconnect://")) {
+    throw new Error("Invalid NWC URL format");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(
+      url.replace("nostr+walletconnect://", "https://nwc.temp/"),
+    );
+  } catch {
+    throw new Error("Invalid NWC URL format: malformed URL structure");
+  }
+
+  const pubkey = parsed.pathname.slice(1);
+  if (!pubkey) throw new Error("Missing pubkey in NWC URL");
+  const secret = parsed.searchParams.get("secret");
+  if (!secret) throw new Error("Missing secret in NWC URL");
+
+  return { pubkey, secret, relays: parsed.searchParams.getAll("relay") };
+}
+
+export function generateNWCURL(options: NIP47ConnectionOptions): string {
+  if (!options.pubkey) throw new Error("Missing pubkey in connection options");
+  if (!options.secret) throw new Error("Missing secret in connection options");
+  if (!options.relays || options.relays.length === 0) {
+    throw new Error("At least one relay must be specified");
+  }
+
+  const params = new URLSearchParams();
+  options.relays.forEach((relay) => params.append("relay", relay));
+  params.append("secret", options.secret);
+  return `nostr+walletconnect://${options.pubkey}?${params.toString()}`;
+}
+
+export function validateNIP47Response(
+  response: unknown,
+  invalid: (message: string) => Error,
+): NIP47Response {
+  if (!response || typeof response !== "object") {
+    throw invalid("Invalid response: not an object");
+  }
+  const value = response as Record<string, unknown>;
+  if (!value.result_type || typeof value.result_type !== "string") {
+    throw invalid("Invalid response: missing or invalid result_type");
+  }
+  if (!Object.values(NIP47Method).includes(value.result_type as NIP47Method)) {
+    throw invalid(
+      `Invalid response: unknown result_type '${value.result_type}'`,
+    );
+  }
+
+  const hasError = "error" in value;
+  const errorValue = hasError ? value.error : null;
+  if (errorValue !== null) {
+    if (!errorValue || typeof errorValue !== "object") {
+      throw invalid("Invalid response: error field must be an object or null");
+    }
+    const error = errorValue as Record<string, unknown>;
+    if (!error.code || typeof error.code !== "string") {
+      throw invalid("Invalid response: error must have a code field");
+    }
+    if (!error.message || typeof error.message !== "string") {
+      throw invalid("Invalid response: error must have a message field");
+    }
+    if (value.result !== null) {
+      throw invalid(
+        "Invalid response: when error is present, result must be null",
+      );
+    }
+  } else if (value.result === null || value.result === undefined) {
+    throw invalid(
+      "Invalid response: when error is null, result must be defined and not null",
+    );
+  }
+
+  return hasError
+    ? (response as NIP47Response)
+    : ({
+        ...(response as Omit<NIP47Response, "error">),
+        error: null,
+      } as NIP47Response);
+}
+
+export function parseNIP47Request(content: string): NIP47Request {
+  const request: unknown = JSON.parse(content);
+  if (!request || typeof request !== "object") {
+    throw new Error("Invalid request: not an object");
+  }
+  const value = request as Record<string, unknown>;
+  if (typeof value.method !== "string" || !value.method) {
+    throw new Error("Invalid request: missing or invalid method");
+  }
+  if (
+    !value.params ||
+    typeof value.params !== "object" ||
+    Array.isArray(value.params)
+  ) {
+    throw new Error("Invalid request: missing or invalid params");
+  }
+  return request as NIP47Request;
+}
+
+export function parseNIP47Response(
+  content: string,
+  invalid: (message: string) => Error,
+): NIP47Response {
+  try {
+    return validateNIP47Response(JSON.parse(content), invalid);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw invalid("Invalid response: malformed JSON");
+    }
+    throw error;
+  }
+}

--- a/src/nip47/requestDispatcher.ts
+++ b/src/nip47/requestDispatcher.ts
@@ -1,0 +1,188 @@
+import {
+  ERROR_CATEGORIES,
+  ERROR_RECOVERY_HINTS,
+  ListTransactionsParams,
+  LookupInvoiceParams,
+  MakeInvoiceParams,
+  NIP47EncryptionScheme,
+  NIP47ErrorCode,
+  NIP47Method,
+  NIP47Request,
+  NIP47Response,
+  NIP47ResponseResult,
+  PayInvoiceParams,
+  SignMessageParams,
+  WalletImplementation,
+} from "./types";
+
+export interface NIP47RequestDispatcherOptions {
+  wallet: WalletImplementation;
+  supportedMethods: readonly NIP47Method[];
+  supportedEncryption: readonly NIP47EncryptionScheme[];
+}
+
+function errorResponse(
+  method: NIP47Method,
+  code: NIP47ErrorCode,
+  message: string,
+  data?: Record<string, unknown>,
+): NIP47Response {
+  return {
+    result_type: method,
+    result: null,
+    error: {
+      code,
+      message,
+      category: ERROR_CATEGORIES[code],
+      recoveryHint: ERROR_RECOVERY_HINTS[code],
+      data,
+    },
+  };
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+export async function dispatchNIP47Request(
+  request: NIP47Request,
+  options: NIP47RequestDispatcherOptions,
+): Promise<NIP47Response> {
+  const { wallet, supportedMethods, supportedEncryption } = options;
+  if (!supportedMethods.includes(request.method)) {
+    return errorResponse(
+      request.method,
+      NIP47ErrorCode.INVALID_REQUEST,
+      `Method ${request.method} not supported`,
+    );
+  }
+
+  const invalid = (message: string) =>
+    errorResponse(request.method, NIP47ErrorCode.INVALID_REQUEST, message);
+
+  try {
+    let result: NIP47ResponseResult;
+    switch (request.method) {
+      case NIP47Method.GET_INFO:
+        result = {
+          ...(await wallet.getInfo()),
+          encryption: [...supportedEncryption],
+        };
+        break;
+      case NIP47Method.GET_BALANCE:
+        result = await wallet.getBalance();
+        break;
+      case NIP47Method.PAY_INVOICE: {
+        const params = request.params as PayInvoiceParams;
+        if (
+          !isObject(params) ||
+          typeof params.invoice !== "string" ||
+          (params.amount !== undefined && typeof params.amount !== "number") ||
+          (params.maxfee !== undefined && typeof params.maxfee !== "number")
+        )
+          return invalid("Invalid parameters for pay_invoice method");
+        result = await wallet.payInvoice(
+          params.invoice,
+          params.amount,
+          params.maxfee,
+        );
+        break;
+      }
+      case NIP47Method.MAKE_INVOICE: {
+        const params = request.params as MakeInvoiceParams;
+        if (
+          !isObject(params) ||
+          typeof params.amount !== "number" ||
+          (params.description !== undefined &&
+            typeof params.description !== "string") ||
+          (params.description_hash !== undefined &&
+            typeof params.description_hash !== "string") ||
+          (params.expiry !== undefined && typeof params.expiry !== "number")
+        )
+          return invalid("Invalid parameters for make_invoice method");
+        result = await wallet.makeInvoice(
+          params.amount,
+          params.description,
+          params.description_hash,
+          params.expiry,
+        );
+        break;
+      }
+      case NIP47Method.LOOKUP_INVOICE: {
+        const params = request.params as LookupInvoiceParams;
+        if (
+          !isObject(params) ||
+          (typeof params.payment_hash !== "string" &&
+            typeof params.invoice !== "string")
+        )
+          return invalid("Invalid parameters for lookup_invoice method");
+        try {
+          result = await wallet.lookupInvoice({
+            payment_hash: params.payment_hash as string | undefined,
+            invoice: params.invoice as string | undefined,
+          });
+        } catch (error) {
+          const known = error as { code?: NIP47ErrorCode; message?: string };
+          if (known.code !== NIP47ErrorCode.NOT_FOUND) throw error;
+          const lookupType = params.payment_hash ? "payment_hash" : "invoice";
+          const lookupValue = params.payment_hash || params.invoice;
+          return errorResponse(
+            request.method,
+            NIP47ErrorCode.NOT_FOUND,
+            `Invoice not found: Could not find ${lookupType}: ${lookupValue} in the wallet's database`,
+          );
+        }
+        break;
+      }
+      case NIP47Method.LIST_TRANSACTIONS: {
+        const params = request.params as ListTransactionsParams;
+        if (
+          !isObject(params) ||
+          (params.from !== undefined && typeof params.from !== "number") ||
+          (params.until !== undefined && typeof params.until !== "number") ||
+          (params.limit !== undefined && typeof params.limit !== "number") ||
+          (params.offset !== undefined && typeof params.offset !== "number") ||
+          (params.unpaid !== undefined && typeof params.unpaid !== "boolean") ||
+          (params.type !== undefined && typeof params.type !== "string")
+        )
+          return invalid("Invalid parameters for list_transactions method");
+        result = {
+          transactions: await wallet.listTransactions(
+            params.from,
+            params.until,
+            params.limit,
+            params.offset,
+            params.unpaid,
+            params.type,
+          ),
+        };
+        break;
+      }
+      case NIP47Method.SIGN_MESSAGE: {
+        const params = request.params as SignMessageParams;
+        if (!isObject(params) || typeof params.message !== "string") {
+          return invalid("Invalid parameters for sign_message method");
+        }
+        if (!wallet.signMessage) {
+          return invalid("sign_message method not implemented by wallet");
+        }
+        result = await wallet.signMessage(params.message);
+        break;
+      }
+      default:
+        return invalid(`Method ${request.method} not supported`);
+    }
+    return { result_type: request.method, result, error: null };
+  } catch (error) {
+    const known = error as {
+      code?: NIP47ErrorCode;
+      message?: string;
+      data?: Record<string, unknown>;
+    };
+    return errorResponse(
+      request.method,
+      known.code || NIP47ErrorCode.INTERNAL_ERROR,
+      known.message || "An error occurred processing the request",
+      known.data,
+    );
+  }
+}

--- a/src/nip47/requestDispatcher.ts
+++ b/src/nip47/requestDispatcher.ts
@@ -111,14 +111,18 @@ export async function dispatchNIP47Request(
         const params = request.params as LookupInvoiceParams;
         if (
           !isObject(params) ||
+          (params.payment_hash !== undefined &&
+            typeof params.payment_hash !== "string") ||
+          (params.invoice !== undefined &&
+            typeof params.invoice !== "string") ||
           (typeof params.payment_hash !== "string" &&
             typeof params.invoice !== "string")
         )
           return invalid("Invalid parameters for lookup_invoice method");
         try {
           result = await wallet.lookupInvoice({
-            payment_hash: params.payment_hash as string | undefined,
-            invoice: params.invoice as string | undefined,
+            payment_hash: params.payment_hash,
+            invoice: params.invoice,
           });
         } catch (error) {
           const known = error as { code?: NIP47ErrorCode; message?: string };

--- a/src/nip47/service.ts
+++ b/src/nip47/service.ts
@@ -29,7 +29,7 @@ import { maybeUnref } from "../utils/timers";
 import { Logger, LogLevel } from "../utils/logger";
 import type { DiagnosticLogger } from "../utils/logger";
 import { dispatchNIP47Request } from "./requestDispatcher";
-import { parseNIP47Request } from "./protocol";
+import { NIP47RequestParseError, parseNIP47Request } from "./protocol";
 
 /**
  * TTL Map implementation with automatic cleanup
@@ -415,7 +415,9 @@ export class NostrWalletService {
         }
       } catch (error) {
         if (error instanceof SecurityValidationError) {
-          this.logger.warn("NIP-47: Bounds checking error in expiration parsing");
+          this.logger.warn(
+            "NIP-47: Bounds checking error in expiration parsing",
+          );
         }
       }
 
@@ -545,9 +547,7 @@ export class NostrWalletService {
             event.content,
           );
         }
-        this.logger.trace(
-          "Successfully decrypted request content",
-        );
+        this.logger.trace("Successfully decrypted request content");
       } catch (decryptError) {
         this.logger.error(
           "Failed to decrypt message:",
@@ -636,7 +636,9 @@ export class NostrWalletService {
         await this.sendErrorResponse(
           requesterClientPubkey,
           this.pubkey,
-          NIP47ErrorCode.INTERNAL_ERROR,
+          error instanceof NIP47RequestParseError
+            ? NIP47ErrorCode.INVALID_REQUEST
+            : NIP47ErrorCode.INTERNAL_ERROR,
           error instanceof Error ? error.message : "Internal server error",
           event.id,
           methodForError,

--- a/src/nip47/service.ts
+++ b/src/nip47/service.ts
@@ -17,12 +17,6 @@ import {
   ERROR_CATEGORIES,
   ERROR_RECOVERY_HINTS,
   NIP47NotificationType,
-  NIP47RequestParams,
-  PayInvoiceParams,
-  MakeInvoiceParams,
-  LookupInvoiceParams,
-  ListTransactionsParams,
-  SignMessageParams,
   NIP47ResponseResult,
   NIP47EncryptionScheme,
 } from "./types";
@@ -34,6 +28,8 @@ import {
 import { maybeUnref } from "../utils/timers";
 import { Logger, LogLevel } from "../utils/logger";
 import type { DiagnosticLogger } from "../utils/logger";
+import { dispatchNIP47Request } from "./requestDispatcher";
+import { parseNIP47Request } from "./protocol";
 
 /**
  * TTL Map implementation with automatic cleanup
@@ -562,7 +558,7 @@ export class NostrWalletService {
         return;
       }
 
-      nip47Request = JSON.parse(decryptedContent) as NIP47Request;
+      nip47Request = parseNIP47Request(decryptedContent);
 
       // Now that we have the request method, we can use it if an expiration occurs during processing
 
@@ -759,268 +755,13 @@ export class NostrWalletService {
     };
   }
 
-  /**
-   * Type guard for PayInvoiceParams
-   */
-  private isPayInvoiceParams(
-    method: NIP47Method,
-    params: NIP47RequestParams,
-  ): params is PayInvoiceParams {
-    return (
-      method === NIP47Method.PAY_INVOICE &&
-      typeof params === "object" &&
-      params !== null &&
-      typeof (params as PayInvoiceParams).invoice === "string" &&
-      ((params as PayInvoiceParams).amount === undefined ||
-        typeof (params as PayInvoiceParams).amount === "number") &&
-      ((params as PayInvoiceParams).maxfee === undefined ||
-        typeof (params as PayInvoiceParams).maxfee === "number")
-    );
-  }
-
-  /**
-   * Type guard for MakeInvoiceParams
-   */
-  private isMakeInvoiceParams(
-    method: NIP47Method,
-    params: NIP47RequestParams,
-  ): params is MakeInvoiceParams {
-    return (
-      method === NIP47Method.MAKE_INVOICE &&
-      typeof params === "object" &&
-      params !== null &&
-      typeof (params as MakeInvoiceParams).amount === "number" &&
-      ((params as MakeInvoiceParams).description === undefined ||
-        typeof (params as MakeInvoiceParams).description === "string") &&
-      ((params as MakeInvoiceParams).description_hash === undefined ||
-        typeof (params as MakeInvoiceParams).description_hash === "string") &&
-      ((params as MakeInvoiceParams).expiry === undefined ||
-        typeof (params as MakeInvoiceParams).expiry === "number")
-    );
-  }
-
-  /**
-   * Type guard for LookupInvoiceParams
-   */
-  private isLookupInvoiceParams(
-    method: NIP47Method,
-    params: NIP47RequestParams,
-  ): params is LookupInvoiceParams {
-    return (
-      method === NIP47Method.LOOKUP_INVOICE &&
-      typeof params === "object" &&
-      params !== null &&
-      // Must have at least one of payment_hash or invoice
-      (typeof (params as LookupInvoiceParams).payment_hash === "string" ||
-        typeof (params as LookupInvoiceParams).invoice === "string")
-    );
-  }
-
-  /**
-   * Type guard for ListTransactionsParams
-   */
-  private isListTransactionsParams(
-    method: NIP47Method,
-    params: NIP47RequestParams,
-  ): params is ListTransactionsParams {
-    return (
-      method === NIP47Method.LIST_TRANSACTIONS &&
-      typeof params === "object" &&
-      params !== null &&
-      ((params as ListTransactionsParams).from === undefined ||
-        typeof (params as ListTransactionsParams).from === "number") &&
-      ((params as ListTransactionsParams).until === undefined ||
-        typeof (params as ListTransactionsParams).until === "number") &&
-      ((params as ListTransactionsParams).limit === undefined ||
-        typeof (params as ListTransactionsParams).limit === "number") &&
-      ((params as ListTransactionsParams).offset === undefined ||
-        typeof (params as ListTransactionsParams).offset === "number") &&
-      ((params as ListTransactionsParams).unpaid === undefined ||
-        typeof (params as ListTransactionsParams).unpaid === "boolean") &&
-      ((params as ListTransactionsParams).type === undefined ||
-        typeof (params as ListTransactionsParams).type === "string")
-    );
-  }
-
-  /**
-   * Type guard for SignMessageParams
-   */
-  private isSignMessageParams(
-    method: NIP47Method,
-    params: NIP47RequestParams,
-  ): params is SignMessageParams {
-    return (
-      method === NIP47Method.SIGN_MESSAGE &&
-      typeof params === "object" &&
-      params !== null &&
-      typeof (params as SignMessageParams).message === "string"
-    );
-  }
-
-  /**
-   * Handle a request and produce a response
-   */
-  private async handleRequest(request: NIP47Request): Promise<NIP47Response> {
-    // Check if method is supported
-    if (!this.supportedMethods.includes(request.method)) {
-      return this.createErrorResponse(
-        request.method,
-        NIP47ErrorCode.INVALID_REQUEST,
-        `Method ${request.method} not supported`,
-      );
-    }
-
-    try {
-      let result;
-
-      // Execute the appropriate method
-      switch (request.method) {
-        case NIP47Method.GET_INFO:
-          result = await this.walletImpl.getInfo();
-          // Add encryption information to the result
-          result = {
-            ...result,
-            encryption: this.supportedEncryption,
-          };
-          break;
-
-        case NIP47Method.GET_BALANCE:
-          result = await this.walletImpl.getBalance();
-          break;
-
-        case NIP47Method.PAY_INVOICE:
-          if (this.isPayInvoiceParams(request.method, request.params)) {
-            result = await this.walletImpl.payInvoice(
-              request.params.invoice,
-              request.params.amount,
-              request.params.maxfee,
-            );
-          } else {
-            return this.createErrorResponse(
-              request.method,
-              NIP47ErrorCode.INVALID_REQUEST,
-              "Invalid parameters for pay_invoice method",
-            );
-          }
-          break;
-
-        case NIP47Method.MAKE_INVOICE:
-          if (this.isMakeInvoiceParams(request.method, request.params)) {
-            result = await this.walletImpl.makeInvoice(
-              request.params.amount,
-              request.params.description,
-              request.params.description_hash,
-              request.params.expiry,
-            );
-          } else {
-            return this.createErrorResponse(
-              request.method,
-              NIP47ErrorCode.INVALID_REQUEST,
-              "Invalid parameters for make_invoice method",
-            );
-          }
-          break;
-
-        case NIP47Method.LOOKUP_INVOICE:
-          if (this.isLookupInvoiceParams(request.method, request.params)) {
-            try {
-              result = await this.walletImpl.lookupInvoice({
-                payment_hash: request.params.payment_hash,
-                invoice: request.params.invoice,
-              });
-            } catch (error: unknown) {
-              const err = error as {
-                code?: NIP47ErrorCode;
-                message?: string;
-                data?: Record<string, unknown>;
-              };
-              // Enhance NOT_FOUND errors with more context for lookupInvoice
-              if (err.code === NIP47ErrorCode.NOT_FOUND) {
-                const lookupType = request.params.payment_hash
-                  ? "payment_hash"
-                  : "invoice";
-                const lookupValue =
-                  request.params.payment_hash || request.params.invoice;
-
-                return this.createErrorResponse(
-                  request.method,
-                  NIP47ErrorCode.NOT_FOUND,
-                  `Invoice not found: Could not find ${lookupType}: ${lookupValue} in the wallet's database`,
-                );
-              }
-              throw error;
-            }
-          } else {
-            return this.createErrorResponse(
-              request.method,
-              NIP47ErrorCode.INVALID_REQUEST,
-              "Invalid parameters for lookup_invoice method",
-            );
-          }
-          break;
-
-        case NIP47Method.LIST_TRANSACTIONS: {
-          if (this.isListTransactionsParams(request.method, request.params)) {
-            const transactions = await this.walletImpl.listTransactions(
-              request.params.from,
-              request.params.until,
-              request.params.limit,
-              request.params.offset,
-              request.params.unpaid,
-              request.params.type,
-            );
-            result = { transactions };
-          } else {
-            return this.createErrorResponse(
-              request.method,
-              NIP47ErrorCode.INVALID_REQUEST,
-              "Invalid parameters for list_transactions method",
-            );
-          }
-          break;
-        }
-
-        case NIP47Method.SIGN_MESSAGE:
-          if (this.isSignMessageParams(request.method, request.params)) {
-            if (!this.walletImpl.signMessage) {
-              return this.createErrorResponse(
-                request.method,
-                NIP47ErrorCode.INVALID_REQUEST,
-                "sign_message method not implemented by wallet",
-              );
-            }
-            result = await this.walletImpl.signMessage(request.params.message);
-          } else {
-            return this.createErrorResponse(
-              request.method,
-              NIP47ErrorCode.INVALID_REQUEST,
-              "Invalid parameters for sign_message method",
-            );
-          }
-          break;
-
-        default:
-          return this.createErrorResponse(
-            request.method,
-            NIP47ErrorCode.INVALID_REQUEST,
-            `Method ${request.method} not supported`,
-          );
-      }
-
-      return this.createSuccessResponse(request.method, result);
-    } catch (error: unknown) {
-      const err = error as {
-        code?: NIP47ErrorCode;
-        message?: string;
-        data?: Record<string, unknown>;
-      };
-      return this.createErrorResponse(
-        request.method,
-        err.code || NIP47ErrorCode.INTERNAL_ERROR,
-        err.message || "An error occurred processing the request",
-        err.data,
-      );
-    }
+  /** Delegate pure parameter validation and wallet invocation. */
+  private handleRequest(request: NIP47Request): Promise<NIP47Response> {
+    return dispatchNIP47Request(request, {
+      wallet: this.walletImpl,
+      supportedMethods: this.supportedMethods,
+      supportedEncryption: this.supportedEncryption,
+    });
   }
 
   /**

--- a/tests/nip47/nip47.test.ts
+++ b/tests/nip47/nip47.test.ts
@@ -164,6 +164,14 @@ interface ServiceWithPrivates {
   handleEvent: (
     event: import("../../src/types/nostr").NostrEvent,
   ) => Promise<void>;
+  sendErrorResponse: (
+    clientPubkey: string,
+    serviceContextPubkey: string,
+    errorCode: NIP47ErrorCode,
+    errorMessage: string,
+    requestId: string,
+    method: NIP47Method,
+  ) => Promise<void>;
 }
 
 interface ClientInitializationState {
@@ -347,8 +355,7 @@ describe("NIP-47 client initialization fallback", () => {
   );
 
   it("invalidates an in-flight initialization when disconnected", async () => {
-    const { fallbackClient, internals, subscriptions } =
-      createFallbackClient();
+    const { fallbackClient, internals, subscriptions } = createFallbackClient();
     let releaseCapabilityWait!: () => void;
     const capabilityWaitGate = new Promise<void>((resolve) => {
       releaseCapabilityWait = resolve;
@@ -668,7 +675,9 @@ describe("NIP-47: Nostr Wallet Connect", () => {
         expect(diagnostics).not.toContain(connectionOptions.secret);
         expect(diagnostics).not.toContain(diagnosticClient.getPublicKey());
         expect(diagnostics).not.toMatch(/\b[0-9a-f]{64}\b/i);
-        expect(diagnostics).not.toMatch(/event id|request id|subscription ids?/i);
+        expect(diagnostics).not.toMatch(
+          /event id|request id|subscription ids?/i,
+        );
       } finally {
         await diagnosticClient.disconnect();
       }
@@ -1032,16 +1041,13 @@ describe("NIP-47: Nostr Wallet Connect", () => {
 
         // Verify the error was logged
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          expect.stringContaining(
-            "Failed to decrypt message:",
-          ),
+          expect.stringContaining("Failed to decrypt message:"),
           expect.any(Error),
         );
 
         // Verify the map was cleaned up
         expect(requestEncryptionMap.size).toBe(initialSize);
         expect(requestEncryptionMap.has(event.id)).toBe(false);
-
         consoleErrorSpy.mockRestore();
       });
 
@@ -1100,6 +1106,10 @@ describe("NIP-47: Nostr Wallet Connect", () => {
         const serviceWithPrivates = service as unknown as ServiceWithPrivates;
         const requestEncryptionMap = serviceWithPrivates.requestEncryption;
         const initialSize = requestEncryptionMap.size;
+        const sendErrorResponseSpy = jest.spyOn(
+          serviceWithPrivates,
+          "sendErrorResponse",
+        );
 
         // Spy on console.error to verify the error is logged
         const consoleErrorSpy = jest
@@ -1121,6 +1131,14 @@ describe("NIP-47: Nostr Wallet Connect", () => {
         // Verify the map was cleaned up
         expect(requestEncryptionMap.size).toBe(initialSize);
         expect(requestEncryptionMap.has(event.id)).toBe(false);
+        expect(sendErrorResponseSpy).toHaveBeenCalledWith(
+          clientKeypair.publicKey,
+          serviceKeypair.publicKey,
+          NIP47ErrorCode.INVALID_REQUEST,
+          "Invalid request: malformed JSON",
+          event.id,
+          NIP47Method.UNKNOWN,
+        );
 
         consoleErrorSpy.mockRestore();
       });

--- a/tests/nip47/protocol.test.ts
+++ b/tests/nip47/protocol.test.ts
@@ -1,0 +1,52 @@
+import {
+  generateNWCURL,
+  parseNIP47Request,
+  parseNIP47Response,
+  parseNWCURL,
+  validateNIP47Response,
+} from "../../src/nip47/protocol";
+
+describe("NIP-47 protocol codecs", () => {
+  test("round-trips encoded relay URLs without losing repeats", () => {
+    const options = {
+      pubkey: "wallet",
+      secret: "secret",
+      relays: ["wss://one.example/path", "wss://two.example"],
+    };
+
+    expect(parseNWCURL(generateNWCURL(options))).toEqual(options);
+  });
+
+  test("keeps the caller's protocol error type", () => {
+    class ProtocolError extends Error {}
+
+    expect(() =>
+      validateNIP47Response({}, (message) => new ProtocolError(message)),
+    ).toThrow(ProtocolError);
+    expect(() =>
+      parseNIP47Response("{", (message) => new ProtocolError(message)),
+    ).toThrow(ProtocolError);
+  });
+
+  test("normalizes an omitted success error field", () => {
+    expect(
+      validateNIP47Response(
+        { result_type: "get_balance", result: 1 },
+        (message) => new Error(message),
+      ),
+    ).toEqual({ result_type: "get_balance", result: 1, error: null });
+  });
+
+  test("parses request envelopes and rejects missing params", () => {
+    expect(parseNIP47Request('{"method":"get_balance","params":{}}')).toEqual({
+      method: "get_balance",
+      params: {},
+    });
+    expect(() => parseNIP47Request('{"method":"get_balance"}')).toThrow(
+      "Invalid request: missing or invalid params",
+    );
+    expect(() =>
+      parseNIP47Request('{"method":"get_balance","params":[]}'),
+    ).toThrow("Invalid request: missing or invalid params");
+  });
+});

--- a/tests/nip47/protocol.test.ts
+++ b/tests/nip47/protocol.test.ts
@@ -15,6 +15,9 @@ describe("NIP-47 protocol codecs", () => {
     };
 
     expect(parseNWCURL(generateNWCURL(options))).toEqual(options);
+    expect(() =>
+      parseNWCURL("nostr+walletconnect://wallet?secret=secret"),
+    ).toThrow("At least one relay must be specified");
   });
 
   test("keeps the caller's protocol error type", () => {
@@ -48,5 +51,8 @@ describe("NIP-47 protocol codecs", () => {
     expect(() =>
       parseNIP47Request('{"method":"get_balance","params":[]}'),
     ).toThrow("Invalid request: missing or invalid params");
+    expect(() => parseNIP47Request("{")).toThrow(
+      "Invalid request: malformed JSON",
+    );
   });
 });

--- a/tests/nip47/requestDispatcher.test.ts
+++ b/tests/nip47/requestDispatcher.test.ts
@@ -1,0 +1,94 @@
+import { dispatchNIP47Request } from "../../src/nip47/requestDispatcher";
+import {
+  NIP47EncryptionScheme,
+  NIP47ErrorCode,
+  NIP47Method,
+  WalletImplementation,
+} from "../../src/nip47/types";
+
+function wallet(): jest.Mocked<WalletImplementation> {
+  return {
+    getInfo: jest.fn(async () => ({ methods: ["get_info"] })),
+    getBalance: jest.fn(async () => 42),
+    payInvoice: jest.fn(),
+    makeInvoice: jest.fn(),
+    lookupInvoice: jest.fn(),
+    listTransactions: jest.fn(async () => []),
+    signMessage: jest.fn(),
+  };
+}
+
+describe("NIP-47 request dispatcher", () => {
+  const supportedEncryption = [NIP47EncryptionScheme.NIP44_V2];
+
+  test("validates parameters before invoking the wallet", async () => {
+    const implementation = wallet();
+    const response = await dispatchNIP47Request(
+      {
+        method: NIP47Method.PAY_INVOICE,
+        params: { invoice: 1 } as never,
+      },
+      {
+        wallet: implementation,
+        supportedMethods: [NIP47Method.PAY_INVOICE],
+        supportedEncryption,
+      },
+    );
+
+    expect(implementation.payInvoice).not.toHaveBeenCalled();
+    expect(response.error?.code).toBe(NIP47ErrorCode.INVALID_REQUEST);
+    expect(response.error?.message).toBe(
+      "Invalid parameters for pay_invoice method",
+    );
+  });
+
+  test("dispatches supported methods and preserves result envelopes", async () => {
+    const implementation = wallet();
+    const response = await dispatchNIP47Request(
+      { method: NIP47Method.GET_BALANCE, params: {} },
+      {
+        wallet: implementation,
+        supportedMethods: [NIP47Method.GET_BALANCE],
+        supportedEncryption,
+      },
+    );
+
+    expect(response).toEqual({
+      result_type: NIP47Method.GET_BALANCE,
+      result: 42,
+      error: null,
+    });
+  });
+
+  test("reports unsupported methods without touching the wallet", async () => {
+    const implementation = wallet();
+    const response = await dispatchNIP47Request(
+      { method: NIP47Method.GET_BALANCE, params: {} },
+      { wallet: implementation, supportedMethods: [], supportedEncryption },
+    );
+
+    expect(implementation.getBalance).not.toHaveBeenCalled();
+    expect(response.error?.message).toBe("Method get_balance not supported");
+  });
+
+  test("keeps lookup not-found compatibility context", async () => {
+    const implementation = wallet();
+    implementation.lookupInvoice.mockRejectedValue({
+      code: NIP47ErrorCode.NOT_FOUND,
+    });
+    const response = await dispatchNIP47Request(
+      {
+        method: NIP47Method.LOOKUP_INVOICE,
+        params: { payment_hash: "missing" },
+      },
+      {
+        wallet: implementation,
+        supportedMethods: [NIP47Method.LOOKUP_INVOICE],
+        supportedEncryption,
+      },
+    );
+
+    expect(response.error?.code).toBe(NIP47ErrorCode.NOT_FOUND);
+    expect(response.error?.message).toContain("payment_hash: missing");
+  });
+});

--- a/tests/nip47/requestDispatcher.test.ts
+++ b/tests/nip47/requestDispatcher.test.ts
@@ -91,4 +91,22 @@ describe("NIP-47 request dispatcher", () => {
     expect(response.error?.code).toBe(NIP47ErrorCode.NOT_FOUND);
     expect(response.error?.message).toContain("payment_hash: missing");
   });
+
+  test("rejects an invalid secondary lookup identifier", async () => {
+    const implementation = wallet();
+    const response = await dispatchNIP47Request(
+      {
+        method: NIP47Method.LOOKUP_INVOICE,
+        params: { payment_hash: "valid", invoice: 1 } as never,
+      },
+      {
+        wallet: implementation,
+        supportedMethods: [NIP47Method.LOOKUP_INVOICE],
+        supportedEncryption,
+      },
+    );
+
+    expect(implementation.lookupInvoice).not.toHaveBeenCalled();
+    expect(response.error?.code).toBe(NIP47ErrorCode.INVALID_REQUEST);
+  });
 });


### PR DESCRIPTION
Closes #114

## Summary
- centralize NWC URL, request JSON, response JSON, and response-envelope validation in an internal protocol codec
- centralize supported-method gating, parameter guards, wallet invocation, and response construction in an internal dispatcher
- keep relay lifecycle, encryption negotiation, correlation, timeouts, notifications, and publishing in the public client/service
- add direct codec and dispatcher tests while preserving existing public behavior and error mapping

## Verification
- focused NIP-47: 8 suites, 70/70
- full Jest and Bun: 1021/1021 each
- commands validation, lint, root/examples typechecks
- CJS/ESM builds, examples build, pack verification
- local CodeRabbit: 2 fixed; 7 evidence-based compatibility/security-scope skips

## Delegation note
The owner-required Grok `agent` CLI was present but unauthenticated, so no substitute delegated subagent was used; implementation and local review were completed directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added NIP-47 protocol support for parsing/generating wallet connection URLs and request/response payloads.
  - Added standardized NIP-47 request dispatching with method-based validation and consistent response envelopes.
  - Improved in-flight request state cleanup with automatic TTL expiration.
- **Bug Fixes**
  - Preserved repeated relay entries when processing wallet connection URLs.
  - Improved handling of malformed/invalid request and response payloads with clearer error responses.
- **Documentation**
  - Added and updated issue `#114` review/session/verification documentation and refreshed cleanup ticket ledgers.
- **Tests**
  - Added protocol and dispatcher test coverage, including wallet error scenarios and validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->