### PR TITLE
fix(nip46): redact sensitive diagnostics

### DIFF
--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -1,0 +1,83 @@
+# Feature Dev Run Ledger: High-impact Cleanup 1–9
+
+## Run
+
+- Run ID: `snstr-cleanup-1-9-20260718`
+- Loop: nine sequential `feature-dev` runs
+- Target repo: `snstr`
+- Base branch: `staging`
+- Feature branches: one branch per approved ticket, created from the latest integrated `staging`
+- Human owner: plebdev
+- Started: 2026-07-18
+- Current status: item 1 / issue #131 in implementation on `feature/nip46-diagnostic-redaction`
+- Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
+
+## Goal
+
+Complete cleanup items 1–9 from the staging audit end to end, branch by branch, with every healthy slice reviewed, verified, and merged into `staging`: redact NIP-46 diagnostics, remove Jest from published declarations, complete the shared diagnostic seam, make NIP-47 lifecycle restart-safe, consolidate NIP-57 behavior, unify the NIP-46 protocol core, shorten the default test loop, move tests off private shapes, and split ephemeral Relay internals.
+
+## Durable Artifacts
+
+- CONTEXT updates: none currently required; existing Nostr Event, Relay, Subscription Filter, and NIP terms cover the work
+- ADRs: ADR 0002 governs compatible diagnostic consolidation; no new hard-to-reverse decision identified yet
+- Prototype source branch, if any: none
+- Spec issue: #130 — Complete the high-impact cleanup chain
+- Tickets: #131–#139
+- Ticket sessions: created as each ticket starts
+- Agent briefs: Grok 4.5 is the exclusive delegated sidecar; authentication is pending at preflight and no substitute subagent is authorized
+- Review packets: created per ticket
+- Local CodeRabbit report: created per ticket
+- PR URL: created per ticket, always non-draft and targeting `staging`
+
+## Commands
+
+- Install: `npm ci`; compatibility lane `bun install --frozen-lockfile`
+- Typecheck: `npx tsc --noEmit -p tsconfig.json` and packed-consumer checks where relevant
+- Test: focused Jest/Bun suites during TDD; full Jest and Bun suites once per issue
+- Build: `npm run commands:verify && npm run package-manager:verify && npm run lint && npm run build && npm run build:examples && npm run pack:verify`
+- Visual verification: not applicable
+
+## Ticket Ledger
+
+| Issue                             | Type | Status            | Branch                                  | Review  | Verified |
+| --------------------------------- | ---- | ----------------- | --------------------------------------- | ------- | -------- |
+| #131 NIP-46 diagnostic redaction  | AFK  | in implementation | `feature/nip46-diagnostic-redaction`    | pending | pending  |
+| #132 published declaration purity | AFK  | blocked by #131   | `feature/public-type-test-purity`       | pending | pending  |
+| #133 shared diagnostic seam       | AFK  | blocked by #132   | `feature/shared-diagnostics-completion` | pending | pending  |
+| #134 NIP-47 service lifecycle     | AFK  | blocked by #133   | `feature/nip47-service-lifecycle`       | pending | pending  |
+| #135 NIP-57 consolidation         | AFK  | blocked by #134   | `feature/nip57-client-consolidation`    | pending | pending  |
+| #136 NIP-46 protocol core         | AFK  | blocked by #135   | `feature/nip46-protocol-core`           | pending | pending  |
+| #137 default test feedback loop   | AFK  | blocked by #136   | `feature/fast-default-test-loop`        | pending | pending  |
+| #138 public behavior test seams   | AFK  | blocked by #137   | `feature/public-behavior-test-seams`    | pending | pending  |
+| #139 ephemeral Relay internals    | AFK  | blocked by #138   | `feature/ephemeral-relay-internals`     | pending | pending  |
+
+## Parked HITL Slices
+
+| Issue | Why parked | Blocks | Required human action | Final PR decision |
+| ----- | ---------- | ------ | --------------------- | ----------------- |
+| None  | —          | —      | —                     | —                 |
+
+## Issue Session Ledger
+
+| Issue | Fixed point | Implementation owner                          | Commit  | Review result | Checks  |
+| ----- | ----------- | --------------------------------------------- | ------- | ------------- | ------- |
+| #131  | `f4bda34`   | current Codex orchestrator; Grok auth pending | pending | pending       | pending |
+
+## Alignment Decisions
+
+- The ranked staging audit is the authoritative scope for cleanup items 1–9.
+- The owner's instruction grants approval for the public testing seams, nine-ticket granularity, linear dependency graph, and agent-performable AFK classification.
+- Each ticket uses a dedicated branch and PR, then integrates into `staging` before dependent work begins; this intentionally runs the Feature Dev loop back to back.
+- Existing 0.x public interfaces remain compatible, except for removal of accidental Jest ownership from production declarations in issue #132.
+- NIP-46 diagnostic redaction lands before the broader NIP-46 consolidation so the canonical engine inherits the safe policy.
+- The shared core logger remains canonical and NIP-specific compatibility aliases protected by ADR 0002 remain through 0.x.
+- Grok is the exclusive delegated system. CodeRabbit remains a required review gate and is not used as an implementation subagent.
+- Production deployment, release, and promotion to `main` are out of scope.
+
+## Open Questions
+
+- None.
+
+## Escalations
+
+- Grok preflight: `agent` and Node are installed, but the Cursor CLI requires one-time browser authentication. The login session is waiting while local work proceeds.

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: item 1 / issue #131 in implementation on `feature/nip46-diagnostic-redaction`
+- Current status: item 1 / issue #131 reviewed and locally verified; delivery PR pending on `feature/nip46-diagnostic-redaction`
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -24,9 +24,9 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Spec issue: #130 — Complete the high-impact cleanup chain
 - Tickets: #131–#139
 - Ticket sessions: created as each ticket starts
-- Agent briefs: Grok 4.5 is the exclusive delegated sidecar; authentication is pending at preflight and no substitute subagent is authorized
-- Review packets: created per ticket
-- Local CodeRabbit report: created per ticket
+- Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all item #131 standards/spec passes
+- Review packets: `issue-131-review-packet.md`; created per later ticket
+- Local CodeRabbit report: `issue-131-coderabbit-local.md`; created per later ticket
 - PR URL: created per ticket, always non-draft and targeting `staging`
 
 ## Commands
@@ -39,17 +39,17 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 
 ## Ticket Ledger
 
-| Issue                             | Type | Status            | Branch                                  | Review  | Verified |
-| --------------------------------- | ---- | ----------------- | --------------------------------------- | ------- | -------- |
-| #131 NIP-46 diagnostic redaction  | AFK  | in implementation | `feature/nip46-diagnostic-redaction`    | pending | pending  |
-| #132 published declaration purity | AFK  | blocked by #131   | `feature/public-type-test-purity`       | pending | pending  |
-| #133 shared diagnostic seam       | AFK  | blocked by #132   | `feature/shared-diagnostics-completion` | pending | pending  |
-| #134 NIP-47 service lifecycle     | AFK  | blocked by #133   | `feature/nip47-service-lifecycle`       | pending | pending  |
-| #135 NIP-57 consolidation         | AFK  | blocked by #134   | `feature/nip57-client-consolidation`    | pending | pending  |
-| #136 NIP-46 protocol core         | AFK  | blocked by #135   | `feature/nip46-protocol-core`           | pending | pending  |
-| #137 default test feedback loop   | AFK  | blocked by #136   | `feature/fast-default-test-loop`        | pending | pending  |
-| #138 public behavior test seams   | AFK  | blocked by #137   | `feature/public-behavior-test-seams`    | pending | pending  |
-| #139 ephemeral Relay internals    | AFK  | blocked by #138   | `feature/ephemeral-relay-internals`     | pending | pending  |
+| Issue                             | Type | Status          | Branch                                  | Review                                                  | Verified                            |
+| --------------------------------- | ---- | --------------- | --------------------------------------- | ------------------------------------------------------- | ----------------------------------- |
+| #131 NIP-46 diagnostic redaction  | AFK  | ready for PR    | `feature/nip46-diagnostic-redaction`    | Grok standards/spec pass; CodeRabbit 3 fixed then clean | Jest/Bun 1052/1052; all local gates |
+| #132 published declaration purity | AFK  | blocked by #131 | `feature/public-type-test-purity`       | pending                                                 | pending                             |
+| #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                 | pending                             |
+| #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                 | pending                             |
+| #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                 | pending                             |
+| #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                 | pending                             |
+| #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                 | pending                             |
+| #138 public behavior test seams   | AFK  | blocked by #137 | `feature/public-behavior-test-seams`    | pending                                                 | pending                             |
+| #139 ephemeral Relay internals    | AFK  | blocked by #138 | `feature/ephemeral-relay-internals`     | pending                                                 | pending                             |
 
 ## Parked HITL Slices
 
@@ -59,9 +59,9 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 
 ## Issue Session Ledger
 
