### PR TITLE
Make NIP-47 wallet service lifecycle restart-safe

### DIFF
--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: items 1–3 / issues #131–#133 merged into `staging`; item 4 / issue #134 passed independent review and is entering local CodeRabbit review
+- Current status: items 1–3 / issues #131–#133 merged into `staging`; item 4 / issue #134 passed all local gates and is entering hosted review
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -44,7 +44,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes  | Jest/Bun 1054/1054; hosted CI green       |
 | #132 published declaration purity | AFK  | merged          | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1055/1055; hosted CI green       |
 | #133 shared diagnostic seam       | AFK  | merged          | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted clean           | Jest/Bun 1067/1067; hosted CI green       |
-| #134 NIP-47 service lifecycle     | AFK  | local re-review | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit minor doc finding fixed             | Jest/Bun 1073/1073; all local gates green |
+| #134 NIP-47 service lifecycle     | AFK  | PR pending      | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local re-review clean               | Jest/Bun 1073/1073; all local gates green |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                   | pending                                   |
 | #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                   | pending                                   |
 | #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                   | pending                                   |

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: items 1–2 / issues #131–#132 merged into `staging`; item 3 / issue #133 hosted findings fixed and all local verification complete, incremental CodeRabbit re-review pending
+- Current status: items 1–3 / issues #131–#133 merged into `staging`; item 4 / issue #134 passed independent review and is entering local CodeRabbit review
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -27,7 +27,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
 - Review packets: `issue-131-review-packet.md`, `issue-132-review-packet.md`, `issue-133-review-packet.md`; created per later ticket
 - Local CodeRabbit report: `issue-131-coderabbit-local.md`, `issue-132-coderabbit-local.md`, `issue-133-coderabbit-local.md`; created per later ticket
-- PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 open for issue #133; created per later ticket, always non-draft and targeting `staging`
+- PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; created per later ticket, always non-draft and targeting `staging`
 
 ## Commands
 
@@ -43,8 +43,8 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | --------------------------------- | ---- | --------------- | --------------------------------------- | --------------------------------------------------------- | ----------------------------------------- |
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes  | Jest/Bun 1054/1054; hosted CI green       |
 | #132 published declaration purity | AFK  | merged          | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1055/1055; hosted CI green       |
-| #133 shared diagnostic seam       | AFK  | re-review       | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted findings fixed | Jest/Bun 1067/1067; all local gates green |
-| #134 NIP-47 service lifecycle     | AFK  | blocked by #133 | `feature/nip47-service-lifecycle`       | pending                                                   | pending                                   |
+| #133 shared diagnostic seam       | AFK  | merged          | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted clean           | Jest/Bun 1067/1067; hosted CI green       |
+| #134 NIP-47 service lifecycle     | AFK  | local review    | `feature/nip47-service-lifecycle`       | Grok standards/spec pass after race fixes                 | focused Jest/Bun 6/6; NIP-47 Jest green   |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                   | pending                                   |
 | #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                   | pending                                   |
 | #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                   | pending                                   |
