### PR TITLE
refactor: extract Nostr relay registry

### DIFF
--- a/docs/agents/runs/deep-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/deep-cleanup-1-8-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, rebased from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: issues #112, #118, and #113 merged into `staging`; issue #114 implementation in progress
+- Current status: issues #112, #118, #113, and #114 merged into `staging`; issue #115 implementation in progress
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, single-context domain docs)
 
 ## Goal
@@ -27,7 +27,7 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 - Agent briefs: Grok 4.5 is the only owner-approved delegated sidecar; `agent` authentication was unavailable at preflight, so no substitute subagent is used and Codex owns local execution/review
 - Review packets: created per ticket
 - Local CodeRabbit report: issue #112 round completed with five worthy fixes in `issue-112-coderabbit-local.md`
-- PR URLs: #120 for issue #112, #121 for issue #118, #122 for issue #113 (all merged); later tickets pending
+- PR URLs: #120 for issue #112, #121 for issue #118, #122 for issue #113, #123 for issue #114 (all merged); later tickets pending
 
 ## Commands
 
@@ -44,8 +44,8 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 | #112 NIP-44 legacy behavior | AFK | merged into `staging` | `feature/nip44-legacy-compat` | standards/spec pass; local CodeRabbit 5 fixed; hosted CodeRabbit 3 fixed | yes |
 | #118 authoritative protocol messages | AFK | merged into `staging` | `feature/protocol-message-types` | standards/spec pass; local CodeRabbit 4 fixed, 1 evidence-based skip; hosted 2 fixed | Jest 994/994; Bun full; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
 | #113 Relay event-store seam | AFK | merged into `staging` | `feature/relay-event-store` | standards/spec pass; local CodeRabbit 4 fixed; hosted clean | focused Jest/Bun 80/80; full Jest/Bun 1013/1013; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
-| #114 NIP-47 protocol machinery | AFK | hosted review fixes verified; hosted matrix rerunning | `feature/nip47-protocol-codecs` | standards/spec pass; local CodeRabbit 2 fixed, 7 compatibility skips; hosted 3 fixed | focused 71/71; pre-hosted-fix full Jest/Bun 1021/1021; commands, lint, types, builds, pack |
-| #115 Nostr relay registry | AFK | blocked by #113 | `feature/nostr-relay-registry` | pending | no |
+| #114 NIP-47 protocol machinery | AFK | merged into `staging` | `feature/nip47-protocol-codecs` | standards/spec pass; local CodeRabbit 2 fixed, 7 compatibility skips; hosted 3 fixed; final hosted clean | focused 71/71; full Jest/Bun 1021/1021; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
+| #115 Nostr relay registry | AFK | implementation, local review, and full matrix verified | `feature/nostr-relay-registry` | standards/spec pass; local CodeRabbit 1 fixed | focused 61/61; full Jest/Bun 1026/1026; commands, lint, types, builds, pack |
 | #116 ephemeral Relay ownership | AFK | blocked by #113 | `feature/ephemeral-relay-ownership` | pending | no |
 | #117 security validation ownership | AFK | blocked by #113 and #115 | `feature/security-validation-ownership` | pending | no |
 | #119 package-manager policy | AFK | ready | `feature/package-manager-policy` | pending | no |
@@ -63,7 +63,8 @@ Complete cleanup items 1–8 from the post-v0.5.0 repository audit end to end, b
 | #112 | `df13432` | current Codex orchestrator; Grok unavailable at auth preflight | PR #120, merge `c7cb99f` | standards/spec pass after one fix; local CodeRabbit 5/5 and hosted CodeRabbit 3/3 fixed | NIP-44 107/107; Jest 991/991; Bun 991/991; hosted Node 16/18/20 + Bun; lint, types, builds, commands, pack |
 | #118 | `c7cb99f` | current Codex orchestrator; Grok unavailable at auth preflight | PR #121, merge `8c36233` | standards/spec pass; local CodeRabbit 4 fixed, 1 skipped with type evidence; hosted 2/2 fixed | Jest 994/994; Bun full; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
 | #113 | `8c36233` | current Codex orchestrator; Grok unavailable at auth preflight | PR #122, merge `da7361e` | standards/spec pass; local CodeRabbit 4/4 fixed; hosted clean | focused Relay/store Jest and Bun 80/80; full Jest/Bun 1013/1013; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