-| Issue | Fixed point | Implementation owner                          | Commit  | Review result | Checks  |
-| ----- | ----------- | --------------------------------------------- | ------- | ------------- | ------- |
-| #131  | `f4bda34`   | current Codex orchestrator; Grok auth pending | pending | pending       | pending |
+| Issue | Fixed point | Implementation owner                                | Commit                          | Review result                                                  | Checks                                                                                        |
+| ----- | ----------- | --------------------------------------------------- | ------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9` | Grok standards/spec pass after fixes; CodeRabbit round 2 clean | focused Jest/Bun 5/5; final Jest/Bun 1052/1052; policies, lint, types, builds, examples, pack |
 
 ## Alignment Decisions
 
@@ -80,4 +80,4 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 
 ## Escalations
 
-- Grok preflight: `agent` and Node are installed, but the Cursor CLI requires one-time browser authentication. The login session is waiting while local work proceeds.
+- Resolved: Cursor CLI authentication completed. The skill's `grok-4.5-xhigh` alias is not present in the installed catalog; the highest available Grok 4.5 tier, `cursor-grok-4.5-high`, is used and verified.

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -59,9 +59,9 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 
 ## Issue Session Ledger
 
-| Issue | Fixed point | Implementation owner                                | Commit                                                         | Review result                                                                | Checks                                                                                        |
-| ----- | ----------- | --------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9` plus hosted-review fix pending | Grok approved after hosted fixes; CodeRabbit local clean before hosted round | focused Jest/Bun 7/7; final Jest/Bun 1054/1054; policies, lint, types, builds, examples, pack |
+| Issue | Fixed point | Implementation owner                                | Commit                                     | Review result                                                        | Checks                                                                                        |
+| ----- | ----------- | --------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9`, `426c17b` | Grok approved after hosted fixes; CodeRabbit local code review clean | focused Jest/Bun 7/7; final Jest/Bun 1054/1054; policies, lint, types, builds, examples, pack |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: item 1 / issue #131 reviewed and locally verified; delivery PR pending on `feature/nip46-diagnostic-redaction`
+- Current status: item 1 / issue #131 reviewed and locally verified; PR #140 open against `staging`
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -27,7 +27,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all item #131 standards/spec passes
 - Review packets: `issue-131-review-packet.md`; created per later ticket
 - Local CodeRabbit report: `issue-131-coderabbit-local.md`; created per later ticket
-- PR URL: created per ticket, always non-draft and targeting `staging`
+- PR URL: #140 for issue #131; created per later ticket, always non-draft and targeting `staging`
 
 ## Commands
 
@@ -41,7 +41,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 
 | Issue                             | Type | Status          | Branch                                  | Review                                                  | Verified                            |
 | --------------------------------- | ---- | --------------- | --------------------------------------- | ------------------------------------------------------- | ----------------------------------- |
-| #131 NIP-46 diagnostic redaction  | AFK  | ready for PR    | `feature/nip46-diagnostic-redaction`    | Grok standards/spec pass; CodeRabbit 3 fixed then clean | Jest/Bun 1052/1052; all local gates |
+| #131 NIP-46 diagnostic redaction  | AFK  | PR #140 open    | `feature/nip46-diagnostic-redaction`    | Grok standards/spec pass; CodeRabbit 3 fixed then clean | Jest/Bun 1052/1052; all local gates |
 | #132 published declaration purity | AFK  | blocked by #131 | `feature/public-type-test-purity`       | pending                                                 | pending                             |
 | #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                 | pending                             |
 | #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                 | pending                             |

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: item 1 / issue #131 reviewed and locally verified; PR #140 open against `staging`
+- Current status: item 1 / issue #131 hosted-review fixes complete and fully verified; PR #140 open against `staging`
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -41,7 +41,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 
 | Issue                             | Type | Status          | Branch                                  | Review                                                  | Verified                            |
 | --------------------------------- | ---- | --------------- | --------------------------------------- | ------------------------------------------------------- | ----------------------------------- |
-| #131 NIP-46 diagnostic redaction  | AFK  | PR #140 open    | `feature/nip46-diagnostic-redaction`    | Grok standards/spec pass; CodeRabbit 3 fixed then clean | Jest/Bun 1052/1052; all local gates |
+| #131 NIP-46 diagnostic redaction  | AFK  | PR #140 open    | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local 3 fixed, hosted 2 fixed | Jest/Bun 1054/1054; all local gates |
 | #132 published declaration purity | AFK  | blocked by #131 | `feature/public-type-test-purity`       | pending                                                 | pending                             |
 | #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                 | pending                             |
 | #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                 | pending                             |
@@ -59,9 +59,9 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 
 ## Issue Session Ledger
 
-| Issue | Fixed point | Implementation owner                                | Commit                          | Review result                                                  | Checks                                                                                        |
-| ----- | ----------- | --------------------------------------------------- | ------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9` | Grok standards/spec pass after fixes; CodeRabbit round 2 clean | focused Jest/Bun 5/5; final Jest/Bun 1052/1052; policies, lint, types, builds, examples, pack |
+| Issue | Fixed point | Implementation owner                                | Commit                                                         | Review result                                                                | Checks                                                                                        |
+| ----- | ----------- | --------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9` plus hosted-review fix pending | Grok approved after hosted fixes; CodeRabbit local clean before hosted round | focused Jest/Bun 7/7; final Jest/Bun 1054/1054; policies, lint, types, builds, examples, pack |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: item 1 / issue #131 hosted-review fixes complete and fully verified; PR #140 open against `staging`
+- Current status: item 1 / issue #131 fully reviewed and verified; PR #140 ready to merge into `staging`
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -39,17 +39,17 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 
 ## Ticket Ledger
 
-| Issue                             | Type | Status          | Branch                                  | Review                                                  | Verified                            |
-| --------------------------------- | ---- | --------------- | --------------------------------------- | ------------------------------------------------------- | ----------------------------------- |
-| #131 NIP-46 diagnostic redaction  | AFK  | PR #140 open    | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local 3 fixed, hosted 2 fixed | Jest/Bun 1054/1054; all local gates |
-| #132 published declaration purity | AFK  | blocked by #131 | `feature/public-type-test-purity`       | pending                                                 | pending                             |
-| #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                 | pending                             |
-| #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                 | pending                             |
-| #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                 | pending                             |
-| #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                 | pending                             |
-| #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                 | pending                             |
-| #138 public behavior test seams   | AFK  | blocked by #137 | `feature/public-behavior-test-seams`    | pending                                                 | pending                             |
-| #139 ephemeral Relay internals    | AFK  | blocked by #138 | `feature/ephemeral-relay-internals`     | pending                                                 | pending                             |
+| Issue                             | Type | Status          | Branch                                  | Review                                                   | Verified                            |
+| --------------------------------- | ---- | --------------- | --------------------------------------- | -------------------------------------------------------- | ----------------------------------- |
+| #131 NIP-46 diagnostic redaction  | AFK  | PR #140 ready   | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes | Jest/Bun 1054/1054; hosted CI green |
+| #132 published declaration purity | AFK  | blocked by #131 | `feature/public-type-test-purity`       | pending                                                  | pending                             |
+| #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                  | pending                             |
+| #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                  | pending                             |
+| #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                  | pending                             |
+| #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                  | pending                             |
+| #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                  | pending                             |
+| #138 public behavior test seams   | AFK  | blocked by #137 | `feature/public-behavior-test-seams`    | pending                                                  | pending                             |
+| #139 ephemeral Relay internals    | AFK  | blocked by #138 | `feature/ephemeral-relay-internals`     | pending                                                  | pending                             |
 
 ## Parked HITL Slices
 

--- a/docs/agents/runs/issue-131-coderabbit-local.md
+++ b/docs/agents/runs/issue-131-coderabbit-local.md
@@ -1,0 +1,31 @@
+# CodeRabbit Round: #131 Local Branch
+
+## Round
+
+- Scope: local committed branch against `staging`
+- Round number: 1–2
+- Command or trigger: `coderabbit review --agent --type committed --base staging -c AGENTS.md`
+- Started: 2026-07-18
+- Completed: 2026-07-18
+- Availability: completed
+- Fallback review thread: not needed
+
+## Findings To Address
+
+| Finding                                                            | Severity | Decision | Notes                                                                                         |
+| ------------------------------------------------------------------ | -------- | -------- | --------------------------------------------------------------------------------------------- |
+| Normalized `privateKey` was absent from the sensitive-field policy | major    | fixed    | Added `privatekey` and actual generated private keys to public leak sentinels.                |
+| Tests did not include generated user and signer private keys       | minor    | fixed    | Every relevant assertion now treats both private keys as forbidden output.                    |
+| Throwing-logger test lacked a successful operation                 | minor    | fixed    | A real simple client/bunker connect and ping completes with every diagnostic method throwing. |
+
+## Findings Not Addressed
+
+| Finding | Reason |
+| ------- | ------ |
+| None    | —      |
+
+## Result
+
+- Continue: yes; round 2 reviewed the complete committed diff and raised zero issues
+- Escalate: no
+- Notes: focused Jest and Bun redaction suites are green after all fixes; final full Jest and Bun suites are also green.

--- a/docs/agents/runs/issue-131-coderabbit-local.md
+++ b/docs/agents/runs/issue-131-coderabbit-local.md
@@ -3,7 +3,7 @@
 ## Round
 
 - Scope: local committed branch against `staging`
-- Round number: 1–3
+- Round number: 1–4
 - Command or trigger: `coderabbit review --agent --type committed --base staging -c AGENTS.md`
 - Started: 2026-07-18
 - Completed: 2026-07-18
@@ -27,6 +27,6 @@
 
 ## Result
 
-- Continue: yes; round 2 reviewed the pre-hosted-fix committed diff with zero issues; round 3 found no code defects and one fixed documentation inconsistency
+- Continue: yes; round 2 reviewed the pre-hosted-fix committed diff with zero issues; round 3 found no code defects and one fixed documentation inconsistency; round 4 reviewed the complete branch with zero findings
 - Escalate: no
 - Notes: focused Jest and Bun redaction suites are green after all fixes; final full Jest and Bun suites are also green at 1054/1054 tests.

--- a/docs/agents/runs/issue-131-coderabbit-local.md
+++ b/docs/agents/runs/issue-131-coderabbit-local.md
@@ -3,7 +3,7 @@
 ## Round
 
 - Scope: local committed branch against `staging`
-- Round number: 1–2
+- Round number: 1–3
 - Command or trigger: `coderabbit review --agent --type committed --base staging -c AGENTS.md`
 - Started: 2026-07-18
 - Completed: 2026-07-18
@@ -17,6 +17,7 @@
 | Normalized `privateKey` was absent from the sensitive-field policy | major    | fixed    | Added `privatekey` and actual generated private keys to public leak sentinels.                |
 | Tests did not include generated user and signer private keys       | minor    | fixed    | Every relevant assertion now treats both private keys as forbidden output.                    |
 | Throwing-logger test lacked a successful operation                 | minor    | fixed    | A real simple client/bunker connect and ping completes with every diagnostic method throwing. |
+| Session artifact had contradictory hosted-gate status              | minor    | fixed    | Clarified that local review is complete while hosted rerun and CI still gate merge.           |
 
 ## Findings Not Addressed
 
@@ -26,6 +27,6 @@
 
 ## Result
 
-- Continue: yes; round 2 reviewed the complete committed diff and raised zero issues
+- Continue: yes; round 2 reviewed the pre-hosted-fix committed diff with zero issues; round 3 found no code defects and one fixed documentation inconsistency
 - Escalate: no
-- Notes: focused Jest and Bun redaction suites are green after all fixes; final full Jest and Bun suites are also green.
+- Notes: focused Jest and Bun redaction suites are green after all fixes; final full Jest and Bun suites are also green at 1054/1054 tests.

--- a/docs/agents/runs/issue-131-review-packet.md
+++ b/docs/agents/runs/issue-131-review-packet.md
@@ -17,7 +17,7 @@ All four NIP-46 client and bunker facades now route diagnostics through one inte
 - `implement` session: `issue-131-session.md`
 - `tdd` used: yes
 - Red test, if applicable: public constructor options rejected logger injection before implementation; subsequent red cycles caught `connectResult` and the simple bunker's response envelope
-- Green implementation, if applicable: five public integration tests cover advanced/simple cross-pairs, legacy simple/simple, invalid-secret metadata, encryption plaintext, private-key sentinels, all diagnostic levels, and throwing loggers
+- Green implementation, if applicable: seven public integration tests cover advanced/simple cross-pairs, legacy simple/simple, invalid-secret metadata, encryption plaintext, private-key sentinels, all diagnostic levels, throwing loggers, multiline payloads, reflected `Error` messages, and malformed legacy permissions
 - Refactor, if applicable: one internal adapter owns recursive field policy, legacy message handling, non-throwing delegation, and optional level forwarding
 - Commands run: focused Jest/Bun; NIP-46 Jest; full Jest/Bun; policy verifiers; lint; TypeScript; CJS/ESM builds; examples; pack verifier
 
@@ -35,4 +35,9 @@ STANDARDS_FINDINGS:
 SPEC_STATUS: pass
 SPEC_FINDINGS:
 - Initial coverage gaps and one free-form secret interpolation were fixed; all four acceptance criteria pass on follow-up.
+
+HOSTED_REVIEW_STATUS: pass after fixes
+HOSTED_REVIEW_FINDINGS:
+- CodeRabbit found multiline legacy payload leakage and reflected untrusted error messages; both were reproduced through public seams and fixed.
+- A follow-up Grok pass found one additional legacy permission interpolation path; a public red test reproduced it, the log now exposes only permission count, and Grok approved the final patch.
 ```