@@ -63,6 +63,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | ----- | ----------- | --------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9`, `426c17b` | Grok approved after hosted fixes; CodeRabbit local code review clean | focused Jest/Bun 7/7; final Jest/Bun 1054/1054; policies, lint, types, builds, examples, pack |
 | #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | `0c111d7`, `20565a0`, `abfc836`, `dea7aa0` | Grok passed; CodeRabbit local/hosted clean after four local fixes    | focused 8/8; Jest/Bun 1055/1055; all local gates and four hosted lanes green                  |
+| #133  | `46d7289`   | current Codex orchestrator; Grok 4.5 High reviewers | `b238461`, `6dd75c3`, `ae15ace`             | Grok standards/spec passed; CodeRabbit local/hosted clean           | focused 204/204; Jest/Bun 1067/1067; all local gates and four hosted lanes green               |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -27,7 +27,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
 - Review packets: `issue-131-review-packet.md`, `issue-132-review-packet.md`, `issue-133-review-packet.md`; created per later ticket
 - Local CodeRabbit report: `issue-131-coderabbit-local.md`, `issue-132-coderabbit-local.md`, `issue-133-coderabbit-local.md`, `issue-134-coderabbit-local.md`; created per later ticket
-- PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; created per later ticket, always non-draft and targeting `staging`
+- PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; #143 open for issue #134; created per later ticket, always non-draft and targeting `staging`
 
 ## Commands
 
@@ -44,7 +44,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes  | Jest/Bun 1054/1054; hosted CI green       |
 | #132 published declaration purity | AFK  | merged          | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1055/1055; hosted CI green       |
 | #133 shared diagnostic seam       | AFK  | merged          | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted clean           | Jest/Bun 1067/1067; hosted CI green       |
-| #134 NIP-47 service lifecycle     | AFK  | PR pending      | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local re-review clean               | Jest/Bun 1073/1073; all local gates green |
+| #134 NIP-47 service lifecycle     | AFK  | hosted review   | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local clean; hosted pending         | Jest/Bun 1073/1073; all local gates green |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                   | pending                                   |
 | #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                   | pending                                   |
 | #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                   | pending                                   |

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -44,7 +44,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes  | Jest/Bun 1054/1054; hosted CI green       |
 | #132 published declaration purity | AFK  | merged          | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1055/1055; hosted CI green       |
 | #133 shared diagnostic seam       | AFK  | merged          | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted clean           | Jest/Bun 1067/1067; hosted CI green       |
-| #134 NIP-47 service lifecycle     | AFK  | review cooldown | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local retry pending                 | Jest/Bun 1073/1073; all local gates green |
+| #134 NIP-47 service lifecycle     | AFK  | local re-review | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit minor doc finding fixed             | Jest/Bun 1073/1073; all local gates green |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                   | pending                                   |
 | #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                   | pending                                   |
 | #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                   | pending                                   |

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -26,7 +26,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Ticket sessions: created as each ticket starts
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
 - Review packets: `issue-131-review-packet.md`, `issue-132-review-packet.md`, `issue-133-review-packet.md`; created per later ticket
-- Local CodeRabbit report: `issue-131-coderabbit-local.md`, `issue-132-coderabbit-local.md`, `issue-133-coderabbit-local.md`; created per later ticket
+- Local CodeRabbit report: `issue-131-coderabbit-local.md`, `issue-132-coderabbit-local.md`, `issue-133-coderabbit-local.md`, `issue-134-coderabbit-local.md`; created per later ticket
 - PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; created per later ticket, always non-draft and targeting `staging`
 
 ## Commands
@@ -44,7 +44,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes  | Jest/Bun 1054/1054; hosted CI green       |
 | #132 published declaration purity | AFK  | merged          | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1055/1055; hosted CI green       |
 | #133 shared diagnostic seam       | AFK  | merged          | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted clean           | Jest/Bun 1067/1067; hosted CI green       |
-| #134 NIP-47 service lifecycle     | AFK  | local review    | `feature/nip47-service-lifecycle`       | Grok standards/spec pass after race fixes                 | focused Jest/Bun 6/6; NIP-47 Jest green   |
+| #134 NIP-47 service lifecycle     | AFK  | review cooldown | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local retry pending                 | Jest/Bun 1073/1073; all local gates green |
 | #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                   | pending                                   |
 | #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                   | pending                                   |
 | #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                   | pending                                   |

--- a/docs/agents/runs/issue-133-session.md
+++ b/docs/agents/runs/issue-133-session.md
@@ -5,8 +5,8 @@
 - Issue: #133
 - Fixed point before session: `46d7289`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
-- Commit: pending
-- Status: implementation, independent Grok review, local and hosted CodeRabbit fixes, and final local verification complete; incremental CodeRabbit re-review pending
+- Commit: `b238461`, `6dd75c3`, `ae15ace`; merged into `staging` at `2a3556d`
+- Status: merged; issue closed
 
 ## Inputs
 
@@ -29,7 +29,7 @@
 - Review fixed point: `46d7289`
 - Design findings: Grok inventoried every production `console.*` call and recommended additive instance/call injection over mutable global configuration, WARN/ERROR-visible defaults, a non-throwing dispatcher, safe structured context, and unchanged NIP-02 compatibility aliases
 - Standards findings: initial review failed because the default Relay logger prefix retained the raw relay URL; a later pass caught an unbounded unknown relay wire type; both secret-exposure paths were fixed with red-to-green tests, and the final standards re-review passed with no hard findings
-- Spec findings: passed with no missing, partial, over-scoped, or incorrectly implemented acceptance criteria
+- Spec findings: passed with no missing, partial, over-scoped, or incorrectly implemented acceptance criteria; final hosted incremental review was clean
 - Worthy fixes applied: a shared non-throwing dispatcher; additive stateful and stateless logger seams; canonical policy propagation to default and explicitly configured child Relays; replacement logging for existing pooled Relays; bounded failure types; redacted relay identifiers and prefixes; stable unknown-wire metadata; and migration of console-spy tests to injected public seams
 - Findings ignored with reasons: test-only Nostr silence and DEBUG eviction metadata shape remain optional because they are not default-visible production WARN/ERROR behavior; all CodeRabbit findings were accepted and fixed
 
@@ -38,7 +38,7 @@
 - Focused: 14/14 suites and 204/204 tests; final seam test 11/11 after review-driven red-to-green cycles
 - Full Jest: 82/82 suites and 1067/1067 tests, rerun after hosted fixes
 - Full Bun: 82 files and 1067/1067 tests, rerun after hosted fixes
-- Repository gates: commands and package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, and pack verification all green
+- Repository gates: commands and package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, pack verification, and all four hosted CI lanes green
 
 ## Risks
 

--- a/docs/agents/runs/issue-134-coderabbit-local.md
+++ b/docs/agents/runs/issue-134-coderabbit-local.md
@@ -5,7 +5,7 @@
 - Command: `coderabbit review --agent --type committed --base staging -c AGENTS.md`
 - Reviewed commits: `569b266`, `644b52f`
 - Initial result: one minor documentation finding after the included-review cooldown
-- Re-review: pending
+- Re-review: clean with 0 findings after commit `ec8a754`
 
 ## Findings and Resolutions
 
@@ -19,3 +19,4 @@
 - Full Bun: 83 files, 1073/1073 tests
 - Commands/package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, and pack verification: green
 - Grok spec and final standards re-review: pass with no remaining hard findings
+- Final CodeRabbit committed review: 0 findings across all seven changed files

--- a/docs/agents/runs/issue-134-coderabbit-local.md
+++ b/docs/agents/runs/issue-134-coderabbit-local.md
@@ -1,0 +1,21 @@
+# Local CodeRabbit Review: #134 NIP-47 Service Lifecycle
+
+## Review
+
+- Command: `coderabbit review --agent --type committed --base staging -c AGENTS.md`
+- Reviewed commit: `569b266`
+- Initial result: service rate limit; retry required after the included-review cooldown
+- Re-review: pending
+
+## Findings and Resolutions
+
+- Pending successful review execution.
+
+## Verification Before Retry
+
+- Focused lifecycle Jest/Bun: 6/6
+- NIP-47 Jest: 9/9 suites, 76/76 tests before the final review-driven test addition
+- Full Jest: 83/83 suites, 1073/1073 tests
+- Full Bun: 83 files, 1073/1073 tests
+- Commands/package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, and pack verification: green
+- Grok spec and final standards re-review: pass with no remaining hard findings

--- a/docs/agents/runs/issue-134-coderabbit-local.md
+++ b/docs/agents/runs/issue-134-coderabbit-local.md
@@ -3,13 +3,13 @@
 ## Review
 
 - Command: `coderabbit review --agent --type committed --base staging -c AGENTS.md`
-- Reviewed commit: `569b266`
-- Initial result: service rate limit; retry required after the included-review cooldown
+- Reviewed commits: `569b266`, `644b52f`
+- Initial result: one minor documentation finding after the included-review cooldown
 - Re-review: pending
 
 ## Findings and Resolutions
 
-- Pending successful review execution.
+1. The issue session still recorded its implementation commit as pending. Fixed by recording implementation commit `569b266` and verification-artifact commit `644b52f`.
 
 ## Verification Before Retry
 

--- a/docs/agents/runs/issue-134-review-packet.md
+++ b/docs/agents/runs/issue-134-review-packet.md
@@ -1,0 +1,41 @@
+# Review Packet: #134 NIP-47 Service Lifecycle
+
+## Issue
+
+- Issue: #134
+- Slice type: AFK lifecycle cleanup
+- Acceptance criteria: sequential initialization keeps at most one subscription; concurrent initialization is single-flight; disconnect is idempotent and releases lifecycle resources; restart restores one working expiration-aware subscription; tests use the public service API
+- Baseline: `2a3556d`
+- Current diff: `git diff staging...HEAD`
+
+## Implementation Summary
+
+`NostrWalletService` now owns an explicit single-flight lifecycle. Initialization coalesces concurrent callers, no-ops once ready, waits for active teardown, scopes subscriptions to one lifecycle generation, and cleans failed attempts. Disconnect invalidates stale initialization, coalesces concurrent callers, releases subscriptions, relay connections, and expiration tracking, and synchronously observes expected cancellation rejections without hiding them from callers that await the original initialization promise. Reinitialization restarts expiration cleanup and creates one fresh request subscription.
+
+## Implementation Evidence
+
+- `implement` session: `issue-134-session.md`
+- `tdd` used: yes
+- Red tests: sequential initialization left two active Relay subscriptions; concurrent initialization returned different promises and duplicated work; a queued restart originally survived a later disconnect
+- Green implementation: public lifecycle suite covers sequential and concurrent initialization, repeated disconnect, queued and in-flight cancellation, restart, one active subscription, and an encrypted expired request after restart
+- Refactor: lifecycle state and resource ownership remain private to `NostrWalletService`; no production test hook or public API addition was introduced
+- Commands run: focused Jest/Bun lifecycle suites, NIP-47 Jest regression suite, strict TypeScript, ESLint, and diff checks; full repository gates pending final review
+
+## Review Instructions
+
+Review only issue #134 unless a severe cross-slice regression appears. Keep standards and spec axes separate. Verify promise identity and failure consistency, all init/disconnect interleavings, synchronous observation of expected cancellation, attempt-scoped subscription cleanup, stale callback suppression, TTL cleanup restart, idempotent resource release, unchanged public signatures, and public-behavior test coverage.
+
+## Reviewer Output
+
+```text
+STANDARDS_STATUS: pass
+STANDARDS_FINDINGS:
+- initial queued-cancellation rejection observer fixed
+- primary cancellation observer timing fixed in follow-up
+- final targeted re-review found no remaining correctness or standards blockers
+
+SPEC_STATUS: pass
+SPEC_FINDINGS:
+- all five acceptance criteria met
+- no missing or incorrectly implemented criteria
+```

--- a/docs/agents/runs/issue-134-review-packet.md
+++ b/docs/agents/runs/issue-134-review-packet.md
@@ -38,4 +38,9 @@ SPEC_STATUS: pass
 SPEC_FINDINGS:
 - all five acceptance criteria met
 - no missing or incorrectly implemented criteria
+
+CODERABBIT_STATUS: pass
+CODERABBIT_FINDINGS:
+- one minor stale session commit record fixed
+- final committed re-review returned 0 findings
 ```