-| #114 | `da7361e` | current Codex orchestrator; Grok unavailable at auth preflight | PR #123 pending | standards/spec pass; local CodeRabbit 2 fixed, 7 skipped to preserve public compatibility; hosted 3 fixed | focused NIP-47 71/71; pre-hosted-fix full Jest/Bun 1021/1021; commands, lint, types, builds, pack; hosted rerun pending |
+| #114 | `da7361e` | current Codex orchestrator; Grok unavailable at auth preflight | PR #123, merge `4e40b63` | standards/spec pass; local CodeRabbit 2 fixed, 7 skipped to preserve public compatibility; hosted 3 fixed; final hosted clean | focused NIP-47 71/71; full Jest/Bun 1021/1021; hosted Node 16/18/20 + Bun; commands, lint, types, builds, pack |
+| #115 | `4e40b63` | current Codex orchestrator; Grok unavailable at auth preflight | pending | standards/spec pass; local CodeRabbit 1/1 fixed | focused Nostr/registry/integration 61/61; full Jest/Bun 1026/1026; commands, lint, types, builds, pack |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/issue-115-coderabbit-local.md
+++ b/docs/agents/runs/issue-115-coderabbit-local.md
@@ -1,0 +1,20 @@
+# CodeRabbit Round: #115 Local Branch
+
+## Round
+
+- Scope: local
+- Command: `coderabbit review --agent --type all --base staging`
+- Completed: 2026-07-18
+- Findings: 1
+
+## Decisions
+
+| Finding | Decision | Notes |
+| --- | --- | --- |
+| Map-compatible accessors bypassed canonical identity and disconnect ownership | fixed | Get/has canonicalize gracefully; set canonicalizes and disconnects a displaced Relay; delete canonicalizes and disconnects the removed Relay. |
+
+## Result
+
+- Worthy findings fixed: 1
+- Findings skipped: 0
+- Post-fix focused verification: 61/61; full Jest/Bun 1026/1026; all types, builds, commands, and pack checks pass

--- a/docs/agents/runs/issue-115-review-packet.md
+++ b/docs/agents/runs/issue-115-review-packet.md
@@ -1,0 +1,26 @@
+# Review Packet: #115 Nostr Relay Registry
+
+## Fixed Point
+
+- Base: `staging` at `4e40b63`
+- Branch: `feature/nostr-relay-registry`
+- Issue: #115
+
+## Change Story
+
+- `RelayRegistry` owns canonical URLs, instance registration, lookup, required lookup, replacement, removal, and disconnect-on-removal.
+- `Nostr` remains the public facade and delegates only relay identity/ownership decisions.
+- Public tests prove normalized operations share one Relay and invalid lookup/removal remain graceful.
+- Direct registry tests cover replacement and deletion lifecycle policy.
+
+## Verification
+
+- Focused Nostr/registry/integration: 3 suites, 61/61
+- Full Jest: 77 suites, 1026/1026
+- Full Bun: 1026/1026
+- Commands, lint, root/examples typechecks, CJS/ESM build, examples build, and pack verification: pass
+- Local CodeRabbit: 1/1 finding fixed
+
+## Known Tooling Limitation
+
+- Grok could not be delegated because the required `agent` CLI is unauthenticated. Per the Grok skill, no substitute subagent was used.