--- a/docs/agents/runs/issue-131-review-packet.md
+++ b/docs/agents/runs/issue-131-review-packet.md
@@ -1,0 +1,38 @@
+# Review Packet: #131 NIP-46 Diagnostic Redaction
+
+## Issue
+
+- Issue: #131
+- Slice type: AFK security and diagnostic compatibility cleanup
+- Acceptance criteria: no sensitive NIP-46 material at info/debug/trace; useful safe metadata retained; public behavior and logger compatibility preserved; all four facades covered through public seams
+- Baseline: `f4bda34`
+- Current diff: `git diff staging...HEAD`
+
+## Implementation Summary
+
+All four NIP-46 client and bunker facades now route diagnostics through one internal redacting, non-throwing adapter. Consumers may inject the existing structural `DiagnosticLogger`; defaults and 0.x logger aliases remain compatible. Connection strings, secrets, private keys, request parameters, plaintext, decrypted payloads, response results, auth URLs, and legacy interpolated envelopes are removed before delegation while operation, method, request ID, event ID, public-key, and safe failure context remains.
+
+## Implementation Evidence
+
+- `implement` session: `issue-131-session.md`
+- `tdd` used: yes
+- Red test, if applicable: public constructor options rejected logger injection before implementation; subsequent red cycles caught `connectResult` and the simple bunker's response envelope
+- Green implementation, if applicable: five public integration tests cover advanced/simple cross-pairs, legacy simple/simple, invalid-secret metadata, encryption plaintext, private-key sentinels, all diagnostic levels, and throwing loggers
+- Refactor, if applicable: one internal adapter owns recursive field policy, legacy message handling, non-throwing delegation, and optional level forwarding
+- Commands run: focused Jest/Bun; NIP-46 Jest; full Jest/Bun; policy verifiers; lint; TypeScript; CJS/ESM builds; examples; pack verifier
+
+## Review Instructions
+
+Review only issue #131 unless a severe cross-slice regression appears. Keep standards and spec axes separate. Verify sensitive data cannot cross the configured diagnostic seam, diagnostics cannot alter public control flow, safe metadata remains useful, and the new logger option is additive and platform-safe.
+
+## Reviewer Output
+
+```text
+STANDARDS_STATUS: pass
+STANDARDS_FINDINGS:
+- Two hard findings and several judgment-call gaps were fixed; Grok follow-up found no remaining actionable defect.
+
+SPEC_STATUS: pass
+SPEC_FINDINGS:
+- Initial coverage gaps and one free-form secret interpolation were fixed; all four acceptance criteria pass on follow-up.
+```

--- a/docs/agents/runs/issue-131-session.md
+++ b/docs/agents/runs/issue-131-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `f4bda34`
 - Worker session: current Codex orchestrator; Grok 4.5 High standards/spec reviewers
 - Commit: `7ed8433`, `00104cc`, `21b4ad9`
-- Status: reviewed, locally verified, ready for delivery PR
+- Status: PR #140 open against `staging`; hosted gates pending
 
 ## Inputs
 

--- a/docs/agents/runs/issue-131-session.md
+++ b/docs/agents/runs/issue-131-session.md
@@ -4,9 +4,9 @@
 
 - Issue: #131
 - Fixed point before session: `f4bda34`
-- Worker session: current Codex orchestrator; Grok authentication pending
-- Commit: pending
-- Status: TDD red phase
+- Worker session: current Codex orchestrator; Grok 4.5 High standards/spec reviewers
+- Commit: `7ed8433`, `00104cc`, `21b4ad9`
+- Status: reviewed, locally verified, ready for delivery PR
 
 ## Inputs
 
@@ -19,19 +19,28 @@
 ## Implementation
 
 - Public interface used: diagnostic logger options on all four NIP-46 client and bunker constructors
-- Behaviors covered: connection secrets, request parameters, decrypted protocol payloads, and event plaintext never reach injected diagnostics; safe method and correlation metadata remains
+- Behaviors covered: connection secrets, private keys, request parameters, decrypted protocol payloads, event and encryption plaintext, and full response envelopes never reach injected diagnostics; safe method, correlation, and failure metadata remains
 - `tdd` used: yes; cross-facade public integration tests written before the logger adapter
-- Commands run during implementation: pending
+- Commands run during implementation: focused Jest and Bun redaction suites; full NIP-46 Jest suite; targeted ESLint; TypeScript; Prettier; repository policy, lint, build, examples, and pack gates
 - Full suite command: `npm test -- --runInBand --detectOpenHandles`
 
 ## Review
 
 - Review fixed point: `f4bda34`
-- Standards findings: pending
-- Spec findings: pending
-- Worthy fixes applied: pending
-- Findings ignored with reasons: pending
+- Standards findings: Grok found two hard issues (throwing diagnostics could alter behavior; one interpolated connect secret) and judgment-call gaps around repeated object graphs, structural `setLevel`, and test coverage
+- Spec findings: Grok found partial failure/secret-class/level coverage and the same free-form interpolation gap
+- Worthy fixes applied: made diagnostics non-throwing; removed secret interpolation; fixed repeated-reference handling; forwarded optional structural `setLevel`; added encryption, invalid-secret, legacy simple/simple, per-level, private-key, and throwing-logger operation coverage; Grok follow-up reported no remaining defects
+- Findings ignored with reasons: workflow ledgers are required Feature Dev artifacts; four facade wiring sites remain intentionally until issue #136 unifies the NIP-46 core; broad `data`/`result` redaction is deliberate security policy
+
+## Verification
+
+- Focused redaction: Jest 5/5; Bun 5/5
+- NIP-46 regression: Jest 166/166 before review fixes
+- Final Jest: 80/80 suites, 1052/1052 tests, no open handles, 291.17 seconds
+- Final Bun: 1052/1052 tests, 8154 assertions, 264.52 seconds
+- Build/package: commands and package-manager policy, lint, TypeScript, CJS/ESM builds, examples, and pack verification green
+- CodeRabbit: round 1 raised three valid issues; all fixed; round 2 raised zero issues
 
 ## Risks
 
-- Recursive diagnostic sanitization must handle cycles and error objects without changing application behavior.
+- None open. Recursive graphs and throwing custom loggers are isolated from public NIP-46 behavior.

--- a/docs/agents/runs/issue-131-session.md
+++ b/docs/agents/runs/issue-131-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `f4bda34`
 - Worker session: current Codex orchestrator; Grok 4.5 High standards/spec reviewers
 - Commit: `7ed8433`, `00104cc`, `21b4ad9`, `426c17b`
-- Status: local implementation and review complete; PR #140 open against `staging`; hosted rerun and CI pending for `426c17b`
+- Status: local and hosted review complete; PR #140 open against `staging`; all hosted gates passed for `4ea5fbc`
 
 ## Inputs
 
@@ -41,9 +41,9 @@
 - Final Bun after hosted fixes: 1054/1054 tests, 8173 assertions, 269.65 seconds
 - Build/package: commands and package-manager policy, lint, TypeScript, CJS/ESM builds, examples, and pack verification green
 - Local CodeRabbit: round 1 raised three valid code/test issues; all fixed; round 2 raised zero issues; round 3 raised one documentation-status inconsistency, fixed; round 4 raised zero issues
-- Hosted CodeRabbit: raised two valid major findings; both fixed with public regressions; final hosted rerun pending
+- Hosted CodeRabbit: raised two valid major findings; both fixed with public regressions; final hosted rerun passed
 - Grok hosted-fix review: initial pass found one additional permission interpolation; fixed after a public red test; follow-up verdict `APPROVE`
 
 ## Risks
 
-- No code risks remain open. Merge remains gated on the final hosted CodeRabbit rerun and CI for `426c17b`.
+- No code or hosted-gate risks remain open; `4ea5fbc` is ready to merge into `staging`.

--- a/docs/agents/runs/issue-131-session.md
+++ b/docs/agents/runs/issue-131-session.md
@@ -1,0 +1,37 @@
+# Issue Session: #131 NIP-46 Diagnostic Redaction
+
+## Issue
+
+- Issue: #131
+- Fixed point before session: `f4bda34`
+- Worker session: current Codex orchestrator; Grok authentication pending
+- Commit: pending
+- Status: TDD red phase
+
+## Inputs
+
+- Spec issue: #130
+- Ticket: #131
+- Relevant glossary terms: Nostr Event, Relay, NIP
+- Relevant ADRs: ADR 0002 — unify diagnostics compatibly
+- Prototype answer and source branch, if any: none
+
+## Implementation
+
+- Public interface used: diagnostic logger options on all four NIP-46 client and bunker constructors
+- Behaviors covered: connection secrets, request parameters, decrypted protocol payloads, and event plaintext never reach injected diagnostics; safe method and correlation metadata remains
+- `tdd` used: yes; cross-facade public integration tests written before the logger adapter
+- Commands run during implementation: pending
+- Full suite command: `npm test -- --runInBand --detectOpenHandles`
+
+## Review
+
+- Review fixed point: `f4bda34`
+- Standards findings: pending
+- Spec findings: pending
+- Worthy fixes applied: pending
+- Findings ignored with reasons: pending
+
+## Risks
+
+- Recursive diagnostic sanitization must handle cycles and error objects without changing application behavior.