--- a/docs/agents/runs/issue-134-review-packet.md
+++ b/docs/agents/runs/issue-134-review-packet.md
@@ -19,7 +19,7 @@
 - Red tests: sequential initialization left two active Relay subscriptions; concurrent initialization returned different promises and duplicated work; a queued restart originally survived a later disconnect
 - Green implementation: public lifecycle suite covers sequential and concurrent initialization, repeated disconnect, queued and in-flight cancellation, restart, one active subscription, and an encrypted expired request after restart
 - Refactor: lifecycle state and resource ownership remain private to `NostrWalletService`; no production test hook or public API addition was introduced
-- Commands run: focused Jest/Bun lifecycle suites, NIP-47 Jest regression suite, strict TypeScript, ESLint, and diff checks; full repository gates pending final review
+- Commands run: focused Jest/Bun lifecycle suites, NIP-47 Jest regression suite, full Jest/Bun, command and package-manager policy checks, strict TypeScript, ESLint, CJS/ESM builds, examples, pack verification, and diff checks
 
 ## Review Instructions
 

--- a/docs/agents/runs/issue-134-session.md
+++ b/docs/agents/runs/issue-134-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `2a3556d`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
 - Commit: `569b266`; verification artifacts: `644b52f`
-- Status: implementation, full verification, and independent Grok standards/spec review complete; local CodeRabbit review waiting on service cooldown
+- Status: implementation, full verification, independent Grok standards/spec review, and local CodeRabbit re-review complete; PR pending
 
 ## Inputs
 

