### PR TITLE
Remove Jest from published declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ try {
 }
 ```
 
+Framework-neutral relay test-double types live at the same boundary, so using
+them does not add Jest (or another test runner) to application declarations:
+
+```typescript
+import type { RelayTestContext, RelayTestMock } from "snstr/testing";
+```
+
 The testing subpath is supported during the 0.x release line, but it is not a
 production relay server and may evolve between minor 0.x releases. The legacy
 `snstr/utils/ephemeral-relay` subpath remains available for 0.x compatibility.

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: item 1 / issue #131 merged into `staging`; item 2 / issue #132 passed Grok review and all local verification; local CodeRabbit review pending
+- Current status: item 1 / issue #131 merged into `staging`; item 2 / issue #132 passed Grok review and all local verification; local CodeRabbit findings fixed with clean rerun pending
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -26,7 +26,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Ticket sessions: created as each ticket starts
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
 - Review packets: `issue-131-review-packet.md`, `issue-132-review-packet.md`; created per later ticket
-- Local CodeRabbit report: `issue-131-coderabbit-local.md`; created per later ticket
+- Local CodeRabbit report: `issue-131-coderabbit-local.md`, `issue-132-coderabbit-local.md`; created per later ticket
 - PR URL: #140 merged for issue #131; created per later ticket, always non-draft and targeting `staging`
 
 ## Commands
@@ -42,7 +42,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | Issue                             | Type | Status          | Branch                                  | Review                                                   | Verified                            |
 | --------------------------------- | ---- | --------------- | --------------------------------------- | -------------------------------------------------------- | ----------------------------------- |
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes | Jest/Bun 1054/1054; hosted CI green |
-| #132 published declaration purity | AFK  | in review       | `feature/public-type-test-purity`       | Grok standards/spec pass; CodeRabbit pending             | Jest/Bun 1055/1055; all gates green |
+| #132 published declaration purity | AFK  | in review       | `feature/public-type-test-purity`       | Grok pass; CodeRabbit findings fixed, rerun pending      | Jest/Bun 1055/1055; all gates green |
 | #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                  | pending                             |
 | #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                  | pending                             |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                  | pending                             |

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: item 1 / issue #131 merged into `staging`; item 2 / issue #132 passed Grok review and all local verification; local CodeRabbit findings fixed with clean rerun pending
+- Current status: item 1 / issue #131 merged into `staging`; item 2 / issue #132 passed Grok review, all local verification, and local CodeRabbit code review; PR publication pending
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -42,7 +42,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | Issue                             | Type | Status          | Branch                                  | Review                                                   | Verified                            |
 | --------------------------------- | ---- | --------------- | --------------------------------------- | -------------------------------------------------------- | ----------------------------------- |
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes | Jest/Bun 1054/1054; hosted CI green |
-| #132 published declaration purity | AFK  | in review       | `feature/public-type-test-purity`       | Grok pass; CodeRabbit findings fixed, rerun pending      | Jest/Bun 1055/1055; all gates green |
+| #132 published declaration purity | AFK  | in review       | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local code review clean            | Jest/Bun 1055/1055; all gates green |
 | #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                  | pending                             |
 | #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                  | pending                             |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                  | pending                             |

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: item 1 / issue #131 merged into `staging`; item 2 / issue #132 is open as PR #141 with hosted CI and CodeRabbit pending
+- Current status: item 1 / issue #131 merged into `staging`; item 2 / issue #132 is ready to merge as PR #141 after hosted CI and CodeRabbit completed cleanly
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -42,7 +42,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | Issue                             | Type | Status          | Branch                                  | Review                                                   | Verified                            |
 | --------------------------------- | ---- | --------------- | --------------------------------------- | -------------------------------------------------------- | ----------------------------------- |
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes | Jest/Bun 1054/1054; hosted CI green |
-| #132 published declaration purity | AFK  | in review       | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local zero findings                | Jest/Bun 1055/1055; all gates green |
+| #132 published declaration purity | AFK  | ready to merge  | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                 | Jest/Bun 1055/1055; hosted CI green |
 | #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                  | pending                             |
 | #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                  | pending                             |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                  | pending                             |
@@ -62,7 +62,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | Issue | Fixed point | Implementation owner                                | Commit                                     | Review result                                                        | Checks                                                                                        |
 | ----- | ----------- | --------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9`, `426c17b` | Grok approved after hosted fixes; CodeRabbit local code review clean | focused Jest/Bun 7/7; final Jest/Bun 1054/1054; policies, lint, types, builds, examples, pack |
-| #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | `0c111d7`, `20565a0`, `abfc836`, `dea7aa0` | Grok passed; CodeRabbit local zero findings after four fixes         | focused 8/8; Jest/Bun 1055/1055; policies, lint, types, builds, examples, and pack green      |
+| #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | `0c111d7`, `20565a0`, `abfc836`, `dea7aa0` | Grok passed; CodeRabbit local/hosted clean after four local fixes    | focused 8/8; Jest/Bun 1055/1055; all local gates and four hosted lanes green                  |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: item 1 / issue #131 fully reviewed and verified; PR #140 ready to merge into `staging`
+- Current status: item 1 / issue #131 merged into `staging`; item 2 / issue #132 passed Grok review and all local verification; local CodeRabbit review pending
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -24,10 +24,10 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Spec issue: #130 — Complete the high-impact cleanup chain
 - Tickets: #131–#139
 - Ticket sessions: created as each ticket starts
-- Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all item #131 standards/spec passes
-- Review packets: `issue-131-review-packet.md`; created per later ticket
+- Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
+- Review packets: `issue-131-review-packet.md`, `issue-132-review-packet.md`; created per later ticket
 - Local CodeRabbit report: `issue-131-coderabbit-local.md`; created per later ticket
-- PR URL: #140 for issue #131; created per later ticket, always non-draft and targeting `staging`
+- PR URL: #140 merged for issue #131; created per later ticket, always non-draft and targeting `staging`
 
 ## Commands
 
@@ -41,8 +41,8 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 
 | Issue                             | Type | Status          | Branch                                  | Review                                                   | Verified                            |
 | --------------------------------- | ---- | --------------- | --------------------------------------- | -------------------------------------------------------- | ----------------------------------- |