--- a/docs/agents/runs/issue-131-session.md
+++ b/docs/agents/runs/issue-131-session.md
@@ -5,8 +5,8 @@
 - Issue: #131
 - Fixed point before session: `f4bda34`
 - Worker session: current Codex orchestrator; Grok 4.5 High standards/spec reviewers
-- Commit: `7ed8433`, `00104cc`, `21b4ad9`; hosted-review fix pending commit
-- Status: PR #140 open against `staging`; hosted gates pending
+- Commit: `7ed8433`, `00104cc`, `21b4ad9`, `426c17b`
+- Status: local implementation and review complete; PR #140 open against `staging`; hosted rerun and CI pending for `426c17b`
 
 ## Inputs
 
@@ -40,10 +40,10 @@
 - Final Jest after hosted fixes: 80/80 suites, 1054/1054 tests, no open handles, 298.293 seconds
 - Final Bun after hosted fixes: 1054/1054 tests, 8173 assertions, 269.65 seconds
 - Build/package: commands and package-manager policy, lint, TypeScript, CJS/ESM builds, examples, and pack verification green
-- Local CodeRabbit: round 1 raised three valid issues; all fixed; round 2 raised zero issues
+- Local CodeRabbit: round 1 raised three valid code/test issues; all fixed; round 2 raised zero issues; round 3 raised one documentation-status inconsistency, fixed
 - Hosted CodeRabbit: raised two valid major findings; both fixed with public regressions; final hosted rerun pending
 - Grok hosted-fix review: initial pass found one additional permission interpolation; fixed after a public red test; follow-up verdict `APPROVE`
 
 ## Risks
 
-- None open. Recursive graphs and throwing custom loggers are isolated from public NIP-46 behavior.
+- No code risks remain open. Merge remains gated on the final hosted CodeRabbit rerun and CI for `426c17b`.

--- a/docs/agents/runs/issue-131-session.md
+++ b/docs/agents/runs/issue-131-session.md
@@ -5,7 +5,7 @@
 - Issue: #131
 - Fixed point before session: `f4bda34`
 - Worker session: current Codex orchestrator; Grok 4.5 High standards/spec reviewers
-- Commit: `7ed8433`, `00104cc`, `21b4ad9`
+- Commit: `7ed8433`, `00104cc`, `21b4ad9`; hosted-review fix pending commit
 - Status: PR #140 open against `staging`; hosted gates pending
 
 ## Inputs
@@ -30,16 +30,19 @@
 - Standards findings: Grok found two hard issues (throwing diagnostics could alter behavior; one interpolated connect secret) and judgment-call gaps around repeated object graphs, structural `setLevel`, and test coverage
 - Spec findings: Grok found partial failure/secret-class/level coverage and the same free-form interpolation gap
 - Worthy fixes applied: made diagnostics non-throwing; removed secret interpolation; fixed repeated-reference handling; forwarded optional structural `setLevel`; added encryption, invalid-secret, legacy simple/simple, per-level, private-key, and throwing-logger operation coverage; Grok follow-up reported no remaining defects
+- Hosted review fixes: made legacy payload matching cross line boundaries; replaced raw `Error.message` with safe type/code metadata; redacted `error`, `message`, and `details` fields plus positional error/warn strings; removed two interpolated error messages; replaced legacy permission interpolation with count-only metadata
 - Findings ignored with reasons: workflow ledgers are required Feature Dev artifacts; four facade wiring sites remain intentionally until issue #136 unifies the NIP-46 core; broad `data`/`result` redaction is deliberate security policy
 
 ## Verification
 
-- Focused redaction: Jest 5/5; Bun 5/5
+- Focused redaction: Jest 7/7; Bun 7/7
 - NIP-46 regression: Jest 166/166 before review fixes
-- Final Jest: 80/80 suites, 1052/1052 tests, no open handles, 291.17 seconds
-- Final Bun: 1052/1052 tests, 8154 assertions, 264.52 seconds
+- Final Jest after hosted fixes: 80/80 suites, 1054/1054 tests, no open handles, 298.293 seconds
+- Final Bun after hosted fixes: 1054/1054 tests, 8173 assertions, 269.65 seconds
 - Build/package: commands and package-manager policy, lint, TypeScript, CJS/ESM builds, examples, and pack verification green
-- CodeRabbit: round 1 raised three valid issues; all fixed; round 2 raised zero issues
+- Local CodeRabbit: round 1 raised three valid issues; all fixed; round 2 raised zero issues
+- Hosted CodeRabbit: raised two valid major findings; both fixed with public regressions; final hosted rerun pending
+- Grok hosted-fix review: initial pass found one additional permission interpolation; fixed after a public red test; follow-up verdict `APPROVE`
 
 ## Risks
 

--- a/docs/agents/runs/issue-131-session.md
+++ b/docs/agents/runs/issue-131-session.md
@@ -40,7 +40,7 @@
 - Final Jest after hosted fixes: 80/80 suites, 1054/1054 tests, no open handles, 298.293 seconds
 - Final Bun after hosted fixes: 1054/1054 tests, 8173 assertions, 269.65 seconds
 - Build/package: commands and package-manager policy, lint, TypeScript, CJS/ESM builds, examples, and pack verification green
-- Local CodeRabbit: round 1 raised three valid code/test issues; all fixed; round 2 raised zero issues; round 3 raised one documentation-status inconsistency, fixed
+- Local CodeRabbit: round 1 raised three valid code/test issues; all fixed; round 2 raised zero issues; round 3 raised one documentation-status inconsistency, fixed; round 4 raised zero issues
 - Hosted CodeRabbit: raised two valid major findings; both fixed with public regressions; final hosted rerun pending
 - Grok hosted-fix review: initial pass found one additional permission interpolation; fixed after a public red test; follow-up verdict `APPROVE`
 

--- a/src/nip46/bunker.ts
+++ b/src/nip46/bunker.ts
@@ -31,7 +31,8 @@ import {
   validateKeypairForCrypto,
   securePermissionCheck,
 } from "./utils/security";