--- a/docs/agents/runs/issue-115-session.md
+++ b/docs/agents/runs/issue-115-session.md
@@ -1,0 +1,24 @@
+# Issue Session: #115 Nostr Relay Registry
+
+## Scope
+
+- Fixed point: `4e40b63` (`staging` after PR #123)
+- Branch: `feature/nostr-relay-registry`
+- Issue: #115
+- Owner: current Codex orchestrator; Grok unavailable because `agent` authentication is required
+
+## Acceptance Map
+
+| Acceptance criterion | Implementation / verification seam |
+| --- | --- |
+| Stable public Nostr facade | unchanged constructor and relay-management signatures |
+| One owner for normalization, identity, lookup, removal, and lifecycle | `src/nip01/relayRegistry.ts` |
+| Same observable Relay set | Nostr publishing, subscriptions, auth, fetch, and rate limits iterate the registry |
+| Public behavior coverage | normalized add/get/remove and graceful invalid operations in `nostr.test.ts` |
+| Full verification | focused 61/61; full Jest/Bun 1026/1026; commands, types, builds, pack |
+
+## Decisions
+
+- Keep callback attachment and all protocol operations in the Nostr facade.
+- Keep the registry internal and Map-compatible only for existing test seams.
+- Make every compatibility accessor uphold canonical identity and disconnect ownership.

--- a/src/nip01/nostr.ts
+++ b/src/nip01/nostr.ts
@@ -11,7 +11,6 @@ import {
 } from "../types/nostr";
 import type { RelayConnectionOptions } from "../types/protocol";
 import { getPublicKey, generateKeypair } from "../utils/crypto";
-import { isValidRelayUrl } from "../nip19";
 import { createSignedAuthEvent } from "../nip42";
 import {
   createSignedEvent,
@@ -19,11 +18,6 @@ import {
   createDirectMessage,
   createMetadataEvent,
 } from "./event";
-import {
-  preprocessRelayUrl as preprocessRelayUrlUtil,
-  normalizeRelayUrl as normalizeRelayUrlUtil,
-  RelayUrlValidationError,
-} from "../utils/relayUrl";
 import { Logger, LogLevel } from "../utils/logger";
 import {
   validateFilters,
@@ -33,6 +27,7 @@ import {
   RateLimitState,
 } from "../utils/security-validator";
 import { getRegisteredNIP04 } from "../nip04/registry";
+import { RelayRegistry } from "./relayRegistry";
 
 /**
  * Rate limit configuration for different operation types
@@ -119,7 +114,7 @@ function formatRetryAfterSeconds(retryAfter?: number): number {
 }
 
 export class Nostr {
-  private relays: Map<string, Relay> = new Map();
+  private relays: RelayRegistry;
   private privateKey?: string;
   private publicKey?: string;
   private relayOptions?: RelayConnectionOptions;
@@ -161,6 +156,7 @@ export class Nostr {
    */
   constructor(relayUrls: string[] = [], options?: NostrOptions) {
     this.relayOptions = options?.relayOptions;
+    this.relays = new RelayRegistry(this.relayOptions);
 
     // Initialize rate limits with defaults or user-provided values
     this.RATE_LIMITS = {
@@ -179,30 +175,6 @@ export class Nostr {
       silent: process.env.NODE_ENV === "test",
     });
     relayUrls.forEach((url) => this.addRelay(url));
-  }
-
-  /**
-   * Normalize a relay URL by lowercasing only the scheme and host,
-   * while preserving the case of path, query, and fragment parts.
-   * This is the correct behavior per URL standards.
-   */
-  private normalizeRelayUrl(url: string): string {
-    // Delegate to shared utility for consistent canonicalization
-    return normalizeRelayUrlUtil(url);
-  }
-
-  /**
-   * Preprocesses a relay URL before normalization and validation.
-   * Adds wss:// prefix only to URLs without any scheme.
-   * Throws an error for URLs with incompatible schemes.
-   *
-   * @param url - The input URL string to preprocess
-   * @returns The preprocessed URL with appropriate scheme
-   * @throws Error if URL has an incompatible scheme
-   */
-  private preprocessRelayUrl(url: string): string {
-    // Delegate to shared utility for consistent preprocessing
-    return preprocessRelayUrlUtil(url);
   }
 
   // Helper function to create the event handler wrapper
@@ -258,18 +230,10 @@ export class Nostr {
   }
 
   public addRelay(url: string): Relay {
-    url = this.preprocessRelayUrl(url);
-    url = this.normalizeRelayUrl(url);
-    if (!isValidRelayUrl(url)) {
-      throw new Error(`Invalid relay URL: ${url}`);
-    }
-
-    if (this.relays.has(url)) {
-      return this.relays.get(url)!;
-    }
-
-    const relay = new Relay(url, this.relayOptions);
-    this.relays.set(url, relay);
+    const registration = this.relays.register(url);
+    if (!registration.created) return registration.relay;
+    const { relay } = registration;
+    url = registration.url;
 
     // Attach stored callbacks to the new relay
     this.eventCallbacks.forEach((callbacksSet, eventType) => {
@@ -308,46 +272,11 @@ export class Nostr {
   }
 
   public getRelay(url: string): Relay | undefined {
-    // Re-use the same normalisation logic as addRelay()
-    try {
-      url = this.preprocessRelayUrl(url);
-      url = this.normalizeRelayUrl(url);
-      if (!isValidRelayUrl(url)) {
-        return undefined;
-      }
-      return this.relays.get(url);
-    } catch (error) {
-      // Handle RelayUrlValidationError and other URL processing errors gracefully
-      if (error instanceof RelayUrlValidationError) {
-        return undefined;
-      }
-      // For other unexpected errors, also return undefined for graceful handling
-      return undefined;
-    }
+    return this.relays.lookup(url);
   }
 
   public removeRelay(url: string): void {
-    // Re-use the same normalisation logic as addRelay() and getRelay()
-    try {
-      url = this.preprocessRelayUrl(url);
-      url = this.normalizeRelayUrl(url);
-      if (!isValidRelayUrl(url)) {
-        return;
-      }
-
-      const relay = this.relays.get(url);
-      if (relay) {
-        relay.disconnect();
-        this.relays.delete(url);
-      }
-    } catch (error) {
-      // Handle RelayUrlValidationError and other URL processing errors gracefully
-      if (error instanceof RelayUrlValidationError) {
-        return; // Silently ignore invalid URLs as intended
-      }
-      // For other unexpected errors, also return void for graceful handling
-      return;
-    }
+    this.relays.remove(url);
   }
 
   public async connectToRelays(): Promise<void> {
@@ -1203,9 +1132,7 @@ export class Nostr {
   ): Promise<PublishResponse> {
     this.enforcePublishRateLimit();
 
-    const normalizedRelayUrl = this.normalizeRelayUrl(
-      this.preprocessRelayUrl(relayUrl),
-    );
+    const normalizedRelayUrl = this.relays.canonicalUrl(relayUrl);
     const relay = this.getRelayByUrl(normalizedRelayUrl);
     const { createdAt, ...publishOptions } = options;
 
@@ -1239,15 +1166,7 @@ export class Nostr {
   }
 
   private getRelayByUrl(relayUrl: string): Relay {
-    const preprocessedUrl = this.preprocessRelayUrl(relayUrl);
-    const normalizedUrl = this.normalizeRelayUrl(preprocessedUrl);
-    const relay = this.relays.get(normalizedUrl);
-
-    if (!relay) {
-      throw new Error(`Relay not found: ${normalizedUrl}`);
-    }
-
-    return relay;
+    return this.relays.require(relayUrl);
   }
 
   private enforcePublishRateLimit(): void {

--- a/src/nip01/relayRegistry.ts
+++ b/src/nip01/relayRegistry.ts
@@ -1,0 +1,99 @@
+import type { RelayConnectionOptions } from "../types/protocol";
+import { isValidRelayUrl } from "../nip19";
+import { normalizeRelayUrl, preprocessRelayUrl } from "../utils/relayUrl";
+import { Relay } from "./relay";
+
+export interface RelayRegistration {
+  url: string;
+  relay: Relay;
+  created: boolean;
+}
+
+/** Owns canonical relay identity, instances, and removal lifecycle. */
+export class RelayRegistry {
+  private readonly relays = new Map<string, Relay>();
+
+  constructor(private readonly relayOptions?: RelayConnectionOptions) {}
+
+  canonicalUrl(url: string): string {
+    const canonical = normalizeRelayUrl(preprocessRelayUrl(url));
+    if (!isValidRelayUrl(canonical)) {
+      throw new Error(`Invalid relay URL: ${canonical}`);
+    }
+    return canonical;
+  }
+
+  register(url: string): RelayRegistration {
+    const canonical = this.canonicalUrl(url);
+    const existing = this.relays.get(canonical);
+    if (existing) return { url: canonical, relay: existing, created: false };
+
+    const relay = new Relay(canonical, this.relayOptions);
+    this.relays.set(canonical, relay);
+    return { url: canonical, relay, created: true };
+  }
+
+  lookup(url: string): Relay | undefined {
+    try {
+      return this.relays.get(this.canonicalUrl(url));
+    } catch {
+      return undefined;
+    }
+  }
+
+  require(url: string): Relay {
+    const canonical = this.canonicalUrl(url);
+    const relay = this.relays.get(canonical);
+    if (!relay) throw new Error(`Relay not found: ${canonical}`);
+    return relay;
+  }
+
+  remove(url: string): void {
+    this.delete(url);
+  }
+
+  get size(): number {
+    return this.relays.size;
+  }
+
+  get(url: string): Relay | undefined {
+    return this.lookup(url);
+  }
+
+  set(url: string, relay: Relay): this {
+    const canonical = this.canonicalUrl(url);
+    const displaced = this.relays.get(canonical);
+    if (displaced && displaced !== relay) displaced.disconnect();
+    this.relays.set(canonical, relay);
+    return this;
+  }
+
+  has(url: string): boolean {
+    return this.lookup(url) !== undefined;
+  }
+
+  delete(url: string): boolean {
+    let canonical: string;
+    try {
+      canonical = this.canonicalUrl(url);
+    } catch {
+      return false;
+    }
+    const relay = this.relays.get(canonical);
+    if (!relay) return false;
+    relay.disconnect();
+    return this.relays.delete(canonical);
+  }
+
+  values(): IterableIterator<Relay> {
+    return this.relays.values();
+  }
+
+  entries(): IterableIterator<[string, Relay]> {
+    return this.relays.entries();
+  }
+
+  forEach(callback: (relay: Relay, url: string) => void): void {
+    this.relays.forEach(callback);
+  }
+}

--- a/tests/nip01/nostr.test.ts
+++ b/tests/nip01/nostr.test.ts
@@ -77,6 +77,27 @@ describe("Nostr Client", () => {
       expect(relays.has(normalizedRelay)).toBe(true);
     });
 
+    test("should use one Relay identity across normalized public operations", () => {
+      const parsed = new URL(ephemeralRelay.url);
+      const equivalentUrl = `${parsed.protocol}//${parsed.hostname.toUpperCase()}:${parsed.port}/`;
+
+      const existing = client.getRelay(ephemeralRelay.url);
+      expect(client.addRelay(equivalentUrl)).toBe(existing);
+      expect(client.getRelay(equivalentUrl)).toBe(existing);
+      expect(getNostrInternals(client).relays.size).toBe(1);
+
+      client.removeRelay(equivalentUrl);
+      expect(client.getRelay(ephemeralRelay.url)).toBeUndefined();
+    });
+
+    test("should keep invalid public lookup and removal operations graceful", () => {
+      expect(client.getRelay("https://not-a-relay.example")).toBeUndefined();
+      expect(() =>
+        client.removeRelay("https://not-a-relay.example"),
+      ).not.toThrow();
+      expect(getNostrInternals(client).relays.size).toBe(1);
+    });
+
     test("should connect to relays", async () => {
       let connectCount = 0;
       client.on(RelayEvent.Connect, () => {

--- a/tests/nip01/relay/relayRegistry.test.ts
+++ b/tests/nip01/relay/relayRegistry.test.ts
@@ -1,0 +1,30 @@
+import { Relay } from "../../../src/nip01/relay";
+import { RelayRegistry } from "../../../src/nip01/relayRegistry";
+
+describe("RelayRegistry", () => {
+  test("canonicalizes Map-compatible access and owns replacement lifecycle", () => {
+    const registry = new RelayRegistry();
+    const first = new Relay("wss://relay.example/path");
+    const second = new Relay("wss://relay.example/path");
+    const firstDisconnect = jest.spyOn(first, "disconnect");
+    const secondDisconnect = jest.spyOn(second, "disconnect");
+
+    registry.set("wss://RELAY.EXAMPLE/path", first);
+    expect(registry.get("relay.example/path")).toBe(first);
+    expect(registry.has("wss://relay.example/path")).toBe(true);
+
+    registry.set("wss://relay.example/path", second);
+    expect(firstDisconnect).toHaveBeenCalledTimes(1);
+    expect(registry.delete("RELAY.EXAMPLE/path")).toBe(true);
+    expect(secondDisconnect).toHaveBeenCalledTimes(1);
+    expect(registry.size).toBe(0);
+  });
+
+  test("keeps invalid lookup and deletion graceful", () => {
+    const registry = new RelayRegistry();
+
+    expect(registry.get("https://invalid.example")).toBeUndefined();
+    expect(registry.has("https://invalid.example")).toBe(false);
+    expect(registry.delete("https://invalid.example")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #115

## Summary
- add an internal RelayRegistry as the canonical owner of relay URL identity, registration, lookup, replacement, removal, and disconnect lifecycle
- keep Nostr as the stable public facade for callbacks, publishing, subscriptions, authentication, fetches, and rate limiting
- preserve Map-compatible test seams while enforcing registry policy through them
- add public normalized add/get/remove coverage plus deterministic replacement/deletion lifecycle tests

## Verification
- focused Nostr/registry/integration: 3 suites, 61/61
- full Jest and Bun: 1026/1026 each
- commands validation, lint, root/examples typechecks
- CJS/ESM builds, examples build, pack verification
- local CodeRabbit: 1/1 finding fixed

## Delegation note
The owner-required Grok `agent` CLI was present but unauthenticated, so no substitute delegated subagent was used; implementation and local review were completed directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized relay management with URL canonicalization, registration, lookup, replacement, and removal.
  * Relay operations now consistently reuse equivalent relay URLs and safely handle invalid or unknown URLs.
  * Added documentation covering the relay registry implementation, review process, and verification results.

* **Bug Fixes**
  * Improved relay replacement and disconnection handling.

* **Tests**
  * Added coverage for URL normalization, relay identity reuse, safe lookups, deletion behavior, and disconnect handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->