-| #131 NIP-46 diagnostic redaction  | AFK  | PR #140 ready   | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes | Jest/Bun 1054/1054; hosted CI green |
-| #132 published declaration purity | AFK  | blocked by #131 | `feature/public-type-test-purity`       | pending                                                  | pending                             |
+| #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes | Jest/Bun 1054/1054; hosted CI green |
+| #132 published declaration purity | AFK  | in review       | `feature/public-type-test-purity`       | Grok standards/spec pass; CodeRabbit pending             | Jest/Bun 1055/1055; all gates green |
 | #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                  | pending                             |
 | #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                  | pending                             |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                  | pending                             |
@@ -62,6 +62,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | Issue | Fixed point | Implementation owner                                | Commit                                     | Review result                                                        | Checks                                                                                        |
 | ----- | ----------- | --------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9`, `426c17b` | Grok approved after hosted fixes; CodeRabbit local code review clean | focused Jest/Bun 7/7; final Jest/Bun 1054/1054; policies, lint, types, builds, examples, pack |
+| #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | pending                                    | Grok standards/spec passed after all initial findings were resolved  | focused 8/8; Jest/Bun 1055/1055; policies, lint, types, builds, examples, and pack green      |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: item 1 / issue #131 merged into `staging`; item 2 / issue #132 passed Grok review, all local verification, and local CodeRabbit code review; PR publication pending
+- Current status: item 1 / issue #131 merged into `staging`; item 2 / issue #132 is open as PR #141 with hosted CI and CodeRabbit pending
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -27,7 +27,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
 - Review packets: `issue-131-review-packet.md`, `issue-132-review-packet.md`; created per later ticket
 - Local CodeRabbit report: `issue-131-coderabbit-local.md`, `issue-132-coderabbit-local.md`; created per later ticket
-- PR URL: #140 merged for issue #131; created per later ticket, always non-draft and targeting `staging`
+- PR URL: #140 merged for issue #131; #141 open for issue #132; created per later ticket, always non-draft and targeting `staging`
 
 ## Commands
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -42,7 +42,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | Issue                             | Type | Status          | Branch                                  | Review                                                   | Verified                            |
 | --------------------------------- | ---- | --------------- | --------------------------------------- | -------------------------------------------------------- | ----------------------------------- |
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes | Jest/Bun 1054/1054; hosted CI green |
-| #132 published declaration purity | AFK  | in review       | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local code review clean            | Jest/Bun 1055/1055; all gates green |
+| #132 published declaration purity | AFK  | in review       | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local zero findings                | Jest/Bun 1055/1055; all gates green |
 | #133 shared diagnostic seam       | AFK  | blocked by #132 | `feature/shared-diagnostics-completion` | pending                                                  | pending                             |
 | #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                  | pending                             |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                  | pending                             |
@@ -62,7 +62,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | Issue | Fixed point | Implementation owner                                | Commit                                     | Review result                                                        | Checks                                                                                        |
 | ----- | ----------- | --------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9`, `426c17b` | Grok approved after hosted fixes; CodeRabbit local code review clean | focused Jest/Bun 7/7; final Jest/Bun 1054/1054; policies, lint, types, builds, examples, pack |
-| #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | pending                                    | Grok standards/spec passed after all initial findings were resolved  | focused 8/8; Jest/Bun 1055/1055; policies, lint, types, builds, examples, and pack green      |
+| #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | `0c111d7`, `20565a0`, `abfc836`, `dea7aa0` | Grok passed; CodeRabbit local zero findings after four fixes         | focused 8/8; Jest/Bun 1055/1055; policies, lint, types, builds, examples, and pack green      |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/issue-132-coderabbit-local.md
+++ b/docs/agents/runs/issue-132-coderabbit-local.md
@@ -1,0 +1,28 @@
+# Local CodeRabbit Review: #132 Published Declaration Purity
+
+## Review Scope
+
+- Base: `staging`
+- Branch: `feature/public-type-test-purity`
+- Review mode: committed changes
+- Initial implementation commit: `0c111d7`
+
+## Initial Findings
+
+CodeRabbit reported three minor findings, all accepted:
+
+1. Restrict `capturedCallbacks` to `RelayEvent` keys while preserving each event's callback signature.
+2. Diagnose a missing consumer type version before forming an invalid `@types/*@undefined` install spec.
+3. Detect dynamic TypeScript imports such as `import("jest").Mock` in packed declarations.
+
+## Fixes and Verification
+
+- Replaced the arbitrary callback string index with an event-specific mapped type and added a negative type assertion for foreign keys.
+- Validated every required consumer type against `devDependencies` before installation.
+- Extended the declaration scan to cover dynamic imports from `jest` and `@jest/globals`.
+- Focused Jest: 3/3 suites and 8/8 tests.
+- Lint, strict TypeScript, CJS/ESM build, and packed-consumer verification: green.
+
+## Follow-up
+
+- Status: pending clean rerun

--- a/docs/agents/runs/issue-132-coderabbit-local.md
+++ b/docs/agents/runs/issue-132-coderabbit-local.md
@@ -31,4 +31,5 @@ A later pass reported one additional minor finding: preserve npm stderr when the
 - The second committed review found no code issues. Its only finding was that this section still described the clean rerun as pending.
 - A subsequent pass found the missing npm stderr diagnostic described above; the pack gate remained green after the fix.
 - The post-fix green checks were the focused Jest, lint, strict TypeScript, CJS/ESM build, and packed-consumer run recorded above.
-- Status: code review clean; documentation provenance clarified
+- Final committed review: zero findings across all eight changed files
+- Status: clean

--- a/docs/agents/runs/issue-132-coderabbit-local.md
+++ b/docs/agents/runs/issue-132-coderabbit-local.md
@@ -25,4 +25,6 @@ CodeRabbit reported three minor findings, all accepted:
 
 ## Follow-up
 
-- Status: pending clean rerun
+- The second committed review found no code issues. Its only finding was that this section still described the clean rerun as pending.
+- The post-fix green checks were the focused Jest, lint, strict TypeScript, CJS/ESM build, and packed-consumer run recorded above.
+- Status: code review clean; documentation provenance clarified

--- a/docs/agents/runs/issue-132-coderabbit-local.md
+++ b/docs/agents/runs/issue-132-coderabbit-local.md
@@ -15,16 +15,20 @@ CodeRabbit reported three minor findings, all accepted:
 2. Diagnose a missing consumer type version before forming an invalid `@types/*@undefined` install spec.
 3. Detect dynamic TypeScript imports such as `import("jest").Mock` in packed declarations.
 