--- a/docs/agents/runs/issue-134-session.md
+++ b/docs/agents/runs/issue-134-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `2a3556d`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
 - Commit: pending
-- Status: implementation, focused verification, and independent Grok standards/spec review complete; local CodeRabbit review pending
+- Status: implementation, full verification, and independent Grok standards/spec review complete; local CodeRabbit review waiting on service cooldown
 
 ## Inputs
 
@@ -22,7 +22,7 @@
 - Behaviors covered: sequential and concurrent initialization, idempotent disconnect, restart with one fresh request subscription, and expiration-aware request handling after restart
 - `tdd` used: yes; the focused suite observes service behavior through the public service API and the exported ephemeral Relay test surface
 - Commands run during implementation: focused Jest/Bun lifecycle suites, NIP-47 Jest regression suite, strict TypeScript, ESLint, and diff checks
-- Full suite command: pending
+- Full suite command: `npm test -- --runInBand`; `npm run test:bun`; repository policy, lint, type, build, example, and pack gates
 
 ## Review
 
@@ -36,9 +36,9 @@
 ## Verification
 
 - Focused: Jest/Bun lifecycle suite 6/6 after review-driven additions; NIP-47 Jest regression 9/9 suites and 76/76 tests
-- Full Jest: pending
-- Full Bun: pending
-- Repository gates: pending
+- Full Jest: 83/83 suites and 1073/1073 tests
+- Full Bun: 83 files and 1073/1073 tests
+- Repository gates: commands and package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, and pack verification all green
 
 ## Risks
 