-import { Logger, LogLevel } from "../utils/logger";
+import { LogLevel } from "../utils/logger";
+import { NIP46DiagnosticLogger } from "./utils/diagnostics";
 
 export class NostrRemoteSignerBunker {
   private nostr: Nostr;
@@ -41,7 +42,7 @@ export class NostrRemoteSignerBunker {
   private connectedClients: Map<string, NIP46ClientSession>;
   private pendingAuthChallenges: Map<string, NIP46AuthChallenge>;
   private subId: string | null;
-  private logger: Logger;
+  private logger: NIP46DiagnosticLogger;
   private rateLimiter: NIP46RateLimiter;
   private permissionHandler:
     | ((
@@ -61,7 +62,7 @@ export class NostrRemoteSignerBunker {
     this.subId = null;
 
     // Initialize logger
-    this.logger = new Logger({
+    this.logger = NIP46DiagnosticLogger.create(options.logger, {
       level: options.debug ? LogLevel.DEBUG : LogLevel.INFO,
       prefix: "NIP46-BUNKER",
       includeTimestamp: true,

--- a/src/nip46/client.ts
+++ b/src/nip46/client.ts
@@ -5,7 +5,8 @@ import { encrypt as encryptNIP44, decrypt as decryptNIP44 } from "../nip44";
 import { NostrEvent, NostrFilter } from "../types/nostr";
 import { createSignedEvent } from "../nip01/event";
 import { parseConnectionString } from "./utils/connection";
-import { Logger, LogLevel } from "../utils/logger";
+import { LogLevel } from "../utils/logger";
+import { NIP46DiagnosticLogger } from "./utils/diagnostics";
 import { generateRequestId } from "./utils/request-response";
 import { isValidAuthUrl } from "./utils/auth";
 import {
@@ -43,7 +44,7 @@ export class NostrRemoteSignerClient {
   private authWindow: Window | null;
   private connected = false;
   private subId: string | null = null;
-  private logger: Logger;
+  private logger: NIP46DiagnosticLogger;
   private debug: boolean;
   private pendingAuthChallenges = new Map<
     string,
@@ -71,7 +72,7 @@ export class NostrRemoteSignerClient {
     this.debug = options.debug || false;
 
     // Initialize logger
-    this.logger = new Logger({
+    this.logger = NIP46DiagnosticLogger.create(options.logger, {
       level: options.debug ? LogLevel.DEBUG : LogLevel.INFO,
       prefix: "NIP46-CLIENT",
       includeTimestamp: true,

--- a/src/nip46/simple-bunker.ts
+++ b/src/nip46/simple-bunker.ts
@@ -334,10 +334,9 @@ export class SimpleNIP46Bunker {
           `Failed to handle request: ${errorMessage}`,
         );
         await this.sendResponse(response, event.pubkey);
-      } catch (err) {
+      } catch {
         // Just log if we can't send the response in this case
-        const errMessage = err instanceof Error ? err.message : String(err);
-        this.logger.error(`Could not send error response: ${errMessage}`);
+        this.logger.error("Could not send error response");
       }
     }
   }
@@ -395,9 +394,9 @@ export class SimpleNIP46Bunker {
     this.clients.set(clientPubkey, session);
 
     this.logger.info(`Client ${clientPubkey.slice(0, 8)}... connected`);
-    this.logger.debug(
-      `Client permissions: ${Array.from(session.permissions).join(", ")}`,
-    );
+    this.logger.debug("Client permissions configured", {
+      permissionCount: session.permissions.size,
+    });
 
     // Respond with "ack" or the secret if provided
     return createSuccessResponse(request.id, requestedSecret || "ack");
@@ -856,10 +855,8 @@ export class SimpleNIP46Bunker {
       await this.nostr.publishEvent(signedEvent);
 
       this.logger.debug(`Response sent for request: ${response.id}`);
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      this.logger.error(`Failed to send response: ${errorMessage}`);
+    } catch {
+      this.logger.error("Failed to send response");
     }
   }
 

--- a/src/nip46/simple-bunker.ts
+++ b/src/nip46/simple-bunker.ts
@@ -14,7 +14,8 @@ import {
   NIP46ConnectionError,
   NIP46Method,
 } from "./types";
-import { Logger, LogLevel } from "../utils/logger";
+import { LogLevel } from "../utils/logger";
+import { NIP46DiagnosticLogger } from "./utils/diagnostics";
 import {
   createSuccessResponse,
   createErrorResponse,
@@ -43,7 +44,7 @@ export class SimpleNIP46Bunker {
   private defaultPermissions: Set<string>;
   private subId: string | null;
   private secret?: string;
-  private logger: Logger;
+  private logger: NIP46DiagnosticLogger;
   private debug: boolean;
 
   /**
@@ -74,7 +75,7 @@ export class SimpleNIP46Bunker {
     const logLevel =
       options.logLevel || (this.debug ? LogLevel.DEBUG : LogLevel.INFO);
 
-    this.logger = new Logger({
+    this.logger = NIP46DiagnosticLogger.create(options.logger, {
       prefix: "Bunker",
       level: logLevel,
       silent: process.env.NODE_ENV === "test", // Silent in test environment

--- a/src/nip46/simple-client.ts
+++ b/src/nip46/simple-client.ts
@@ -153,9 +153,9 @@ export class SimpleNIP46Client {
 
       if (connectResponse.result !== "ack") {
         // If not "ack", it should be a required secret value
-        this.logger.debug(
-          `Connect response requires secret: ${connectResponse.result}`,
-        );
+        this.logger.debug("Connect response requires secret", {
+          hasSecret: true,
+        });
         if (!info.secret || info.secret !== connectResponse.result) {
           throw new NIP46ConnectionError("Invalid or missing required secret");
         }

--- a/src/nip46/simple-client.ts
+++ b/src/nip46/simple-client.ts
@@ -5,7 +5,8 @@ import { getUnixTime } from "../utils/time";
 import { encrypt as encryptNIP44, decrypt as decryptNIP44 } from "../nip44";
 import { createSignedEvent } from "../nip01/event";
 import { generateRequestId } from "./utils/request-response";
-import { Logger, LogLevel } from "../utils/logger";
+import { LogLevel } from "../utils/logger";
+import { NIP46DiagnosticLogger } from "./utils/diagnostics";
 import { parseConnectionString } from "./utils/connection";
 import {
   NIP46KeyPair,
@@ -36,7 +37,7 @@ export class SimpleNIP46Client {
   private pendingRequests: Map<string, (response: NIP46Response) => void>;
   private subId: string | null = null;
   private timeout: number;
-  private logger: Logger;
+  private logger: NIP46DiagnosticLogger;
   private debug: boolean;
 
   /**
@@ -58,7 +59,7 @@ export class SimpleNIP46Client {
     const logLevel =
       options.logLevel || (this.debug ? LogLevel.DEBUG : LogLevel.INFO);
 
-    this.logger = new Logger({
+    this.logger = NIP46DiagnosticLogger.create(options.logger, {
       prefix: "Client",
       level: logLevel,
       silent: process.env.NODE_ENV === "test", // Silent in test environment

--- a/src/nip46/types.ts
+++ b/src/nip46/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { RateLimitConfig } from "./utils/rate-limiter";
+import type { DiagnosticLogger } from "../utils/logger";
 
 export interface NIP46Request {
   id: string;
@@ -95,6 +96,7 @@ export interface NIP46ClientOptions extends NIP46ConnectionOptions {
   debug?: boolean;
   authTimeout?: number; // Auth challenge timeout in milliseconds
   authDomainWhitelist?: string[]; // Allowed domains for auth URLs
+  logger?: DiagnosticLogger;
 }
 
 /**
@@ -112,6 +114,7 @@ export interface NIP46BunkerOptions {
   metadata?: NIP46Metadata;
   debug?: boolean;
   rateLimitConfig?: RateLimitConfig;
+  logger?: DiagnosticLogger;
 }
 
 /**
@@ -327,6 +330,7 @@ export interface SimpleNIP46BunkerOptions {
   defaultPermissions?: string[];
   secret?: string;
   debug?: boolean;
+  logger?: DiagnosticLogger;
 }
 
 /**
@@ -336,4 +340,5 @@ export interface SimpleNIP46ClientOptions {
   timeout?: number;
   logLevel?: number; // Using LogLevel enum
   debug?: boolean;
+  logger?: DiagnosticLogger;
 }

--- a/src/nip46/types.ts
+++ b/src/nip46/types.ts
@@ -96,6 +96,7 @@ export interface NIP46ClientOptions extends NIP46ConnectionOptions {
   debug?: boolean;
   authTimeout?: number; // Auth challenge timeout in milliseconds
   authDomainWhitelist?: string[]; // Allowed domains for auth URLs
+  /** Receives redacted NIP-46 diagnostics. The logger controls its own level. */
   logger?: DiagnosticLogger;
 }
 
@@ -114,6 +115,7 @@ export interface NIP46BunkerOptions {
   metadata?: NIP46Metadata;
   debug?: boolean;
   rateLimitConfig?: RateLimitConfig;
+  /** Receives redacted NIP-46 diagnostics. The logger controls its own level. */
   logger?: DiagnosticLogger;
 }
 
@@ -330,6 +332,7 @@ export interface SimpleNIP46BunkerOptions {
   defaultPermissions?: string[];
   secret?: string;
   debug?: boolean;
+  /** Receives redacted NIP-46 diagnostics. The logger controls its own level. */
   logger?: DiagnosticLogger;
 }
 
@@ -340,5 +343,6 @@ export interface SimpleNIP46ClientOptions {
   timeout?: number;
   logLevel?: number; // Using LogLevel enum
   debug?: boolean;
+  /** Receives redacted NIP-46 diagnostics. The logger controls its own level. */
   logger?: DiagnosticLogger;
 }

--- a/src/nip46/utils/diagnostics.ts
+++ b/src/nip46/utils/diagnostics.ts
@@ -1,0 +1,146 @@
+import {
+  DiagnosticLogArgument,
+  DiagnosticLogger,
+  LogLevel,
+  Logger,
+  LoggerOptions,
+} from "../../utils/logger";
+
+const REDACTED = "[REDACTED]";
+const SENSITIVE_FIELD_NAMES = new Set([
+  "authurl",
+  "ciphertext",
+  "connectionstring",
+  "connectresult",
+  "content",
+  "data",
+  "decrypted",
+  "decrypteddata",
+  "eventdata",
+  "params",
+  "plaintext",
+  "result",
+  "secret",
+]);
+const LEGACY_PAYLOAD_MESSAGE = /^(.*(?:decrypted content|json payload):).*/i;
+const LEGACY_PAYLOAD_ARGUMENT_MESSAGE = /sending response for request/i;
+const CONNECTION_URI = /\b(bunker|nostrconnect):\/\/[^\s"']+/gi;
+
+function normalizedFieldName(fieldName: string): string {
+  return fieldName.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function redactDiagnosticText(value: string): string {
+  const withoutConnectionUris = value.replace(
+    CONNECTION_URI,
+    (_match, scheme: string) => `${scheme}://${REDACTED}`,
+  );
+
+  return withoutConnectionUris.replace(
+    LEGACY_PAYLOAD_MESSAGE,
+    (_match, prefix: string) => `${prefix} ${REDACTED}`,
+  );
+}
+
+function redactDiagnosticValue(
+  value: DiagnosticLogArgument,
+  seen: WeakSet<object>,
+): DiagnosticLogArgument {
+  if (typeof value === "string") {
+    return redactDiagnosticText(value);
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: redactDiagnosticText(value.message),
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      redactDiagnosticValue(item as DiagnosticLogArgument, seen),
+    );
+  }
+
+  const sanitized: Record<string, DiagnosticLogArgument> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (SENSITIVE_FIELD_NAMES.has(normalizedFieldName(key))) {
+      sanitized[key] = REDACTED;
+      continue;
+    }
+
+    sanitized[key] = redactDiagnosticValue(
+      nestedValue as DiagnosticLogArgument,
+      seen,
+    );
+  }
+
+  return sanitized;
+}
+
+/**
+ * NIP-46 diagnostic boundary that strips protocol payloads and connection
+ * secrets before forwarding safe operation metadata to the configured logger.
+ */
+export class NIP46DiagnosticLogger implements DiagnosticLogger {
+  private readonly delegate: DiagnosticLogger;
+
+  constructor(delegate: DiagnosticLogger) {
+    this.delegate = delegate;
+  }
+
+  static create(
+    logger: DiagnosticLogger | undefined,
+    defaultOptions: LoggerOptions,
+  ): NIP46DiagnosticLogger {
+    return new NIP46DiagnosticLogger(logger ?? new Logger(defaultOptions));
+  }
+
+  private write(
+    level: keyof DiagnosticLogger,
+    message: string,
+    args: DiagnosticLogArgument[],
+  ): void {
+    const seen = new WeakSet<object>();
+    const sanitizedArguments = LEGACY_PAYLOAD_ARGUMENT_MESSAGE.test(message)
+      ? args.map(() => REDACTED)
+      : args.map((argument) => redactDiagnosticValue(argument, seen));
+    this.delegate[level](redactDiagnosticText(message), ...sanitizedArguments);
+  }
+
+  error(message: string, ...args: DiagnosticLogArgument[]): void {
+    this.write("error", message, args);
+  }
+
+  warn(message: string, ...args: DiagnosticLogArgument[]): void {
+    this.write("warn", message, args);
+  }
+
+  info(message: string, ...args: DiagnosticLogArgument[]): void {
+    this.write("info", message, args);
+  }
+
+  debug(message: string, ...args: DiagnosticLogArgument[]): void {
+    this.write("debug", message, args);
+  }
+
+  trace(message: string, ...args: DiagnosticLogArgument[]): void {
+    this.write("trace", message, args);
+  }
+
+  setLevel(level: LogLevel): void {
+    if (this.delegate instanceof Logger) {
+      this.delegate.setLevel(level);
+    }
+  }
+}

--- a/src/nip46/utils/diagnostics.ts
+++ b/src/nip46/utils/diagnostics.ts
@@ -23,7 +23,7 @@ const SENSITIVE_FIELD_NAMES = new Set([
   "secret",
 ]);
 const LEGACY_PAYLOAD_MESSAGE = /^(.*(?:decrypted content|json payload):).*/i;
-const LEGACY_PAYLOAD_ARGUMENT_MESSAGE = /sending response for request/i;
+const LEGACY_RESPONSE_ENVELOPE_MESSAGE = /sending response for request/i;
 const CONNECTION_URI = /\b(bunker|nostrconnect):\/\/[^\s"']+/gi;
 
 function normalizedFieldName(fieldName: string): string {
@@ -59,33 +59,37 @@ function redactDiagnosticValue(
   }
   seen.add(value);
 
-  if (value instanceof Error) {
-    return {
-      name: value.name,
-      message: redactDiagnosticText(value.message),
-    };
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((item) =>
-      redactDiagnosticValue(item as DiagnosticLogArgument, seen),
-    );
-  }
-
-  const sanitized: Record<string, DiagnosticLogArgument> = {};
-  for (const [key, nestedValue] of Object.entries(value)) {
-    if (SENSITIVE_FIELD_NAMES.has(normalizedFieldName(key))) {
-      sanitized[key] = REDACTED;
-      continue;
+  try {
+    if (value instanceof Error) {
+      return {
+        name: value.name,
+        message: redactDiagnosticText(value.message),
+      };
     }
 
-    sanitized[key] = redactDiagnosticValue(
-      nestedValue as DiagnosticLogArgument,
-      seen,
-    );
-  }
+    if (Array.isArray(value)) {
+      return value.map((item) =>
+        redactDiagnosticValue(item as DiagnosticLogArgument, seen),
+      );
+    }
 
-  return sanitized;
+    const sanitized: Record<string, DiagnosticLogArgument> = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (SENSITIVE_FIELD_NAMES.has(normalizedFieldName(key))) {
+        sanitized[key] = REDACTED;
+        continue;
+      }
+
+      sanitized[key] = redactDiagnosticValue(
+        nestedValue as DiagnosticLogArgument,
+        seen,
+      );
+    }
+
+    return sanitized;
+  } finally {
+    seen.delete(value);
+  }
 }
 
 /**
@@ -111,11 +115,19 @@ export class NIP46DiagnosticLogger implements DiagnosticLogger {
     message: string,
     args: DiagnosticLogArgument[],
   ): void {
-    const seen = new WeakSet<object>();
-    const sanitizedArguments = LEGACY_PAYLOAD_ARGUMENT_MESSAGE.test(message)
-      ? args.map(() => REDACTED)
-      : args.map((argument) => redactDiagnosticValue(argument, seen));
-    this.delegate[level](redactDiagnosticText(message), ...sanitizedArguments);
+    try {
+      const sanitizedArguments = LEGACY_RESPONSE_ENVELOPE_MESSAGE.test(message)
+        ? args.map(() => REDACTED)
+        : args.map((argument) =>
+            redactDiagnosticValue(argument, new WeakSet<object>()),
+          );
+      this.delegate[level](
+        redactDiagnosticText(message),
+        ...sanitizedArguments,
+      );
+    } catch {
+      // Diagnostics are observational and must not alter NIP-46 behavior.
+    }
   }
 
   error(message: string, ...args: DiagnosticLogArgument[]): void {
@@ -139,8 +151,13 @@ export class NIP46DiagnosticLogger implements DiagnosticLogger {
   }
 
   setLevel(level: LogLevel): void {
-    if (this.delegate instanceof Logger) {
-      this.delegate.setLevel(level);
+    try {
+      const levelAwareLogger = this.delegate as DiagnosticLogger & {
+        setLevel?: (nextLevel: LogLevel) => void;
+      };
+      levelAwareLogger.setLevel?.(level);
+    } catch {
+      // A custom logger controls its own filtering and cannot alter behavior.
     }
   }
 }

--- a/src/nip46/utils/diagnostics.ts
+++ b/src/nip46/utils/diagnostics.ts
@@ -16,19 +16,30 @@ const SENSITIVE_FIELD_NAMES = new Set([
   "data",
   "decrypted",
   "decrypteddata",
+  "details",
+  "error",
+  "errormessage",
   "eventdata",
+  "message",
   "params",
   "plaintext",
   "privatekey",
   "result",
   "secret",
 ]);
-const LEGACY_PAYLOAD_MESSAGE = /^(.*(?:decrypted content|json payload):).*/i;
+const LEGACY_PAYLOAD_MESSAGE =
+  /^(.*(?:decrypted content|json payload):)[\s\S]*/i;
 const LEGACY_RESPONSE_ENVELOPE_MESSAGE = /sending response for request/i;
 const CONNECTION_URI = /\b(bunker|nostrconnect):\/\/[^\s"']+/gi;
 
 function normalizedFieldName(fieldName: string): string {
   return fieldName.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function safeDiagnosticLabel(value: unknown, fallback: string): string {
+  return typeof value === "string" && /^[a-z][a-z0-9_.:-]{0,63}$/i.test(value)
+    ? value
+    : fallback;
 }
 
 function redactDiagnosticText(value: string): string {
@@ -62,10 +73,34 @@ function redactDiagnosticValue(
 
   try {
     if (value instanceof Error) {
-      return {
-        name: value.name,
-        message: redactDiagnosticText(value.message),
+      const errorWithMetadata = value as Error & {
+        code?: unknown;
+        type?: unknown;
       };
+      const sanitizedError: Record<string, DiagnosticLogArgument> = {
+        name: safeDiagnosticLabel(value.name, "Error"),
+      };
+
+      if (
+        typeof errorWithMetadata.code === "number" ||
+        typeof errorWithMetadata.code === "boolean"
+      ) {
+        sanitizedError.code = errorWithMetadata.code;
+      } else if (typeof errorWithMetadata.code === "string") {
+        sanitizedError.code = safeDiagnosticLabel(
+          errorWithMetadata.code,
+          "UNKNOWN",
+        );
+      }
+
+      if (typeof errorWithMetadata.type === "string") {
+        sanitizedError.type = safeDiagnosticLabel(
+          errorWithMetadata.type,
+          "Error",
+        );
+      }
+
+      return sanitizedError;
     }
 
     if (Array.isArray(value)) {
@@ -120,7 +155,10 @@ export class NIP46DiagnosticLogger implements DiagnosticLogger {
       const sanitizedArguments = LEGACY_RESPONSE_ENVELOPE_MESSAGE.test(message)
         ? args.map(() => REDACTED)
         : args.map((argument) =>
-            redactDiagnosticValue(argument, new WeakSet<object>()),
+            (level === "error" || level === "warn") &&
+            typeof argument === "string"
+              ? REDACTED
+              : redactDiagnosticValue(argument, new WeakSet<object>()),
           );
       this.delegate[level](
         redactDiagnosticText(message),

--- a/src/nip46/utils/diagnostics.ts
+++ b/src/nip46/utils/diagnostics.ts
@@ -19,6 +19,7 @@ const SENSITIVE_FIELD_NAMES = new Set([
   "eventdata",
   "params",
   "plaintext",
+  "privatekey",
   "result",
   "secret",
 ]);

--- a/tests/nip46/diagnostic-redaction.test.ts
+++ b/tests/nip46/diagnostic-redaction.test.ts
@@ -220,6 +220,7 @@ describe("NIP-46 diagnostic redaction", () => {
     const userKeys = await generateKeypair();
     const signerKeys = await generateKeypair();
     const connectionSecret = "legacy-connect-response-secret";
+    const multilinePlaintext = "multiline-secret-first\nmultiline-secret-last";
     const clientDiagnostics = createCapturingLogger();
     const bunkerDiagnostics = createCapturingLogger();
     const bunker = new SimpleNIP46Bunker(
@@ -228,7 +229,7 @@ describe("NIP-46 diagnostic redaction", () => {
       signerKeys.publicKey,
       {
         secret: connectionSecret,
-        defaultPermissions: ["get_public_key"],
+        defaultPermissions: ["get_public_key", "sign_event"],
         logger: bunkerDiagnostics.logger,
       },
     );
@@ -243,14 +244,24 @@ describe("NIP-46 diagnostic redaction", () => {
     try {
       await bunker.start();
       await client.connect(bunker.getConnectionString());
+      await client.signEvent({
+        kind: 1,
+        content: multilinePlaintext,
+        created_at: 1_700_000_002,
+        tags: [],
+      });
 
       expectNoSensitiveDiagnostics(clientDiagnostics.diagnostics, [
         connectionSecret,
+        multilinePlaintext,
+        "multiline-secret-last",
         userKeys.privateKey,
         signerKeys.privateKey,
       ]);
       expectNoSensitiveDiagnostics(bunkerDiagnostics.diagnostics, [
         connectionSecret,
+        multilinePlaintext,
+        "multiline-secret-last",
         userKeys.privateKey,
         signerKeys.privateKey,
       ]);
@@ -369,6 +380,71 @@ describe("NIP-46 diagnostic redaction", () => {
         userKeys.publicKey,
       );
       await expect(client.ping()).resolves.toBe(true);
+    } finally {
+      await client.disconnect().catch(() => undefined);
+      await bunker.stop().catch(() => undefined);
+    }
+  });
+
+  test("untrusted Error messages retain only safe failure type", async () => {
+    const userKeys = await generateKeypair();
+    const reflectedSecret = "reflected-error-secret";
+    const multilinePayload =
+      "Decrypted content: multiline-reflected-first\nmultiline-reflected-last";
+    const diagnostics = createCapturingLogger();
+    const malformedPermissions = [
+      new Error(reflectedSecret),
+      multilinePayload,
+    ] as unknown as string[];
+
+    expect(
+      () =>
+        new NostrRemoteSignerBunker({
+          userPubkey: userKeys.publicKey,
+          defaultPermissions: malformedPermissions,
+          logger: diagnostics.logger,
+        }),
+    ).not.toThrow();
+
+    const rendered = renderDiagnostics(diagnostics.diagnostics);
+    expect(rendered).not.toContain(reflectedSecret);
+    expect(rendered).not.toContain("multiline-reflected-last");
+    expect(rendered).toContain("[REDACTED]");
+    expect(rendered).toContain("Error");
+  });
+
+  test("simple bunker does not stringify untrusted permission values", async () => {
+    const userKeys = await generateKeypair();
+    const signerKeys = await generateKeypair();
+    const reflectedSecret = "simple-permission-reflection-secret";
+    const diagnostics = createCapturingLogger();
+    const malformedPermissions = [
+      new Error(reflectedSecret),
+    ] as unknown as string[];
+    const bunker = new SimpleNIP46Bunker(
+      [relayUrl],
+      userKeys.publicKey,
+      signerKeys.publicKey,
+      {
+        defaultPermissions: malformedPermissions,
+        logLevel: LogLevel.DEBUG,
+        logger: diagnostics.logger,
+      },
+    );
+    const client = new NostrRemoteSignerClient({
+      relays: [relayUrl],
+      timeout: 3000,
+    });
+    bunker.setUserPrivateKey(userKeys.privateKey);
+    bunker.setSignerPrivateKey(signerKeys.privateKey);
+
+    try {
+      await bunker.start();
+      await client.connect(bunker.getConnectionString());
+
+      const rendered = renderDiagnostics(diagnostics.diagnostics);
+      expect(rendered).not.toContain(reflectedSecret);
+      expect(rendered).toContain("Client permissions");
     } finally {
       await client.disconnect().catch(() => undefined);
       await bunker.stop().catch(() => undefined);

--- a/tests/nip46/diagnostic-redaction.test.ts
+++ b/tests/nip46/diagnostic-redaction.test.ts
@@ -3,6 +3,7 @@ import {
   type DiagnosticLogger,
   NostrRemoteSignerBunker,
   NostrRemoteSignerClient,
+  LogLevel,
   SimpleNIP46Bunker,
   SimpleNIP46Client,
   generateKeypair,
@@ -42,7 +43,7 @@ function renderDiagnostics(diagnostics: CapturedDiagnostic[]): string {
   return JSON.stringify(diagnostics);
 }
 
-function expectSafeDiagnostics(
+function expectNoSensitiveDiagnostics(
   diagnostics: CapturedDiagnostic[],
   sensitiveValues: string[],
 ): void {
@@ -52,8 +53,16 @@ function expectSafeDiagnostics(
     expect(rendered).not.toContain(sensitiveValue);
   }
 
-  expect(rendered).toContain("sign_event");
   expect(diagnostics.length).toBeGreaterThan(0);
+
+  for (const level of ["info", "debug", "trace"] as const) {
+    const atLevel = renderDiagnostics(
+      diagnostics.filter((diagnostic) => diagnostic.level === level),
+    );
+    for (const sensitiveValue of sensitiveValues) {
+      expect(atLevel).not.toContain(sensitiveValue);
+    }
+  }
 }
 
 describe("NIP-46 diagnostic redaction", () => {
@@ -75,6 +84,8 @@ describe("NIP-46 diagnostic redaction", () => {
     const signerKeys = await generateKeypair();
     const connectionSecret = "connection-secret-advanced-client";
     const eventPlaintext = "private-event-advanced-client";
+    const encryptionPlaintext = "private-encryption-advanced-client";
+    const recipientKeys = await generateKeypair();
     const clientDiagnostics = createCapturingLogger();
     const bunkerDiagnostics = createCapturingLogger();
     const bunker = new SimpleNIP46Bunker(
@@ -83,7 +94,12 @@ describe("NIP-46 diagnostic redaction", () => {
       signerKeys.publicKey,
       {
         secret: connectionSecret,
-        defaultPermissions: ["get_public_key", "ping", "sign_event"],
+        defaultPermissions: [
+          "get_public_key",
+          "ping",
+          "sign_event",
+          "nip44_encrypt",
+        ],
         logger: bunkerDiagnostics.logger,
       },
     );
@@ -105,15 +121,24 @@ describe("NIP-46 diagnostic redaction", () => {
         created_at: 1_700_000_000,
         tags: [],
       });
+      await client.nip44Encrypt(recipientKeys.publicKey, encryptionPlaintext);
 
-      expectSafeDiagnostics(clientDiagnostics.diagnostics, [
+      expectNoSensitiveDiagnostics(clientDiagnostics.diagnostics, [
         connectionSecret,
         eventPlaintext,
+        encryptionPlaintext,
       ]);
-      expectSafeDiagnostics(bunkerDiagnostics.diagnostics, [
+      expectNoSensitiveDiagnostics(bunkerDiagnostics.diagnostics, [
         connectionSecret,
         eventPlaintext,
+        encryptionPlaintext,
       ]);
+      expect(renderDiagnostics(clientDiagnostics.diagnostics)).toContain(
+        "sign_event",
+      );
+      expect(renderDiagnostics(bunkerDiagnostics.diagnostics)).toContain(
+        "sign_event",
+      );
     } finally {
       await client.disconnect().catch(() => undefined);
       await bunker.stop().catch(() => undefined);
@@ -125,6 +150,8 @@ describe("NIP-46 diagnostic redaction", () => {
     const signerKeys = await generateKeypair();
     const connectionSecret = "connection-secret-simple-client";
     const eventPlaintext = "private-event-simple-client";
+    const encryptionPlaintext = "private-encryption-simple-client";
+    const recipientKeys = await generateKeypair();
     const clientDiagnostics = createCapturingLogger();
     const bunkerDiagnostics = createCapturingLogger();
     const bunker = new NostrRemoteSignerBunker({
@@ -132,7 +159,12 @@ describe("NIP-46 diagnostic redaction", () => {
       signerPubkey: signerKeys.publicKey,
       relays: [relayUrl],
       secret: connectionSecret,
-      defaultPermissions: ["get_public_key", "ping", "sign_event"],
+      defaultPermissions: [
+        "get_public_key",
+        "ping",
+        "sign_event",
+        "nip44_encrypt",
+      ],
       logger: bunkerDiagnostics.logger,
     });
     const client = new SimpleNIP46Client([relayUrl], {
@@ -152,18 +184,154 @@ describe("NIP-46 diagnostic redaction", () => {
         created_at: 1_700_000_001,
         tags: [],
       });
+      await client.nip44Encrypt(recipientKeys.publicKey, encryptionPlaintext);
 
-      expectSafeDiagnostics(clientDiagnostics.diagnostics, [
+      expectNoSensitiveDiagnostics(clientDiagnostics.diagnostics, [
         connectionSecret,
         eventPlaintext,
+        encryptionPlaintext,
       ]);
-      expectSafeDiagnostics(bunkerDiagnostics.diagnostics, [
+      expectNoSensitiveDiagnostics(bunkerDiagnostics.diagnostics, [
         connectionSecret,
         eventPlaintext,
+        encryptionPlaintext,
       ]);
+      expect(renderDiagnostics(clientDiagnostics.diagnostics)).toContain(
+        "sign_event",
+      );
+      expect(renderDiagnostics(bunkerDiagnostics.diagnostics)).toContain(
+        "sign_event",
+      );
     } finally {
       await client.disconnect().catch(() => undefined);
       await bunker.stop().catch(() => undefined);
     }
+  });
+
+  test("legacy simple facades redact secret connect responses", async () => {
+    const userKeys = await generateKeypair();
+    const signerKeys = await generateKeypair();
+    const connectionSecret = "legacy-connect-response-secret";
+    const clientDiagnostics = createCapturingLogger();
+    const bunkerDiagnostics = createCapturingLogger();
+    const bunker = new SimpleNIP46Bunker(
+      [relayUrl],
+      userKeys.publicKey,
+      signerKeys.publicKey,
+      {
+        secret: connectionSecret,
+        defaultPermissions: ["get_public_key"],
+        logger: bunkerDiagnostics.logger,
+      },
+    );
+    const client = new SimpleNIP46Client([relayUrl], {
+      timeout: 3000,
+      logger: clientDiagnostics.logger,
+    });
+
+    bunker.setUserPrivateKey(userKeys.privateKey);
+    bunker.setSignerPrivateKey(signerKeys.privateKey);
+
+    try {
+      await bunker.start();
+      await client.connect(bunker.getConnectionString());
+
+      expectNoSensitiveDiagnostics(clientDiagnostics.diagnostics, [
+        connectionSecret,
+      ]);
+      expectNoSensitiveDiagnostics(bunkerDiagnostics.diagnostics, [
+        connectionSecret,
+      ]);
+      expect(renderDiagnostics(clientDiagnostics.diagnostics)).toContain(
+        "Connect response requires secret",
+      );
+    } finally {
+      await client.disconnect().catch(() => undefined);
+      await bunker.stop().catch(() => undefined);
+    }
+  });
+
+  test("invalid secrets retain safe failure metadata", async () => {
+    const userKeys = await generateKeypair();
+    const signerKeys = await generateKeypair();
+    const expectedSecret = "expected-connect-secret";
+    const rejectedSecret = "rejected-connect-secret";
+    const clientDiagnostics = createCapturingLogger();
+    const bunkerDiagnostics = createCapturingLogger();
+    const bunker = new SimpleNIP46Bunker(
+      [relayUrl],
+      userKeys.publicKey,
+      signerKeys.publicKey,
+      {
+        secret: expectedSecret,
+        logger: bunkerDiagnostics.logger,
+      },
+    );
+    const client = new NostrRemoteSignerClient({
+      relays: [relayUrl],
+      timeout: 3000,
+      logger: clientDiagnostics.logger,
+    });
+
+    bunker.setUserPrivateKey(userKeys.privateKey);
+    bunker.setSignerPrivateKey(signerKeys.privateKey);
+
+    try {
+      await bunker.start();
+      const rejectedConnectionString = bunker
+        .getConnectionString()
+        .replace(expectedSecret, rejectedSecret);
+
+      await expect(client.connect(rejectedConnectionString)).rejects.toThrow(
+        /invalid secret/i,
+      );
+
+      expectNoSensitiveDiagnostics(clientDiagnostics.diagnostics, [
+        expectedSecret,
+        rejectedSecret,
+      ]);
+      expectNoSensitiveDiagnostics(bunkerDiagnostics.diagnostics, [
+        expectedSecret,
+        rejectedSecret,
+      ]);
+      const failureDiagnostics = renderDiagnostics(
+        bunkerDiagnostics.diagnostics,
+      );
+      expect(failureDiagnostics).toMatch(/invalid secret/i);
+      expect(failureDiagnostics).toContain("connect");
+    } finally {
+      await client.disconnect().catch(() => undefined);
+      await bunker.stop().catch(() => undefined);
+    }
+  });
+
+  test("throwing diagnostics cannot alter public behavior", async () => {
+    const userKeys = await generateKeypair();
+    const setLevel = jest.fn(() => {
+      throw new Error("set level failed");
+    });
+    const throwDiagnostic = (): never => {
+      throw new Error("diagnostic failed");
+    };
+    const logger = {
+      error: throwDiagnostic,
+      warn: throwDiagnostic,
+      info: throwDiagnostic,
+      debug: throwDiagnostic,
+      trace: throwDiagnostic,
+      setLevel,
+    };
+
+    expect(
+      () =>
+        new NostrRemoteSignerBunker({
+          userPubkey: userKeys.publicKey,
+          logger,
+        }),
+    ).not.toThrow();
+
+    const client = new SimpleNIP46Client([], { logger });
+    expect(() => client.setLogLevel(LogLevel.TRACE)).not.toThrow();
+    expect(setLevel).toHaveBeenCalledWith(LogLevel.TRACE);
   });
 });

--- a/tests/nip46/diagnostic-redaction.test.ts
+++ b/tests/nip46/diagnostic-redaction.test.ts
@@ -127,11 +127,15 @@ describe("NIP-46 diagnostic redaction", () => {
         connectionSecret,
         eventPlaintext,
         encryptionPlaintext,
+        userKeys.privateKey,
+        signerKeys.privateKey,
       ]);
       expectNoSensitiveDiagnostics(bunkerDiagnostics.diagnostics, [
         connectionSecret,
         eventPlaintext,
         encryptionPlaintext,
+        userKeys.privateKey,
+        signerKeys.privateKey,
       ]);
       expect(renderDiagnostics(clientDiagnostics.diagnostics)).toContain(
         "sign_event",
@@ -190,11 +194,15 @@ describe("NIP-46 diagnostic redaction", () => {
         connectionSecret,
         eventPlaintext,
         encryptionPlaintext,
+        userKeys.privateKey,
+        signerKeys.privateKey,
       ]);
       expectNoSensitiveDiagnostics(bunkerDiagnostics.diagnostics, [
         connectionSecret,
         eventPlaintext,
         encryptionPlaintext,
+        userKeys.privateKey,
+        signerKeys.privateKey,
       ]);
       expect(renderDiagnostics(clientDiagnostics.diagnostics)).toContain(
         "sign_event",
@@ -238,9 +246,13 @@ describe("NIP-46 diagnostic redaction", () => {
 
       expectNoSensitiveDiagnostics(clientDiagnostics.diagnostics, [
         connectionSecret,
+        userKeys.privateKey,
+        signerKeys.privateKey,
       ]);
       expectNoSensitiveDiagnostics(bunkerDiagnostics.diagnostics, [
         connectionSecret,
+        userKeys.privateKey,
+        signerKeys.privateKey,
       ]);
       expect(renderDiagnostics(clientDiagnostics.diagnostics)).toContain(
         "Connect response requires secret",
@@ -289,10 +301,14 @@ describe("NIP-46 diagnostic redaction", () => {
       expectNoSensitiveDiagnostics(clientDiagnostics.diagnostics, [
         expectedSecret,
         rejectedSecret,
+        userKeys.privateKey,
+        signerKeys.privateKey,
       ]);
       expectNoSensitiveDiagnostics(bunkerDiagnostics.diagnostics, [
         expectedSecret,
         rejectedSecret,
+        userKeys.privateKey,
+        signerKeys.privateKey,
       ]);
       const failureDiagnostics = renderDiagnostics(
         bunkerDiagnostics.diagnostics,
@@ -307,6 +323,7 @@ describe("NIP-46 diagnostic redaction", () => {
 
   test("throwing diagnostics cannot alter public behavior", async () => {
     const userKeys = await generateKeypair();
+    const signerKeys = await generateKeypair();
     const setLevel = jest.fn(() => {
       throw new Error("set level failed");
     });
@@ -330,8 +347,31 @@ describe("NIP-46 diagnostic redaction", () => {
         }),
     ).not.toThrow();
 
-    const client = new SimpleNIP46Client([], { logger });
+    const bunker = new SimpleNIP46Bunker(
+      [relayUrl],
+      userKeys.publicKey,
+      signerKeys.publicKey,
+      {
+        defaultPermissions: ["ping"],
+        logger,
+      },
+    );
+    const client = new SimpleNIP46Client([relayUrl], { logger });
+    bunker.setUserPrivateKey(userKeys.privateKey);
+    bunker.setSignerPrivateKey(signerKeys.privateKey);
+
     expect(() => client.setLogLevel(LogLevel.TRACE)).not.toThrow();
     expect(setLevel).toHaveBeenCalledWith(LogLevel.TRACE);
+
+    try {
+      await bunker.start();
+      await expect(client.connect(bunker.getConnectionString())).resolves.toBe(
+        userKeys.publicKey,
+      );
+      await expect(client.ping()).resolves.toBe(true);
+    } finally {
+      await client.disconnect().catch(() => undefined);
+      await bunker.stop().catch(() => undefined);
+    }
   });
 });

--- a/tests/nip46/diagnostic-redaction.test.ts
+++ b/tests/nip46/diagnostic-redaction.test.ts
@@ -1,0 +1,169 @@
+import {
+  type DiagnosticLogArgument,
+  type DiagnosticLogger,
+  NostrRemoteSignerBunker,
+  NostrRemoteSignerClient,
+  SimpleNIP46Bunker,
+  SimpleNIP46Client,
+  generateKeypair,
+} from "../../src";
+import { NostrRelay } from "../../src/testing";
+
+interface CapturedDiagnostic {
+  level: keyof DiagnosticLogger;
+  message: string;
+  args: DiagnosticLogArgument[];
+}
+
+function createCapturingLogger(): {
+  logger: DiagnosticLogger;
+  diagnostics: CapturedDiagnostic[];
+} {
+  const diagnostics: CapturedDiagnostic[] = [];
+  const capture =
+    (level: keyof DiagnosticLogger) =>
+    (message: string, ...args: DiagnosticLogArgument[]): void => {
+      diagnostics.push({ level, message, args });
+    };
+
+  return {
+    logger: {
+      error: capture("error"),
+      warn: capture("warn"),
+      info: capture("info"),
+      debug: capture("debug"),
+      trace: capture("trace"),
+    },
+    diagnostics,
+  };
+}
+
+function renderDiagnostics(diagnostics: CapturedDiagnostic[]): string {
+  return JSON.stringify(diagnostics);
+}
+
+function expectSafeDiagnostics(
+  diagnostics: CapturedDiagnostic[],
+  sensitiveValues: string[],
+): void {
+  const rendered = renderDiagnostics(diagnostics);
+
+  for (const sensitiveValue of sensitiveValues) {
+    expect(rendered).not.toContain(sensitiveValue);
+  }
+
+  expect(rendered).toContain("sign_event");
+  expect(diagnostics.length).toBeGreaterThan(0);
+}
+
+describe("NIP-46 diagnostic redaction", () => {
+  let relay: NostrRelay;
+  let relayUrl: string;
+
+  beforeAll(async () => {
+    relay = new NostrRelay(0);
+    await relay.start();
+    relayUrl = relay.url;
+  });
+
+  afterAll(async () => {
+    await relay.close();
+  });
+
+  test("advanced client and simple bunker never expose protocol secrets", async () => {
+    const userKeys = await generateKeypair();
+    const signerKeys = await generateKeypair();
+    const connectionSecret = "connection-secret-advanced-client";
+    const eventPlaintext = "private-event-advanced-client";
+    const clientDiagnostics = createCapturingLogger();
+    const bunkerDiagnostics = createCapturingLogger();
+    const bunker = new SimpleNIP46Bunker(
+      [relayUrl],
+      userKeys.publicKey,
+      signerKeys.publicKey,
+      {
+        secret: connectionSecret,
+        defaultPermissions: ["get_public_key", "ping", "sign_event"],
+        logger: bunkerDiagnostics.logger,
+      },
+    );
+    const client = new NostrRemoteSignerClient({
+      relays: [relayUrl],
+      timeout: 3000,
+      logger: clientDiagnostics.logger,
+    });
+
+    bunker.setUserPrivateKey(userKeys.privateKey);
+    bunker.setSignerPrivateKey(signerKeys.privateKey);
+
+    try {
+      await bunker.start();
+      await client.connect(bunker.getConnectionString());
+      await client.signEvent({
+        kind: 1,
+        content: eventPlaintext,
+        created_at: 1_700_000_000,
+        tags: [],
+      });
+
+      expectSafeDiagnostics(clientDiagnostics.diagnostics, [
+        connectionSecret,
+        eventPlaintext,
+      ]);
+      expectSafeDiagnostics(bunkerDiagnostics.diagnostics, [
+        connectionSecret,
+        eventPlaintext,
+      ]);
+    } finally {
+      await client.disconnect().catch(() => undefined);
+      await bunker.stop().catch(() => undefined);
+    }
+  });
+
+  test("simple client and advanced bunker never expose protocol secrets", async () => {
+    const userKeys = await generateKeypair();
+    const signerKeys = await generateKeypair();
+    const connectionSecret = "connection-secret-simple-client";
+    const eventPlaintext = "private-event-simple-client";
+    const clientDiagnostics = createCapturingLogger();
+    const bunkerDiagnostics = createCapturingLogger();
+    const bunker = new NostrRemoteSignerBunker({
+      userPubkey: userKeys.publicKey,
+      signerPubkey: signerKeys.publicKey,
+      relays: [relayUrl],
+      secret: connectionSecret,
+      defaultPermissions: ["get_public_key", "ping", "sign_event"],
+      logger: bunkerDiagnostics.logger,
+    });
+    const client = new SimpleNIP46Client([relayUrl], {
+      timeout: 3000,
+      logger: clientDiagnostics.logger,
+    });
+
+    bunker.setUserPrivateKey(userKeys.privateKey);
+    bunker.setSignerPrivateKey(signerKeys.privateKey);
+
+    try {
+      await bunker.start();
+      await client.connect(bunker.getConnectionString());
+      await client.signEvent({
+        kind: 1,
+        content: eventPlaintext,
+        created_at: 1_700_000_001,
+        tags: [],
+      });
+
+      expectSafeDiagnostics(clientDiagnostics.diagnostics, [
+        connectionSecret,
+        eventPlaintext,
+      ]);
+      expectSafeDiagnostics(bunkerDiagnostics.diagnostics, [
+        connectionSecret,
+        eventPlaintext,
+      ]);
+    } finally {
+      await client.disconnect().catch(() => undefined);
+      await bunker.stop().catch(() => undefined);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- route all four NIP-46 client and bunker facades through one redacting, non-throwing diagnostic adapter
- add compatible structural logger injection while preserving default logger behavior and 0.x aliases
- redact connection strings, secrets, private keys, request parameters, plaintext, decrypted payloads, auth URLs, results, and legacy response envelopes
- retain safe operation, correlation, public-key, event, and failure metadata
- add public cross-facade coverage for info/debug/trace, encryption plaintext, invalid secrets, legacy simple clients, and throwing loggers

## Verification

- Grok 4.5 standards/spec review: pass after fixes; follow-up found no remaining defects
- local CodeRabbit: 3 issues fixed; second round 0 issues
- focused Jest/Bun redaction: 5/5 each
- final Jest: 80/80 suites, 1052/1052 tests, no open handles
- final Bun: 1052/1052 tests, 8154 assertions
- commands/package policy, lint, TypeScript, CJS/ESM builds, examples, and pack verifier: green

Closes #131
Part of #130


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable diagnostic logger option for NIP-46 clients and bunkers.
  * Diagnostic output is now automatically sanitized (e.g., connection secrets/private keys, payload contents, and full response data), including safe handling of circular structures.
* **Bug Fixes**
  * Improved diagnostic logging resilience so logging failures don’t impact normal request/connection behavior.
  * Simplified diagnostic messages for failed response sending while preserving non-sensitive context.
* **Documentation**
  * Added detailed run, review-packet, and issue/session documentation for diagnostic redaction.
* **Tests**
  * Added comprehensive redaction tests across client/bunker variants, invalid-secret scenarios, and throwing diagnostic loggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->