+A later pass reported one additional minor finding: preserve npm stderr when the isolated packed-consumer installation fails. This was also accepted.
+
 ## Fixes and Verification
 
 - Replaced the arbitrary callback string index with an event-specific mapped type and added a negative type assertion for foreign keys.
 - Validated every required consumer type against `devDependencies` before installation.
 - Extended the declaration scan to cover dynamic imports from `jest` and `@jest/globals`.
+- Wrapped the packed-consumer install so npm stderr survives in the final verification diagnostic.
 - Focused Jest: 3/3 suites and 8/8 tests.
 - Lint, strict TypeScript, CJS/ESM build, and packed-consumer verification: green.
 
 ## Follow-up
 
 - The second committed review found no code issues. Its only finding was that this section still described the clean rerun as pending.
+- A subsequent pass found the missing npm stderr diagnostic described above; the pack gate remained green after the fix.
 - The post-fix green checks were the focused Jest, lint, strict TypeScript, CJS/ESM build, and packed-consumer run recorded above.
 - Status: code review clean; documentation provenance clarified

--- a/docs/agents/runs/issue-132-review-packet.md
+++ b/docs/agents/runs/issue-132-review-packet.md
@@ -1,0 +1,42 @@
+# Review Packet: #132 Published Declaration Purity
+
+## Issue
+
+- Issue: #132
+- Slice type: AFK package declaration cleanup
+- Acceptance criteria: root declarations contain no Jest ownership; extracted consumer typechecks without Jest; equivalent relay test context remains at `snstr/testing`; Node/web declaration parity remains green
+- Baseline: `cf705f0`
+- Current diff: `git diff staging...HEAD`
+
+## Implementation Summary
+
+The accidental `RelayTestContext` export has moved from the shared root/web type barrel to the existing Node-only `snstr/testing` boundary. Its mock slots now accept framework-neutral callables, including Jest mocks, without naming Jest. Pack verification scans all published declarations for Jest ownership and compiles an extracted consumer with library checking enabled and automatic ambient types disabled.
+
+## Implementation Evidence
+
+- `implement` session: `issue-132-session.md`
+- `tdd` used: yes
+- Red test: missing testing-entrypoint types and CJS/ESM declarations containing `jest.Mock`
+- Green implementation: focused public type/entry suites, both builds, declaration scan, and extracted packed consumer
+- Refactor: one test-only package boundary owns test context; production barrels own no test framework
+- Commands run: focused Jest; CJS/ESM build; pack verification
+
+## Review Instructions
+
+Review only issue #132 unless a severe cross-slice regression appears. Keep standards and spec axes separate. Verify no published declaration names Jest, the extracted consumer cannot receive Jest ambient types, existing Jest mocks remain assignable to the framework-neutral type, and `snstr/testing` stays Node-only.
+
+## Reviewer Output
+
+```text
+STANDARDS_STATUS: pass
+STANDARDS_FINDINGS:
+- Initial: `unknown[]` rejected specifically typed test doubles; public purity assertions and packed slot assignment were incomplete.
+- Resolved: use a documented permissive callable, assert root/web absence, and exercise plain, typed, and Jest mocks at the testing boundary and in the packed consumer.
+- Follow-up: no remaining findings.
+
+SPEC_STATUS: pass
+SPEC_FINDINGS:
+- Initial: a temp consumer below the checkout could resolve workspace Jest types; declaration patterns and installed-artifact coverage were incomplete.
+- Resolved: install the tarball in an OS temp directory, assert Jest packages are absent, scan all installed declarations for Jest ownership, and compile with `types: []` and `skipLibCheck: false`.
+- Follow-up: no remaining findings.
+```

--- a/docs/agents/runs/issue-132-session.md
+++ b/docs/agents/runs/issue-132-session.md
@@ -5,8 +5,9 @@
 - Issue: #132
 - Fixed point before session: `cf705f0`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
-- Commit: pending
-- Status: implementation, independent Grok review, full verification, and local CodeRabbit code review complete
+- Commits: `0c111d7`, `20565a0`, `abfc836`, `dea7aa0`, `466d1d5`
+- PR: #141
+- Status: PR #141 open against `staging`; hosted CI and CodeRabbit pending
 
 ## Inputs
 

--- a/docs/agents/runs/issue-132-session.md
+++ b/docs/agents/runs/issue-132-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `cf705f0`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
 - Commit: pending
-- Status: implementation, independent Grok review, and full verification complete; local CodeRabbit review pending
+- Status: implementation, independent Grok review, and full verification complete; local CodeRabbit findings fixed with clean rerun pending
 
 ## Inputs
 
@@ -33,6 +33,8 @@
 - Worthy fixes applied: the mock callable uses a documented permissive parameter list; type tests lock root/web absence and typed/Jest mock compatibility; pack verification installs the tarball outside the repository, asserts Jest packages are absent, scans every installed declaration, and compiles a strict consumer that assigns the mock into context slots
 - Findings ignored with reasons: none
 - Follow-up result: Grok standards and spec reviews both passed with no remaining findings
+- Local CodeRabbit findings: three minor findings accepted—event-specific callback keys, explicit missing consumer dependency diagnostics, and dynamic Jest type-import detection
+- Local CodeRabbit fixes: mapped callback captures, dependency version guards, dynamic-import scan coverage, and a negative callback-key type assertion; focused and package gates remain green
 
 ## Verification
 
@@ -42,6 +44,7 @@
 - Repository gates: commands/package-manager policy, lint, TypeScript, CJS/ESM builds, examples, and pack verification all green
 - Full Jest: 81/81 suites and 1055/1055 tests in 296.062 seconds
 - Full Bun: 1055/1055 tests and 8172 assertions across 81 files in 263.38 seconds
+- Post-CodeRabbit focused verification: 3/3 suites and 8/8 tests; lint, strict TypeScript, CJS/ESM build, and pack verification green
 
 ## Risks
 

--- a/docs/agents/runs/issue-132-session.md
+++ b/docs/agents/runs/issue-132-session.md
@@ -5,9 +5,9 @@
 - Issue: #132
 - Fixed point before session: `cf705f0`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
-- Commits: `0c111d7`, `20565a0`, `abfc836`, `dea7aa0`, `466d1d5`
+- Commits: `0c111d7`, `20565a0`, `abfc836`, `dea7aa0`, `466d1d5`, `0d0ef41`
 - PR: #141