--- a/docs/agents/runs/issue-134-session.md
+++ b/docs/agents/runs/issue-134-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `2a3556d`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
 - Commit: `569b266`; verification artifacts: `644b52f`
-- Status: implementation, full verification, independent Grok standards/spec review, and local CodeRabbit re-review complete; PR pending
+- Status: PR #143 open into `staging`; hosted CodeRabbit and CI pending
 
 ## Inputs
 

--- a/docs/agents/runs/issue-134-session.md
+++ b/docs/agents/runs/issue-134-session.md
@@ -1,0 +1,46 @@
+# Issue Session: #134 NIP-47 Service Lifecycle
+
+## Issue
+
+- Issue: #134
+- Fixed point before session: `2a3556d`
+- Worker session: current Codex orchestrator; Grok 4.5 High reviewers
+- Commit: pending
+- Status: implementation, focused verification, and independent Grok standards/spec review complete; local CodeRabbit review pending
+
+## Inputs
+
+- Spec issue: #130
+- Ticket: #134
+- Relevant glossary terms: Relay, Subscription Filter, NIP-47
+- Relevant ADRs: none
+- Prototype answer and source branch, if any: none
+
+## Implementation
+
+- Public interface used: existing `NostrWalletService.init()` and `disconnect()` methods
+- Behaviors covered: sequential and concurrent initialization, idempotent disconnect, restart with one fresh request subscription, and expiration-aware request handling after restart
+- `tdd` used: yes; the focused suite observes service behavior through the public service API and the exported ephemeral Relay test surface
+- Commands run during implementation: focused Jest/Bun lifecycle suites, NIP-47 Jest regression suite, strict TypeScript, ESLint, and diff checks
+- Full suite command: pending
+
+## Review
+
+- Review fixed point: `2a3556d`
+- Design findings: Grok confirmed duplicate sequential/concurrent subscriptions, a permanently stopped TTL cleanup interval after disconnect, and stale initialization races; it recommended client-parity single-flight and generation state while preserving the public API
+- Standards findings: initial review found that a second disconnect cancelled a queued initialization without attaching a rejection observer for fire-and-forget callers; re-review found the same observer was attached too late on the primary disconnect path; both paths now synchronously absorb expected cancellation while preserving rejection for callers that await the original promise
+- Spec findings: passed all five acceptance criteria; noted only partial public observability of the TTL cleanup interval and session-document drift
+- Worthy fixes applied: client-parity single-flight initialization, generation cancellation, teardown serialization, attempt-scoped subscription cleanup, restartable TTL cleanup, stale callback generation guard, and cancellation rejection absorption
+- Findings ignored with reasons: direct TTL interval assertions require private-shape access and conflict with the public-API test criterion; restart behavior is instead proved by an encrypted expired request after reconnect
+
+## Verification
+
+- Focused: Jest/Bun lifecycle suite 6/6 after review-driven additions; NIP-47 Jest regression 9/9 suites and 76/76 tests
+- Full Jest: pending
+- Full Bun: pending
+- Repository gates: pending
+
+## Risks
+
+- Disconnect must invalidate stale initialization without allowing it to publish or retain a zombie subscription.
+- Reinitialization must restart or recreate lifecycle-owned expiration tracking rather than leave a destroyed TTL map inactive.

--- a/docs/agents/runs/issue-134-session.md
+++ b/docs/agents/runs/issue-134-session.md
@@ -5,7 +5,7 @@
 - Issue: #134
 - Fixed point before session: `2a3556d`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
-- Commit: pending
+- Commit: `569b266`; verification artifacts: `644b52f`
 - Status: implementation, full verification, and independent Grok standards/spec review complete; local CodeRabbit review waiting on service cooldown
 
 ## Inputs

--- a/src/nip47/service.ts
+++ b/src/nip47/service.ts
@@ -102,8 +102,13 @@ class TTLMap<K, V> {
   }
 
   private startCleanup(): void {
+    if (this.cleanupInterval) return;
     this.cleanupInterval = setInterval(() => this.cleanup(), 30000);
     maybeUnref(this.cleanupInterval);
+  }
+
+  start(): void {
+    this.startCleanup();
   }
 
   destroy(): void {
@@ -185,6 +190,10 @@ export class NostrWalletService {
   private subIds: string[] = [];
   private authorizedClients: string[] = [];
   private requestEncryption: TTLMap<string, NIP47EncryptionScheme>; // Track encryption per request with TTL
+  private initialized = false;
+  private initializationPromise: Promise<void> | null = null;
+  private disconnectionPromise: Promise<void> | null = null;
+  private lifecycleGeneration = 0;
 
   constructor(
     options: NostrWalletServiceOptions,
@@ -232,26 +241,124 @@ export class NostrWalletService {
   /**
    * Initialize the service, connect to relays, and publish capabilities
    */
-  public async init(): Promise<void> {
-    // Connect to relays
-    await this.client.connectToRelays();
-    this.logger.info("Service connected to configured relays");
+  public init(): Promise<void> {
+    if (this.initialized) return Promise.resolve();
+    if (this.initializationPromise) return this.initializationPromise;
 
-    // Set up subscription to receive requests
-    this.setupSubscription();
-    this.logger.info("Service subscribed to requests");
+    const generation = this.lifecycleGeneration;
+    const initialization = this.initialize(generation).finally(() => {
+      if (this.initializationPromise === initialization) {
+        this.initializationPromise = null;
+      }
+    });
+    this.initializationPromise = initialization;
+    return initialization;
+  }
 
-    // Publish info event
-    await this.publishInfoEvent();
-    this.logger.info(
-      `Service published info event with methods: ${this.supportedMethods.join(", ")}`,
-    );
+  /** Perform one initialization attempt after any active disconnect completes. */
+  private async initialize(generation: number): Promise<void> {
+    if (this.disconnectionPromise) {
+      await this.disconnectionPromise;
+    }
+    this.assertInitializationCurrent(generation);
+    if (this.initialized) return;
+
+    let attemptSubIds: string[] = [];
+
+    try {
+      this.requestEncryption.start();
+
+      await this.client.connectToRelays();
+      this.assertInitializationCurrent(generation);
+      this.logger.info("Service connected to configured relays");
+
+      attemptSubIds = this.setupSubscription(generation);
+      this.subIds = attemptSubIds;
+      this.assertInitializationCurrent(generation);
+      this.logger.info("Service subscribed to requests");
+
+      await this.publishInfoEvent();
+      this.assertInitializationCurrent(generation);
+      this.logger.info(
+        `Service published info event with methods: ${this.supportedMethods.join(", ")}`,
+      );
+      this.initialized = true;
+    } catch (error) {
+      if (attemptSubIds.length > 0) {
+        this.client.unsubscribe(attemptSubIds);
+      }
+      if (this.subIds === attemptSubIds) {
+        this.subIds = [];
+      }
+      if (generation === this.lifecycleGeneration) {
+        this.initialized = false;
+        this.requestEncryption.destroy();
+        try {
+          await this.client.disconnectFromRelays();
+        } catch (disconnectError) {
+          this.logger.error(
+            "Error cleaning up failed service initialization:",
+            disconnectError instanceof Error
+              ? disconnectError
+              : String(disconnectError),
+          );
+        }
+      }
+      throw error;
+    }
+  }
+
+  /** Reject an initialization attempt invalidated by disconnect. */
+  private assertInitializationCurrent(generation: number): void {
+    if (generation !== this.lifecycleGeneration) {
+      throw new Error("Service initialization cancelled by disconnect");
+    }
   }
 
   /**
    * Disconnect from relays
    */
-  public async disconnect(): Promise<void> {
+  public disconnect(): Promise<void> {
+    if (this.disconnectionPromise) {
+      if (this.initializationPromise) {
+        this.lifecycleGeneration += 1;
+        const invalidatedInitialization = this.initializationPromise;
+        this.initializationPromise = null;
+        this.observeInvalidatedInitialization(invalidatedInitialization);
+      }
+      return this.disconnectionPromise;
+    }
+
+    this.lifecycleGeneration += 1;
+    this.initialized = false;
+    const invalidatedInitialization = this.initializationPromise;
+    this.initializationPromise = null;
+    this.observeInvalidatedInitialization(invalidatedInitialization);
+
+    const disconnection = this.performDisconnect(invalidatedInitialization).finally(
+      () => {
+        if (this.disconnectionPromise === disconnection) {
+          this.disconnectionPromise = null;
+        }
+      },
+    );
+    this.disconnectionPromise = disconnection;
+    return disconnection;
+  }
+
+  /** Prevent an expected cancellation from becoming an unhandled rejection. */
+  private observeInvalidatedInitialization(
+    initialization: Promise<void> | null,
+  ): void {
+    void initialization?.catch(() => {
+      // Awaiters still receive the original rejection from initialization.
+    });
+  }
+
+  /** Release all service-owned lifecycle resources. */
+  private async performDisconnect(
+    invalidatedInitialization: Promise<void> | null,
+  ): Promise<void> {
     try {
       // Clean up TTL map
       this.requestEncryption.destroy();
@@ -272,8 +379,16 @@ export class NostrWalletService {
         );
       }
 
+      if (invalidatedInitialization) {
+        try {
+          await invalidatedInitialization;
+        } catch {
+          // Disconnect intentionally invalidates an in-flight initialization.
+        }
+      }
+
       // Short delay to allow any other cleanup to complete
-      return new Promise((resolve) => {
+      await new Promise<void>((resolve) => {
         const t = setTimeout(resolve, 100);
         maybeUnref(t);
       });
@@ -330,14 +445,15 @@ export class NostrWalletService {
   /**
    * Set up subscription to receive requests
    */
-  private setupSubscription(): void {
+  private setupSubscription(generation: number): string[] {
     // Subscribe to request events directed at this service
     const filter = {
       kinds: [NIP47EventKind.REQUEST],
       "#p": [this.pubkey],
     };
 
-    this.subIds = this.client.subscribe([filter], (event: NostrEvent) => {
+    return this.client.subscribe([filter], (event: NostrEvent) => {
+      if (generation !== this.lifecycleGeneration) return;
       this.handleEvent(event);
     });
   }

--- a/tests/nip47/service-lifecycle.test.ts
+++ b/tests/nip47/service-lifecycle.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import {
+  NIP47EncryptionScheme,
+  NIP47ErrorCode,
+  NIP47Method,
+  NostrWalletConnectClient,
+  NostrWalletService,
+  WalletImplementation,
+} from "../../src/nip47";
+import { NostrRelay } from "../../src/testing";
+import { generateKeypair } from "../../src/utils/crypto";
+import { getUnixTime } from "../../src/utils/time";
+
+class LifecycleWallet implements WalletImplementation {
+  public getBalance = jest.fn(async () => 42);
+
+  public async getInfo() {
+    return {
+      alias: "Lifecycle Wallet",
+      methods: [NIP47Method.GET_INFO, NIP47Method.GET_BALANCE],
+    };
+  }
+
+  public async payInvoice(): Promise<never> {
+    throw new Error("Not implemented for lifecycle tests");
+  }
+
+  public async makeInvoice(): Promise<never> {
+    throw new Error("Not implemented for lifecycle tests");
+  }
+
+  public async lookupInvoice(): Promise<never> {
+    throw new Error("Not implemented for lifecycle tests");
+  }
+
+  public async listTransactions(): Promise<never> {
+    throw new Error("Not implemented for lifecycle tests");
+  }
+}
+
+describe("NIP-47 service lifecycle", () => {
+  let relay: NostrRelay;
+  let service: NostrWalletService;
+  let wallet: LifecycleWallet;
+  let serviceKeys: Awaited<ReturnType<typeof generateKeypair>>;
+  const clients: NostrWalletConnectClient[] = [];
+
+  beforeEach(async () => {
+    relay = new NostrRelay(0);
+    await relay.start();
+    serviceKeys = await generateKeypair();
+    wallet = new LifecycleWallet();
+    service = new NostrWalletService(
+      {
+        relays: [relay.url],
+        pubkey: serviceKeys.publicKey,
+        privkey: serviceKeys.privateKey,
+        methods: [NIP47Method.GET_INFO, NIP47Method.GET_BALANCE],
+        encryptionSchemes: [NIP47EncryptionScheme.NIP44_V2],
+      },
+      wallet,
+    );
+  });
+
+  afterEach(async () => {
+    await Promise.all(clients.splice(0).map((client) => client.disconnect()));
+    await service.disconnect();
+    await relay.close();
+  });
+
+  test("sequential initialization keeps one active request subscription", async () => {
+    await service.init();
+    await service.init();
+
+    expect(relay.subs.size).toBe(1);
+  });
+
+  test("concurrent initialization is single-flight and keeps one subscription", async () => {
+    const firstInitialization = service.init();
+    const secondInitialization = service.init();
+
+    expect(secondInitialization).toBe(firstInitialization);
+    await Promise.all([firstInitialization, secondInitialization]);
+    expect(relay.subs.size).toBe(1);
+  });
+
+  test("disconnect is idempotent and releases the request subscription", async () => {
+    await service.init();
+
+    await expect(
+      Promise.all([service.disconnect(), service.disconnect()]),
+    ).resolves.toEqual([undefined, undefined]);
+    await expect(service.disconnect()).resolves.toBeUndefined();
+    expect(relay.subs.size).toBe(0);
+  });
+
+  test("a later disconnect invalidates initialization queued behind teardown", async () => {
+    await service.init();
+
+    const firstDisconnect = service.disconnect();
+    const queuedInitialization = service.init();
+    const laterDisconnect = service.disconnect();
+
+    await laterDisconnect;
+    await expect(queuedInitialization).rejects.toThrow(
+      "Service initialization cancelled by disconnect",
+    );
+    await firstDisconnect;
+    expect(relay.subs.size).toBe(0);
+
+    await service.init();
+    expect(relay.subs.size).toBe(1);
+  });
+
+  test("disconnect invalidates initialization already in flight", async () => {
+    const initialization = service.init();
+    const disconnection = service.disconnect();
+
+    await disconnection;
+    await expect(initialization).rejects.toThrow(
+      "Service initialization cancelled by disconnect",
+    );
+    expect(relay.subs.size).toBe(0);
+
+    await service.init();
+    expect(relay.subs.size).toBe(1);
+  });
+
+  test("initialization after disconnect restores one expiration-aware subscription", async () => {
+    await service.init();
+    await service.disconnect();
+
+    await service.init();
+    expect(relay.subs.size).toBe(1);
+
+    const clientKeys = await generateKeypair();
+    const client = new NostrWalletConnectClient({
+      pubkey: serviceKeys.publicKey,
+      secret: clientKeys.privateKey,
+      relays: [relay.url],
+      preferredEncryption: NIP47EncryptionScheme.NIP44_V2,
+    });
+    clients.push(client);
+    await client.init();
+
+    await expect(
+      client.getBalance({ expiration: getUnixTime() - 5 }),
+    ).rejects.toMatchObject({ code: NIP47ErrorCode.REQUEST_EXPIRED });
+    expect(wallet.getBalance).not.toHaveBeenCalled();
+  }, 10000);
+});


### PR DESCRIPTION
## Summary

- make service initialization single-flight and idempotent
- serialize disconnect and restart while invalidating stale work and callbacks
- restart expiration tracking and prove lifecycle behavior through public APIs

## Verification

- focused Jest and Bun lifecycle suites: 6/6
- NIP-47 Jest regression: green
- full Jest: 83 suites, 1073 tests
- full Bun: 83 files, 1073 tests
- policies, lint, strict types, CJS/ESM builds, examples, and pack verification: green
- Grok standards and spec reviews: pass
- local CodeRabbit re-review: 0 findings

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved NIP-47 service lifecycle management for reliable initialization, disconnection, and restart behavior.
  * Concurrent initialization is now coordinated to prevent duplicate subscriptions and resources.
  * Disconnect operations safely cancel in-progress initialization and clean up active resources.
  * Expired requests are rejected correctly after service restart.

* **Bug Fixes**
  * Prevented duplicate cleanup timers and stale request handling after disconnects.
  * Added coverage for sequential and concurrent initialization, repeated disconnects, cancellation, and expiration handling.

* **Documentation**
  * Added review packets and session records documenting lifecycle behavior, verification results, and completed work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->