-- Status: PR #141 open against `staging`; hosted CI and CodeRabbit pending
+- Status: PR #141 ready to merge after hosted CI and CodeRabbit completed cleanly
 
 ## Inputs
 
@@ -32,12 +32,13 @@
 - Standards findings: the first pass found that `unknown[]` made specifically typed doubles unassignable under strict function variance; it also requested root/web negative assertions and assignment of the exported mock type into packed-consumer context slots
 - Spec findings: the first pass found that a consumer beneath the repository could still resolve workspace Jest types, the declaration scan needed namespace/import coverage, and scanning build output rather than the installed tarball left a packaging gap
 - Worthy fixes applied: the mock callable uses a documented permissive parameter list; type tests lock root/web absence and typed/Jest mock compatibility; pack verification installs the tarball outside the repository, asserts Jest packages are absent, scans every installed declaration, and compiles a strict consumer that assigns the mock into context slots
-- Findings ignored with reasons: none
+- Findings ignored with reasons: hosted CodeRabbit's out-of-scope warning applies to the required feature-loop run artifacts, and its generic docstring-coverage warning conflicts with the existing style for small internal verifier helpers; neither produced an actionable review comment
 - Follow-up result: Grok standards and spec reviews both passed with no remaining findings
 - Local CodeRabbit findings: four minor findings accepted—event-specific callback keys, explicit missing consumer dependency diagnostics, dynamic Jest type-import detection, and preserved npm stderr on consumer install failure
 - Local CodeRabbit fixes: mapped callback captures, dependency version guards, dynamic-import scan coverage, a negative callback-key type assertion, and surfaced npm install diagnostics; focused and package gates remain green
 - Local CodeRabbit follow-up: no code findings; one stale pending-status note in the review record was corrected
 - Local CodeRabbit final result: zero findings
+- Hosted CodeRabbit result: full review completed with no actionable comments
 
 ## Verification
 
@@ -48,6 +49,7 @@
 - Full Jest: 81/81 suites and 1055/1055 tests in 296.062 seconds
 - Full Bun: 1055/1055 tests and 8172 assertions across 81 files in 263.38 seconds
 - Post-CodeRabbit focused verification: 3/3 suites and 8/8 tests; lint, strict TypeScript, CJS/ESM build, and pack verification green
+- Hosted CI: Node 16, Node 18, Node 20, and Bun lanes green on PR #141
 
 ## Risks
 

--- a/docs/agents/runs/issue-132-session.md
+++ b/docs/agents/runs/issue-132-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `cf705f0`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
 - Commit: pending
-- Status: implementation, independent Grok review, and full verification complete; local CodeRabbit findings fixed with clean rerun pending
+- Status: implementation, independent Grok review, full verification, and local CodeRabbit code review complete
 
 ## Inputs
 
@@ -35,6 +35,7 @@
 - Follow-up result: Grok standards and spec reviews both passed with no remaining findings
 - Local CodeRabbit findings: three minor findings accepted—event-specific callback keys, explicit missing consumer dependency diagnostics, and dynamic Jest type-import detection
 - Local CodeRabbit fixes: mapped callback captures, dependency version guards, dynamic-import scan coverage, and a negative callback-key type assertion; focused and package gates remain green
+- Local CodeRabbit follow-up: no code findings; one stale pending-status note in the review record was corrected
 
 ## Verification
 

--- a/docs/agents/runs/issue-132-session.md
+++ b/docs/agents/runs/issue-132-session.md
@@ -1,0 +1,48 @@
+# Issue Session: #132 Published Declaration Purity
+
+## Issue
+
+- Issue: #132
+- Fixed point before session: `cf705f0`
+- Worker session: current Codex orchestrator; Grok 4.5 High reviewers
+- Commit: pending
+- Status: implementation, independent Grok review, and full verification complete; local CodeRabbit review pending
+
+## Inputs
+
+- Spec issue: #130
+- Ticket: #132
+- Relevant glossary terms: Relay
+- Relevant ADRs: none
+- Prototype answer and source branch, if any: none
+
+## Implementation
+
+- Public interface used: `snstr/testing` owns `RelayTestContext` and framework-neutral `RelayTestMock`; neither root nor web declarations expose test-runner types
+- Behaviors covered: every packed declaration rejects Jest ownership; an extracted package consumer imports root and testing types with ambient type packages disabled; Node, browser, and React Native type resolution retain their existing targets
+- `tdd` used: yes; the testing-entrypoint type test failed on missing exports and pack verification failed on both CJS and ESM `jest.Mock` declarations before implementation
+- Commands run during implementation: focused Jest type/entry suites; CJS/ESM build; packed-consumer verification
+- Full suite commands: `npm test -- --runInBand`; `npm run test:bun`; repository policy, lint, type, build, example, and pack gates
+
+## Review
+
+- Review fixed point: `cf705f0`
+- Design findings: Grok recommended moving the context to the existing Node-only testing boundary, using framework-neutral callables, scanning every packed declaration, and compiling an extracted no-Jest consumer
+- Standards findings: the first pass found that `unknown[]` made specifically typed doubles unassignable under strict function variance; it also requested root/web negative assertions and assignment of the exported mock type into packed-consumer context slots
+- Spec findings: the first pass found that a consumer beneath the repository could still resolve workspace Jest types, the declaration scan needed namespace/import coverage, and scanning build output rather than the installed tarball left a packaging gap
+- Worthy fixes applied: the mock callable uses a documented permissive parameter list; type tests lock root/web absence and typed/Jest mock compatibility; pack verification installs the tarball outside the repository, asserts Jest packages are absent, scans every installed declaration, and compiles a strict consumer that assigns the mock into context slots
+- Findings ignored with reasons: none
+- Follow-up result: Grok standards and spec reviews both passed with no remaining findings
+
+## Verification
+
+- Focused Jest: 3/3 suites, 8/8 tests
+- CJS/ESM declarations: green
+- Packed no-Jest consumer: green with `skipLibCheck: false` and automatic ambient types disabled
+- Repository gates: commands/package-manager policy, lint, TypeScript, CJS/ESM builds, examples, and pack verification all green
+- Full Jest: 81/81 suites and 1055/1055 tests in 296.062 seconds
+- Full Bun: 1055/1055 tests and 8172 assertions across 81 files in 263.38 seconds
+
+## Risks
+
+- `RelayTestContext` intentionally leaves the accidental root/web export and remains available from the documented `snstr/testing` subpath.

--- a/docs/agents/runs/issue-132-session.md
+++ b/docs/agents/runs/issue-132-session.md
@@ -33,8 +33,8 @@
 - Worthy fixes applied: the mock callable uses a documented permissive parameter list; type tests lock root/web absence and typed/Jest mock compatibility; pack verification installs the tarball outside the repository, asserts Jest packages are absent, scans every installed declaration, and compiles a strict consumer that assigns the mock into context slots
 - Findings ignored with reasons: none
 - Follow-up result: Grok standards and spec reviews both passed with no remaining findings
-- Local CodeRabbit findings: three minor findings accepted—event-specific callback keys, explicit missing consumer dependency diagnostics, and dynamic Jest type-import detection
-- Local CodeRabbit fixes: mapped callback captures, dependency version guards, dynamic-import scan coverage, and a negative callback-key type assertion; focused and package gates remain green
+- Local CodeRabbit findings: four minor findings accepted—event-specific callback keys, explicit missing consumer dependency diagnostics, dynamic Jest type-import detection, and preserved npm stderr on consumer install failure
+- Local CodeRabbit fixes: mapped callback captures, dependency version guards, dynamic-import scan coverage, a negative callback-key type assertion, and surfaced npm install diagnostics; focused and package gates remain green
 - Local CodeRabbit follow-up: no code findings; one stale pending-status note in the review record was corrected
 
 ## Verification

--- a/docs/agents/runs/issue-132-session.md
+++ b/docs/agents/runs/issue-132-session.md
@@ -36,6 +36,7 @@
 - Local CodeRabbit findings: four minor findings accepted—event-specific callback keys, explicit missing consumer dependency diagnostics, dynamic Jest type-import detection, and preserved npm stderr on consumer install failure
 - Local CodeRabbit fixes: mapped callback captures, dependency version guards, dynamic-import scan coverage, a negative callback-key type assertion, and surfaced npm install diagnostics; focused and package gates remain green
 - Local CodeRabbit follow-up: no code findings; one stale pending-status note in the review record was corrected
+- Local CodeRabbit final result: zero findings
 
 ## Verification
 

--- a/scripts/verify-pack.js
+++ b/scripts/verify-pack.js
@@ -10,6 +10,7 @@
  */
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
 const { builtinModules } = require("module");
@@ -58,19 +59,33 @@ function verifyNodeSubpathResolution(packageRoot) {
   const checks = [
     {
       label: "CommonJS snstr/testing",
-      args: ["-e", 'const api = require("snstr/testing"); if (typeof api.NostrRelay !== "function") process.exit(1);'],
+      args: [
+        "-e",
+        'const api = require("snstr/testing"); if (typeof api.NostrRelay !== "function") process.exit(1);',
+      ],
     },
     {
       label: "ESM snstr/testing",
-      args: ["--input-type=module", "-e", 'const api = await import("snstr/testing"); if (typeof api.NostrRelay !== "function") process.exit(1);'],
+      args: [
+        "--input-type=module",
+        "-e",
+        'const api = await import("snstr/testing"); if (typeof api.NostrRelay !== "function") process.exit(1);',
+      ],
     },
     {
       label: "legacy CommonJS ephemeral relay alias",
-      args: ["-e", 'const api = require("snstr/utils/ephemeral-relay"); if (typeof api.NostrRelay !== "function") process.exit(1);'],
+      args: [
+        "-e",
+        'const api = require("snstr/utils/ephemeral-relay"); if (typeof api.NostrRelay !== "function") process.exit(1);',
+      ],
     },
     {
       label: "legacy ESM ephemeral relay alias",
-      args: ["--input-type=module", "-e", 'const api = await import("snstr/utils/ephemeral-relay"); if (typeof api.NostrRelay !== "function") process.exit(1);'],
+      args: [
+        "--input-type=module",
+        "-e",
+        'const api = await import("snstr/utils/ephemeral-relay"); if (typeof api.NostrRelay !== "function") process.exit(1);',
+      ],
     },
   ];
 
@@ -85,8 +100,98 @@ function verifyNodeSubpathResolution(packageRoot) {
   }
 }
 
+function verifyPackedTypeConsumer(tempDir) {
+  const fixturePath = path.join(tempDir, "consumer.mts");
+  fs.writeFileSync(
+    fixturePath,
+    [
+      'import { RelayEvent, type NostrEvent, type RelayInterface } from "snstr";',
+      'import { NostrRelay, type RelayTestContext, type RelayTestMock } from "snstr/testing";',
+      "",
+      "const mock: RelayTestMock = (id: string, accepted: boolean) => `${id}:${accepted}`;",
+      "declare const relay: RelayInterface;",
+      "declare const event: NostrEvent;",
+      "const context: RelayTestContext = {",
+      "  relay,",
+      "  originals: {},",
+      "  mocks: { send: mock, handlers: { [RelayEvent.OK]: mock } },",
+      "  capturedCallbacks: {},",
+      "};",
+      "void [mock, context, event, NostrRelay];",
+      "",
+    ].join("\n"),
+  );
+
+  const program = ts.createProgram({
+    rootNames: [fixturePath],
+    options: {
+      strict: true,
+      noEmit: true,
+      skipLibCheck: false,
+      types: [],
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      lib: ["lib.es2020.d.ts", "lib.dom.d.ts"],
+    },
+  });
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  if (diagnostics.length === 0) return;
+
+  const formatted = ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+    getCanonicalFileName: (fileName) => fileName,
+    getCurrentDirectory: () => tempDir,
+    getNewLine: () => "\n",
+  });
+  throw new Error(`Packed no-Jest type consumer failed:\n${formatted}`);
+}
+
+function declarationFiles(root) {
+  const found = [];
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      } else if (entry.name.endsWith(".d.ts")) {
+        found.push(entryPath);
+      }
+    }
+  }
+  return found;
+}
+
+function verifyPublishedDeclarationPurity(packageRoot) {
+  const forbiddenJestDeclarationPatterns = [
+    /\bjest\s*\./,
+    /\btypeof\s+jest\b/,
+    /\bnamespace\s+jest\b/,
+    /@types\/jest/,
+    /<reference\s+types=["']jest["']/,
+    /\bfrom\s+["'](?:@jest\/globals|jest)["']/,
+    /\bimport\s+["'](?:@jest\/globals|jest)["']/,
+  ];
+  const polluted = declarationFiles(packageRoot).filter((declarationPath) => {
+    const declaration = fs.readFileSync(declarationPath, "utf8");
+    return forbiddenJestDeclarationPatterns.some((pattern) =>
+      pattern.test(declaration),
+    );
+  });
+  if (polluted.length === 0) return;
+
+  throw new Error(
+    `Published declarations reference Jest: ${polluted
+      .map((declarationPath) => path.relative(packageRoot, declarationPath))
+      .sort()
+      .map((declarationPath) => JSON.stringify(declarationPath))
+      .join(", ")}`,
+  );
+}
+
 function verifyPackedNodeSubpathResolution(cacheDir) {
-  const tempDir = fs.mkdtempSync(path.join(repoRoot, ".pack-verify-"));
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "snstr-pack-verify-"));
   let failure;
 
   try {
@@ -101,17 +206,50 @@ function verifyPackedNodeSubpathResolution(cacheDir) {
         "--pack-destination",
         tempDir,
       ],
-      { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] }
+      { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] },
     );
     const parsed = JSON.parse(packOutput);
     const packInfo = Array.isArray(parsed) ? parsed[0] : parsed;
     const tarballPath = path.join(tempDir, packInfo.filename);
 
-    execFileSync("tar", ["-xzf", tarballPath, "-C", tempDir], {
-      cwd: repoRoot,
-      stdio: "pipe",
-    });
-    verifyNodeSubpathResolution(path.join(tempDir, "package"));
+    fs.writeFileSync(
+      path.join(tempDir, "package.json"),
+      JSON.stringify({ private: true }),
+    );
+    const packageManifest = readJson(path.join(repoRoot, "package.json"));
+    const requiredConsumerTypes = [
+      "@types/crypto-js",
+      "@types/node",
+      "@types/ws",
+    ];
+    execFileSync(
+      "npm",
+      [
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        "--cache",
+        cacheDir,
+        tarballPath,
+        ...requiredConsumerTypes.map(
+          (dependency) =>
+            `${dependency}@${packageManifest.devDependencies[dependency]}`,
+        ),
+      ],
+      { cwd: tempDir, stdio: "pipe" },
+    );
+    const packageRoot = path.join(tempDir, "node_modules", "snstr");
+    for (const forbiddenPackage of ["jest", "@types/jest"]) {
+      if (fs.existsSync(path.join(tempDir, "node_modules", forbiddenPackage))) {
+        throw new Error(
+          `Packed consumer unexpectedly installed ${forbiddenPackage}`,
+        );
+      }
+    }
+    verifyNodeSubpathResolution(packageRoot);
+    verifyPublishedDeclarationPurity(packageRoot);
+    verifyPackedTypeConsumer(tempDir);
   } catch (err) {
     failure = err;
   } finally {
@@ -168,16 +306,23 @@ function collectDependencyReferences(source) {
 
 function verifyPlatformConditionOrder(exportsMap) {
   for (const [subpath, conditions] of Object.entries(exportsMap || {})) {
-    if (!conditions || typeof conditions !== "object" || Array.isArray(conditions)) {
+    if (
+      !conditions ||
+      typeof conditions !== "object" ||
+      Array.isArray(conditions)
+    ) {
       continue;
     }
 
-    const platforms = ["react-native", "browser"].filter((key) => key in conditions);
+    const platforms = ["react-native", "browser"].filter(
+      (key) => key in conditions,
+    );
     if (platforms.length === 0) continue;
 
     if (
       platforms.length === 2 &&
-      JSON.stringify(conditions["react-native"]) !== JSON.stringify(conditions.browser)
+      JSON.stringify(conditions["react-native"]) !==
+        JSON.stringify(conditions.browser)
     ) {
       fail(`${subpath} resolves browser and React Native to different targets`);
     }
@@ -272,7 +417,9 @@ function verifyWebEntryGraph(entryTarget) {
     for (const { kind, specifier } of collectDependencyReferences(source)) {
       if (specifier.startsWith(".")) {
         const resolved = path.resolve(path.dirname(filePath), specifier);
-        const relativeModule = path.relative(sourceRoot, resolved).replaceAll(path.sep, "/");
+        const relativeModule = path
+          .relative(sourceRoot, resolved)
+          .replaceAll(path.sep, "/");
         if (
           relativeModule.startsWith("../") ||
           forbiddenModules.some((forbidden) =>
@@ -296,7 +443,9 @@ function verifyWebEntryGraph(entryTarget) {
         builtins.has(dependency) ||
         forbiddenPackages.has(dependency)
       ) {
-        const relativeFile = path.relative(sourceRoot, filePath).replaceAll(path.sep, "/");
+        const relativeFile = path
+          .relative(sourceRoot, filePath)
+          .replaceAll(path.sep, "/");
         const exceptionKey = `${relativeFile}|${kind}|${specifier}`;
         if (allowedGuardedNodeReferences.has(exceptionKey)) {
           observedGuardedNodeReferences.add(exceptionKey);
@@ -313,11 +462,15 @@ function verifyWebEntryGraph(entryTarget) {
     (exception) => !observedGuardedNodeReferences.has(exception),
   );
   if (staleExceptions.length > 0) {
-    violations.push(`stale guarded dependency exceptions: ${staleExceptions.join(", ")}`);
+    violations.push(
+      `stale guarded dependency exceptions: ${staleExceptions.join(", ")}`,
+    );
   }
 
   if (violations.length > 0) {
-    fail(`Web entry dependency graph is not platform-safe: ${violations.join("; ")}`);
+    fail(
+      `Web entry dependency graph is not platform-safe: ${violations.join("; ")}`,
+    );
   }
 
   return {
@@ -344,13 +497,15 @@ collectExportTargets(pkg.exports, referenced);
 const referencedFiles = [...referenced].filter((p) => !p.endsWith("/"));
 
 // 1) Ensure the referenced targets exist on disk (after build).
-const missingOnDisk = referencedFiles.filter((p) => !fs.existsSync(path.join(repoRoot, p)));
+const missingOnDisk = referencedFiles.filter(
+  (p) => !fs.existsSync(path.join(repoRoot, p)),
+);
 if (missingOnDisk.length) {
   fail(
     `Missing files referenced by package.json: ${missingOnDisk
       .sort()
       .map((p) => JSON.stringify(p))
-      .join(", ")}`
+      .join(", ")}`,
   );
 }
 
@@ -390,10 +545,12 @@ try {
   packJson = execFileSync(
     "npm",
     ["pack", "--dry-run", "--ignore-scripts", "--json", "--cache", cacheDir],
-    { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] }
+    { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] },
   );
 } catch (err) {
-  fail(`npm pack --dry-run failed. ${err && err.message ? err.message : String(err)}`);
+  fail(
+    `npm pack --dry-run failed. ${err && err.message ? err.message : String(err)}`,
+  );
 }
 
 let packInfo;
@@ -401,7 +558,9 @@ try {
   const parsed = JSON.parse(packJson);
   packInfo = Array.isArray(parsed) ? parsed[0] : parsed;
 } catch (err) {
-  fail(`Failed to parse npm pack JSON output. ${err && err.message ? err.message : String(err)}`);
+  fail(
+    `Failed to parse npm pack JSON output. ${err && err.message ? err.message : String(err)}`,
+  );
 }
 
 const packedPaths = new Set((packInfo.files || []).map((f) => f.path));
@@ -430,7 +589,7 @@ if (missingInTarball.length) {
     `Referenced files are not included in the npm tarball: ${missingInTarball
       .sort()
       .map((p) => JSON.stringify(p))
-      .join(", ")}`
+      .join(", ")}`,
   );
 }
 
@@ -442,5 +601,5 @@ try {
 verifyPackedNodeSubpathResolution(cacheDir);
 
 console.log(
-  `[pack:verify] OK (${referencedFiles.length} referenced targets, ${packedPaths.size} packed files, ${webGraph.modules} web modules, ${webGraph.guardedNodeReferences} guarded Node fallbacks)`
+  `[pack:verify] OK (${referencedFiles.length} referenced targets, ${packedPaths.size} packed files, ${webGraph.modules} web modules, ${webGraph.guardedNodeReferences} guarded Node fallbacks)`,
 );

--- a/scripts/verify-pack.js
+++ b/scripts/verify-pack.js
@@ -231,23 +231,30 @@ function verifyPackedNodeSubpathResolution(cacheDir) {
         );
       }
     }
-    execFileSync(
-      "npm",
-      [
-        "install",
-        "--ignore-scripts",
-        "--no-audit",
-        "--no-fund",
-        "--cache",
-        cacheDir,
-        tarballPath,
-        ...requiredConsumerTypes.map(
-          (dependency) =>
-            `${dependency}@${packageManifest.devDependencies[dependency]}`,
-        ),
-      ],
-      { cwd: tempDir, stdio: "pipe" },
-    );
+    try {
+      execFileSync(
+        "npm",
+        [
+          "install",
+          "--ignore-scripts",
+          "--no-audit",
+          "--no-fund",
+          "--cache",
+          cacheDir,
+          tarballPath,
+          ...requiredConsumerTypes.map(
+            (dependency) =>
+              `${dependency}@${packageManifest.devDependencies[dependency]}`,
+          ),
+        ],
+        { cwd: tempDir, stdio: "pipe" },
+      );
+    } catch (err) {
+      const detail = err?.stderr
+        ? err.stderr.toString().trim()
+        : (err?.message ?? String(err));
+      throw new Error(`Packed consumer npm install failed. ${detail}`);
+    }
     const packageRoot = path.join(tempDir, "node_modules", "snstr");
     for (const forbiddenPackage of ["jest", "@types/jest"]) {
       if (fs.existsSync(path.join(tempDir, "node_modules", forbiddenPackage))) {

--- a/scripts/verify-pack.js
+++ b/scripts/verify-pack.js
@@ -172,6 +172,7 @@ function verifyPublishedDeclarationPurity(packageRoot) {
     /<reference\s+types=["']jest["']/,
     /\bfrom\s+["'](?:@jest\/globals|jest)["']/,
     /\bimport\s+["'](?:@jest\/globals|jest)["']/,
+    /\bimport\s*\(\s*["'](?:@jest\/globals|jest)["']\s*\)/,
   ];
   const polluted = declarationFiles(packageRoot).filter((declarationPath) => {
     const declaration = fs.readFileSync(declarationPath, "utf8");
@@ -222,6 +223,14 @@ function verifyPackedNodeSubpathResolution(cacheDir) {
       "@types/node",
       "@types/ws",
     ];
+    for (const dependency of requiredConsumerTypes) {
+      const version = packageManifest.devDependencies?.[dependency];
+      if (typeof version !== "string" || version.trim().length === 0) {
+        throw new Error(
+          `Packed consumer dependency ${JSON.stringify(dependency)} is missing from devDependencies`,
+        );
+      }
+    }
     execFileSync(
       "npm",
       [

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -51,8 +51,7 @@ export interface RelayTestContext {
   };
   /** Callbacks captured from event registrations. */
   capturedCallbacks: {
-    ok?: RelayEventCallbacks[RelayEvent.OK][];
-    [key: string]: RelayEventCallbacks[keyof RelayEventCallbacks][] | undefined;
+    [E in RelayEvent]?: RelayEventCallbacks[E][];
   };
   /** Options passed to the relay under test. */
   options?: {

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -6,3 +6,60 @@
  */
 export { NostrRelay } from "../utils/ephemeral-relay";
 export type { NostrRelayOptions } from "../utils/ephemeral-relay";
+
+import type {
+  RelayEvent,
+  RelayEventCallbacks,
+  RelayInterface,
+} from "../types/nostr";
+
+/**
+ * Framework-neutral callable used by relay test doubles. Test doubles need a
+ * deliberately permissive parameter list so specifically typed functions and
+ * framework mocks remain assignable under strict function variance.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RelayTestMock = (...args: any[]) => unknown;
+
+/**
+ * Relay test state for consumers that need to replace public relay methods and
+ * capture callbacks without depending on one test framework's mock types.
+ */
+export interface RelayTestContext {
+  /** The relay instance being tested. */
+  relay: RelayInterface;
+  /** Original methods or properties replaced by the test. */
+  originals: {
+    ws?: WebSocket | null;
+    on?: <E extends RelayEvent>(
+      event: E,
+      callback: RelayEventCallbacks[E],
+    ) => void;
+    off?: <E extends RelayEvent>(
+      event: E,
+      callback: RelayEventCallbacks[E],
+    ) => void;
+  };
+  /** Framework-neutral test doubles. */
+  mocks: {
+    send?: RelayTestMock;
+    connect?: RelayTestMock;
+    disconnect?: RelayTestMock;
+    handlers?: {
+      [key in RelayEvent]?: RelayTestMock;
+    };
+  };
+  /** Callbacks captured from event registrations. */
+  capturedCallbacks: {
+    ok?: RelayEventCallbacks[RelayEvent.OK][];
+    [key: string]: RelayEventCallbacks[keyof RelayEventCallbacks][] | undefined;
+  };
+  /** Options passed to the relay under test. */
+  options?: {
+    connectionTimeout?: number;
+    bufferFlushDelay?: number;
+    autoReconnect?: boolean;
+    maxReconnectAttempts?: number;
+    maxReconnectDelay?: number;
+  };
+}

--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -624,62 +624,6 @@ export interface RelayDebugOptions {
 }
 
 /**
- * Test context for relay testing
- */
-export interface RelayTestContext {
-  /** The relay instance being tested */
-  relay: RelayInterface;
-  /** Original methods/properties that were mocked during testing */
-  originals: {
-    /** Original WebSocket instance */
-    ws?: WebSocket | null;
-    /** Original on method for event handlers */
-    on?: <E extends RelayEvent>(
-      event: E,
-      callback: RelayEventCallbacks[E],
-    ) => void;
-    /** Original off method for event handlers */
-    off?: <E extends RelayEvent>(
-      event: E,
-      callback: RelayEventCallbacks[E],
-    ) => void;
-  };
-  /** Mock functions used during testing */
-  mocks: {
-    /** Mock WebSocket send function */
-    send?: jest.Mock;
-    /** Mock connect function */
-    connect?: jest.Mock;
-    /** Mock disconnect function */
-    disconnect?: jest.Mock;
-    /** Mock event handlers by event type */
-    handlers?: {
-      [key in RelayEvent]?: jest.Mock;
-    };
-  };
-  /** Captured callbacks from event registrations */
-  capturedCallbacks: {
-    /** Callbacks for ok events */
-    ok?: RelayEventCallbacks[RelayEvent.OK][];
-    /** Callbacks for other event types */
-    [key: string]: RelayEventCallbacks[keyof RelayEventCallbacks][] | undefined;
-  };
-  /** Options passed to the relay */
-  options?: {
-    /** Connection timeout in milliseconds */
-    connectionTimeout?: number;
-    /** Delay between buffering events and processing them (ms) */
-    bufferFlushDelay?: number;
-    /** Whether to automatically reconnect on disconnection */
-    autoReconnect?: boolean;
-    /** Maximum number of reconnection attempts (0 for unlimited) */
-    maxReconnectAttempts?: number;
-    /** Maximum delay between reconnection attempts (ms) */
-    maxReconnectDelay?: number;
-  };
-}
-
-/**
  * Enum for standard relay error types
  */
 export enum RelayErrorType {

--- a/tests/types/relay-test-context.test.ts
+++ b/tests/types/relay-test-context.test.ts
@@ -32,4 +32,20 @@ describe("testing entrypoint relay context types", () => {
     expect(context.mocks.connect).toBe(typedMock);
     expect(context.mocks.handlers?.[RelayEvent.OK]).toBe(jestMock);
   });
+
+  test("preserves event-specific captured callback types", () => {
+    const context: RelayTestContext = {
+      relay: {} as RelayInterface,
+      originals: {},
+      mocks: {},
+      capturedCallbacks: {
+        [RelayEvent.OK]: [(_id, accepted) => void accepted],
+        [RelayEvent.Error]: [(_relay, error) => void error],
+        // @ts-expect-error Callback capture keys must be actual RelayEvent values.
+        message: [],
+      },
+    };
+
+    expect(context.capturedCallbacks[RelayEvent.OK]).toHaveLength(1);
+  });
 });

--- a/tests/types/relay-test-context.test.ts
+++ b/tests/types/relay-test-context.test.ts
@@ -1,0 +1,35 @@
+import { RelayEvent } from "../../src";
+import type { RelayInterface } from "../../src";
+import type { RelayTestContext, RelayTestMock } from "../../src/testing";
+// @ts-expect-error Relay test helpers are available only from the testing entrypoint.
+import type { RelayTestContext as RootRelayTestContext } from "../../src";
+// @ts-expect-error The web entry must not expose Node-only relay test helpers.
+import type { RelayTestContext as WebRelayTestContext } from "../../src/entries/index.web";
+
+void (undefined as unknown as RootRelayTestContext);
+void (undefined as unknown as WebRelayTestContext);
+
+describe("testing entrypoint relay context types", () => {
+  test("accepts framework-neutral and Jest mock callables", () => {
+    const plainMock: RelayTestMock = (...args: unknown[]) => args.length;
+    const jestMock = jest.fn();
+    const typedMock = (id: string, accepted: boolean): string =>
+      `${id}:${accepted}`;
+    const context: RelayTestContext = {
+      relay: {} as RelayInterface,
+      originals: {},
+      mocks: {
+        send: plainMock,
+        connect: typedMock,
+        handlers: {
+          [RelayEvent.OK]: jestMock,
+        },
+      },
+      capturedCallbacks: {},
+    };
+
+    expect(context.mocks.send?.("request")).toBe(1);
+    expect(context.mocks.connect).toBe(typedMock);
+    expect(context.mocks.handlers?.[RelayEvent.OK]).toBe(jestMock);
+  });
+});


### PR DESCRIPTION
Closes #132
Part of #130

## Summary
- move relay test context types to the snstr/testing boundary
- replace Jest-owned mock declarations with framework-neutral callables
- verify the installed tarball from an isolated consumer with no Jest packages
- scan every packed declaration for static, namespace, reference, and dynamic Jest ownership

## Verification
- Jest: 81 suites, 1055 tests passed
- Bun: 1055 tests and 8172 assertions passed
- commands and package-manager policy checks passed
- lint and strict TypeScript passed
- CJS, ESM, examples, and packed-consumer verification passed
- Grok standards and spec reviews passed
- local CodeRabbit final review: zero findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added framework-neutral relay testing types, including `RelayTestContext` and `RelayTestMock`, via the `snstr/testing` entry point.
  - Expanded relay test mock support for event-keyed handlers and common test-state wiring.
- **Documentation**
  - Updated testing guidance to document framework-neutral relay test-double type imports.
- **Bug Fixes**
  - Prevented `RelayTestContext`/relay testing helpers and Jest types from leaking into root/web declarations.
  - Strengthened packaged-consumer verification to ensure declaration purity and no-Jest compatibility.
- **Tests**
  - Added compile-time checks to enforce the intended type visibility boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->