### PR TITLE
Consolidate NIP-57 zap client behavior

### DIFF
--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: items 1–4 / issues #131–#134 merged into `staging`; item 5 / issue #135 passed independent review and all local verification, with committed-diff review pending
+- Current status: items 1–4 / issues #131–#134 merged into `staging`; item 5 / issue #135 passed all local review and verification and is ready for hosted review
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -45,7 +45,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #132 published declaration purity | AFK  | merged          | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1055/1055; hosted CI green       |
 | #133 shared diagnostic seam       | AFK  | merged          | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted clean           | Jest/Bun 1067/1067; hosted CI green       |
 | #134 NIP-47 service lifecycle     | AFK  | merged          | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1073/1073; hosted CI green       |
-| #135 NIP-57 consolidation         | AFK  | local re-review | `feature/nip57-client-consolidation`    | Grok pass; four CodeRabbit findings fixed; re-review pending | Jest/Bun 1081/1081; all local gates green |
+| #135 NIP-57 consolidation         | AFK  | PR prep         | `feature/nip57-client-consolidation`    | Grok pass; CodeRabbit clean after four fixes              | Jest/Bun 1081/1081; all local gates green |
 | #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                   | pending                                   |
 | #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                   | pending                                   |
 | #138 public behavior test seams   | AFK  | blocked by #137 | `feature/public-behavior-test-seams`    | pending                                                   | pending                                   |
@@ -65,7 +65,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | `0c111d7`, `20565a0`, `abfc836`, `dea7aa0` | Grok passed; CodeRabbit local/hosted clean after four local fixes    | focused 8/8; Jest/Bun 1055/1055; all local gates and four hosted lanes green                  |
 | #133  | `46d7289`   | current Codex orchestrator; Grok 4.5 High reviewers | `b238461`, `6dd75c3`, `ae15ace`             | Grok standards/spec passed; CodeRabbit local/hosted clean           | focused 204/204; Jest/Bun 1067/1067; all local gates and four hosted lanes green               |
 | #134  | `2a3556d`   | current Codex orchestrator; Grok 4.5 High reviewers | `569b266` plus review artifacts              | Grok standards/spec passed; CodeRabbit local/hosted clean           | focused 6/6; Jest/Bun 1073/1073; all local gates and four hosted lanes green                    |
-| #135  | `25e055d`   | current Codex orchestrator; Grok 4.5 High reviewers | `0909227` plus review fixes pending           | Grok standards/spec and review-fix pass; CodeRabbit re-review pending | focused 22/22; NIP-57 40/40; Jest/Bun 1081/1081; all local gates green                         |
+| #135  | `25e055d`   | current Codex orchestrator; Grok 4.5 High reviewers | `0909227`, `1b12872`                          | Grok standards/spec and review-fix pass; CodeRabbit clean after fixes | focused 22/22; NIP-57 40/40; Jest/Bun 1081/1081; all local gates green                         |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -26,7 +26,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Ticket sessions: created as each ticket starts
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
 - Review packets: `issue-131-review-packet.md`, `issue-132-review-packet.md`, `issue-133-review-packet.md`, `issue-134-review-packet.md`, `issue-135-review-packet.md`; created per later ticket
-- Local CodeRabbit report: `issue-131-coderabbit-local.md`, `issue-132-coderabbit-local.md`, `issue-133-coderabbit-local.md`, `issue-134-coderabbit-local.md`; created per later ticket
+- Local CodeRabbit report: `issue-131-coderabbit-local.md`, `issue-132-coderabbit-local.md`, `issue-133-coderabbit-local.md`, `issue-134-coderabbit-local.md`, `issue-135-coderabbit-local.md`; created per later ticket
 - PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; #143 merged for issue #134; created per later ticket, always non-draft and targeting `staging`
 
 ## Commands
@@ -45,7 +45,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #132 published declaration purity | AFK  | merged          | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1055/1055; hosted CI green       |
 | #133 shared diagnostic seam       | AFK  | merged          | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted clean           | Jest/Bun 1067/1067; hosted CI green       |
 | #134 NIP-47 service lifecycle     | AFK  | merged          | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1073/1073; hosted CI green       |
-| #135 NIP-57 consolidation         | AFK  | local review    | `feature/nip57-client-consolidation`    | Grok standards/spec pass; CodeRabbit pending             | Jest/Bun 1077/1077; all local gates green |
+| #135 NIP-57 consolidation         | AFK  | local re-review | `feature/nip57-client-consolidation`    | Grok pass; four CodeRabbit findings fixed; re-review pending | Jest/Bun 1081/1081; all local gates green |
 | #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                   | pending                                   |
 | #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                   | pending                                   |
 | #138 public behavior test seams   | AFK  | blocked by #137 | `feature/public-behavior-test-seams`    | pending                                                   | pending                                   |
@@ -65,7 +65,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | `0c111d7`, `20565a0`, `abfc836`, `dea7aa0` | Grok passed; CodeRabbit local/hosted clean after four local fixes    | focused 8/8; Jest/Bun 1055/1055; all local gates and four hosted lanes green                  |
 | #133  | `46d7289`   | current Codex orchestrator; Grok 4.5 High reviewers | `b238461`, `6dd75c3`, `ae15ace`             | Grok standards/spec passed; CodeRabbit local/hosted clean           | focused 204/204; Jest/Bun 1067/1067; all local gates and four hosted lanes green               |
 | #134  | `2a3556d`   | current Codex orchestrator; Grok 4.5 High reviewers | `569b266` plus review artifacts              | Grok standards/spec passed; CodeRabbit local/hosted clean           | focused 6/6; Jest/Bun 1073/1073; all local gates and four hosted lanes green                    |
-| #135  | `25e055d`   | current Codex orchestrator; Grok 4.5 High reviewers | pending                                      | Grok standards/spec passed after compatibility/doc fixes            | focused 18/18; NIP-57 36/36; Jest/Bun 1077/1077; all local gates green                         |
+| #135  | `25e055d`   | current Codex orchestrator; Grok 4.5 High reviewers | `0909227` plus review fixes pending           | Grok standards/spec and review-fix pass; CodeRabbit re-review pending | focused 22/22; NIP-57 40/40; Jest/Bun 1081/1081; all local gates green                         |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: items 1–4 / issues #131–#134 merged into `staging`; item 5 / issue #135 passed all local review and verification and is ready for hosted review
+- Current status: items 1–4 / issues #131–#134 merged into `staging`; item 5 / issue #135 has one hosted review fix fully verified and is awaiting the hosted rerun
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -45,7 +45,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #132 published declaration purity | AFK  | merged          | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1055/1055; hosted CI green       |
 | #133 shared diagnostic seam       | AFK  | merged          | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted clean           | Jest/Bun 1067/1067; hosted CI green       |
 | #134 NIP-47 service lifecycle     | AFK  | merged          | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1073/1073; hosted CI green       |
-| #135 NIP-57 consolidation         | AFK  | PR prep         | `feature/nip57-client-consolidation`    | Grok pass; CodeRabbit clean after four fixes              | Jest/Bun 1081/1081; all local gates green |
+| #135 NIP-57 consolidation         | AFK  | hosted re-review | `feature/nip57-client-consolidation`   | Grok/local clean; one hosted finding fixed                | Jest/Bun 1082/1082; all local gates green |
 | #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                   | pending                                   |
 | #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                   | pending                                   |
 | #138 public behavior test seams   | AFK  | blocked by #137 | `feature/public-behavior-test-seams`    | pending                                                   | pending                                   |
@@ -65,7 +65,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | `0c111d7`, `20565a0`, `abfc836`, `dea7aa0` | Grok passed; CodeRabbit local/hosted clean after four local fixes    | focused 8/8; Jest/Bun 1055/1055; all local gates and four hosted lanes green                  |
 | #133  | `46d7289`   | current Codex orchestrator; Grok 4.5 High reviewers | `b238461`, `6dd75c3`, `ae15ace`             | Grok standards/spec passed; CodeRabbit local/hosted clean           | focused 204/204; Jest/Bun 1067/1067; all local gates and four hosted lanes green               |
 | #134  | `2a3556d`   | current Codex orchestrator; Grok 4.5 High reviewers | `569b266` plus review artifacts              | Grok standards/spec passed; CodeRabbit local/hosted clean           | focused 6/6; Jest/Bun 1073/1073; all local gates and four hosted lanes green                    |
-| #135  | `25e055d`   | current Codex orchestrator; Grok 4.5 High reviewers | `0909227`, `1b12872`                          | Grok standards/spec and review-fix pass; CodeRabbit clean after fixes | focused 22/22; NIP-57 40/40; Jest/Bun 1081/1081; all local gates green                         |
+| #135  | `25e055d`   | current Codex orchestrator; Grok 4.5 High reviewers | `0909227`, `1b12872`, hosted fix pending      | Grok passes; local clean; one hosted CodeRabbit finding fixed        | focused 23/23; NIP-57 41/41; Jest/Bun 1082/1082; all local gates green                         |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: items 1–3 / issues #131–#133 merged into `staging`; item 4 / issue #134 passed all local gates and is entering hosted review
+- Current status: items 1–4 / issues #131–#134 merged into `staging`; item 5 / issue #135 passed independent review and all local verification, with committed-diff review pending
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -25,9 +25,9 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Tickets: #131–#139
 - Ticket sessions: created as each ticket starts
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
-- Review packets: `issue-131-review-packet.md`, `issue-132-review-packet.md`, `issue-133-review-packet.md`; created per later ticket
+- Review packets: `issue-131-review-packet.md`, `issue-132-review-packet.md`, `issue-133-review-packet.md`, `issue-134-review-packet.md`, `issue-135-review-packet.md`; created per later ticket
 - Local CodeRabbit report: `issue-131-coderabbit-local.md`, `issue-132-coderabbit-local.md`, `issue-133-coderabbit-local.md`, `issue-134-coderabbit-local.md`; created per later ticket
-- PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; #143 open for issue #134; created per later ticket, always non-draft and targeting `staging`
+- PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; #143 merged for issue #134; created per later ticket, always non-draft and targeting `staging`
 
 ## Commands
 
@@ -44,8 +44,8 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #131 NIP-46 diagnostic redaction  | AFK  | merged          | `feature/nip46-diagnostic-redaction`    | Grok approved; CodeRabbit local/hosted clean after fixes  | Jest/Bun 1054/1054; hosted CI green       |
 | #132 published declaration purity | AFK  | merged          | `feature/public-type-test-purity`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1055/1055; hosted CI green       |
 | #133 shared diagnostic seam       | AFK  | merged          | `feature/shared-diagnostics-completion` | Grok standards/spec pass; local and hosted clean           | Jest/Bun 1067/1067; hosted CI green       |
-| #134 NIP-47 service lifecycle     | AFK  | hosted review   | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local clean; hosted pending         | Jest/Bun 1073/1073; all local gates green |
-| #135 NIP-57 consolidation         | AFK  | blocked by #134 | `feature/nip57-client-consolidation`    | pending                                                   | pending                                   |
+| #134 NIP-47 service lifecycle     | AFK  | merged          | `feature/nip47-service-lifecycle`       | Grok pass; CodeRabbit local/hosted clean                  | Jest/Bun 1073/1073; hosted CI green       |
+| #135 NIP-57 consolidation         | AFK  | local review    | `feature/nip57-client-consolidation`    | Grok standards/spec pass; CodeRabbit pending             | Jest/Bun 1077/1077; all local gates green |
 | #136 NIP-46 protocol core         | AFK  | blocked by #135 | `feature/nip46-protocol-core`           | pending                                                   | pending                                   |
 | #137 default test feedback loop   | AFK  | blocked by #136 | `feature/fast-default-test-loop`        | pending                                                   | pending                                   |
 | #138 public behavior test seams   | AFK  | blocked by #137 | `feature/public-behavior-test-seams`    | pending                                                   | pending                                   |
@@ -64,6 +64,8 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #131  | `f4bda34`   | current Codex orchestrator; Grok 4.5 High reviewers | `7ed8433`, `00104cc`, `21b4ad9`, `426c17b` | Grok approved after hosted fixes; CodeRabbit local code review clean | focused Jest/Bun 7/7; final Jest/Bun 1054/1054; policies, lint, types, builds, examples, pack |
 | #132  | `cf705f0`   | current Codex orchestrator; Grok 4.5 High reviewers | `0c111d7`, `20565a0`, `abfc836`, `dea7aa0` | Grok passed; CodeRabbit local/hosted clean after four local fixes    | focused 8/8; Jest/Bun 1055/1055; all local gates and four hosted lanes green                  |
 | #133  | `46d7289`   | current Codex orchestrator; Grok 4.5 High reviewers | `b238461`, `6dd75c3`, `ae15ace`             | Grok standards/spec passed; CodeRabbit local/hosted clean           | focused 204/204; Jest/Bun 1067/1067; all local gates and four hosted lanes green               |
+| #134  | `2a3556d`   | current Codex orchestrator; Grok 4.5 High reviewers | `569b266` plus review artifacts              | Grok standards/spec passed; CodeRabbit local/hosted clean           | focused 6/6; Jest/Bun 1073/1073; all local gates and four hosted lanes green                    |
+| #135  | `25e055d`   | current Codex orchestrator; Grok 4.5 High reviewers | pending                                      | Grok standards/spec passed after compatibility/doc fixes            | focused 18/18; NIP-57 36/36; Jest/Bun 1077/1077; all local gates green                         |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/issue-134-session.md
+++ b/docs/agents/runs/issue-134-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `2a3556d`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
 - Commit: `569b266`; verification artifacts: `644b52f`
-- Status: PR #143 open into `staging`; hosted CodeRabbit and CI pending
+- Status: merged through PR #143 into `staging` at `25e055d`; issue closed
 
 ## Inputs
 
@@ -31,14 +31,14 @@
 - Standards findings: initial review found that a second disconnect cancelled a queued initialization without attaching a rejection observer for fire-and-forget callers; re-review found the same observer was attached too late on the primary disconnect path; both paths now synchronously absorb expected cancellation while preserving rejection for callers that await the original promise
 - Spec findings: passed all five acceptance criteria; noted only partial public observability of the TTL cleanup interval and session-document drift
 - Worthy fixes applied: client-parity single-flight initialization, generation cancellation, teardown serialization, attempt-scoped subscription cleanup, restartable TTL cleanup, stale callback generation guard, and cancellation rejection absorption
-- Findings ignored with reasons: direct TTL interval assertions require private-shape access and conflict with the public-API test criterion; restart behavior is instead proved by an encrypted expired request after reconnect
+- Findings ignored with reasons: direct TTL interval assertions require private-shape access and conflict with the public-API test criterion; restart behavior is instead proved by an encrypted expired request after reconnect; hosted CodeRabbit completed with no findings
 
 ## Verification
 
 - Focused: Jest/Bun lifecycle suite 6/6 after review-driven additions; NIP-47 Jest regression 9/9 suites and 76/76 tests
 - Full Jest: 83/83 suites and 1073/1073 tests
 - Full Bun: 83 files and 1073/1073 tests
-- Repository gates: commands and package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, and pack verification all green
+- Repository gates: commands and package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, pack verification, and all four hosted CI lanes green
 
 ## Risks
 

--- a/docs/agents/runs/issue-135-coderabbit-local.md
+++ b/docs/agents/runs/issue-135-coderabbit-local.md
@@ -5,7 +5,7 @@
 - Command: `coderabbit review --agent --type committed --base staging -c AGENTS.md`
 - Reviewed commit: `0909227`
 - Initial result: four findings (one critical, two major, one minor)
-- Re-review: pending after the review-fix commit
+- Re-review: clean with 0 findings after review-fix commit `1b12872`
 
 ## Findings and Resolutions
 
@@ -22,4 +22,4 @@
 - Full Bun: 83 files, 1081/1081 tests
 - Commands/package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, and pack verification: green
 - Grok standards/spec and targeted review-fix passes: clean with no remaining findings
-- Final CodeRabbit committed review: pending
+- Final CodeRabbit committed review: 0 findings across all seven changed files

--- a/docs/agents/runs/issue-135-coderabbit-local.md
+++ b/docs/agents/runs/issue-135-coderabbit-local.md
@@ -1,0 +1,25 @@
+# Local CodeRabbit Review: #135 NIP-57 Client Consolidation
+
+## Review
+
+- Command: `coderabbit review --agent --type committed --base staging -c AGENTS.md`
+- Reviewed commit: `0909227`
+- Initial result: four findings (one critical, two major, one minor)
+- Re-review: pending after the review-fix commit
+
+## Findings and Resolutions
+
+1. Anonymous zap requests used an all-zero event pubkey that could not match the signing private key. Fixed by deriving the request pubkey from the supplied ephemeral private key and verifying the resulting signature through the public client result.
+2. LNURL capability cache entries were reused after a profile LNURL changed and grew without a bound. Fixed with URL-aware hits and instance-local least-recently-used eviction above 256 entries.
+3. The LNURL invoice callback had no request bound and accepted successful payloads without a usable invoice. Fixed with abort-backed 10-second timeout cleanup and non-empty invoice validation.
+4. The review packet still described full verification as pending. Fixed to match the completed session record.
+
+## Verification Before Retry
+
+- Focused public-client Jest/Bun: 22/22
+- NIP-57 Jest: 4/4 suites, 40/40 tests
+- Full Jest: 83/83 suites, 1081/1081 tests
+- Full Bun: 83 files, 1081/1081 tests
+- Commands/package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, and pack verification: green
+- Grok standards/spec and targeted review-fix passes: clean with no remaining findings
+- Final CodeRabbit committed review: pending

--- a/docs/agents/runs/issue-135-review-packet.md
+++ b/docs/agents/runs/issue-135-review-packet.md
@@ -19,7 +19,7 @@
 - Red tests: `ZapClient` lacked the five receipt-query/statistics methods required to compare both public facades; focused compilation failed on those missing public methods
 - Green implementation: both facades reuse per-instance LNURL state, emit equivalent user/event/general receipt filters, preserve `limit: 0`, and calculate equivalent user/event statistics
 - Refactor: all behavior ownership remains private; no private shape or production test hook is used
-- Commands run: focused Jest/Bun public-client suites, NIP-57 Jest regression suite, strict TypeScript, ESLint, and diff checks; full-suite and packaging gates follow independent review
+- Commands run: focused Jest/Bun public-client suites, NIP-57 Jest regression suite, full Jest/Bun suites, strict TypeScript, ESLint, CJS/ESM builds, examples, package verification, and diff checks; all completed successfully before committed-diff review
 
 ## Review Instructions
 
@@ -37,7 +37,11 @@ SPEC_STATUS: pass
 SPEC_FINDINGS:
 - all acceptance criteria met; zero findings
 
-CODERABBIT_STATUS: pending
+CODERABBIT_STATUS: re-review pending
 CODERABBIT_FINDINGS:
-- pending
+- stale verification packet corrected
+- anonymous signer pubkey now derives from the supplied ephemeral private key and verifies cryptographically
+- LNURL cache now respects URL changes and evicts least-recently-used entries above 256
+- invoice callback is bounded to 10 seconds and successful responses require a non-empty invoice
+- all four findings fixed, independently re-reviewed by Grok, and fully verified; final committed-diff CodeRabbit pass pending
 ```

--- a/docs/agents/runs/issue-135-review-packet.md
+++ b/docs/agents/runs/issue-135-review-packet.md
@@ -37,11 +37,11 @@ SPEC_STATUS: pass
 SPEC_FINDINGS:
 - all acceptance criteria met; zero findings
 
-CODERABBIT_STATUS: re-review pending
+CODERABBIT_STATUS: pass
 CODERABBIT_FINDINGS:
 - stale verification packet corrected
 - anonymous signer pubkey now derives from the supplied ephemeral private key and verifies cryptographically
 - LNURL cache now respects URL changes and evicts least-recently-used entries above 256
 - invoice callback is bounded to 10 seconds and successful responses require a non-empty invoice
-- all four findings fixed, independently re-reviewed by Grok, and fully verified; final committed-diff CodeRabbit pass pending
+- all four findings fixed, independently re-reviewed by Grok, fully verified, and accepted by the final committed-diff CodeRabbit pass with zero findings
 ```

--- a/docs/agents/runs/issue-135-review-packet.md
+++ b/docs/agents/runs/issue-135-review-packet.md
@@ -37,11 +37,12 @@ SPEC_STATUS: pass
 SPEC_FINDINGS:
 - all acceptance criteria met; zero findings
 
-CODERABBIT_STATUS: pass
+CODERABBIT_STATUS: hosted re-review pending
 CODERABBIT_FINDINGS:
 - stale verification packet corrected
 - anonymous signer pubkey now derives from the supplied ephemeral private key and verifies cryptographically
 - LNURL cache now respects URL changes and evicts least-recently-used entries above 256
 - invoice callback is bounded to 10 seconds and successful responses require a non-empty invoice
 - all four findings fixed, independently re-reviewed by Grok, fully verified, and accepted by the final committed-diff CodeRabbit pass with zero findings
+- hosted full review found inconsistent seeded fields for an all-invalid receipt set; fixed to return canonical empty statistics through both public facades, passed by Grok, and fully re-verified
 ```

--- a/docs/agents/runs/issue-135-review-packet.md
+++ b/docs/agents/runs/issue-135-review-packet.md
@@ -1,0 +1,43 @@
+# Review Packet: #135 NIP-57 Client Consolidation
+
+## Issue
+
+- Issue: #135
+- Slice type: AFK structural cleanup
+- Acceptance criteria: repeated operations reuse persistent LNURL cache and collaborators; both public facades produce equivalent receipt filters and statistics for equivalent inputs; explicit `limit: 0` is preserved; existing public exports and 0.x behavior remain compatible; tests exercise both public facades without private helpers
+- Baseline: `25e055d`
+- Current diff: working tree against `25e055d`
+
+## Implementation Summary
+
+`NostrZapClient` and `ZapClient` now delegate to one instance-owned, non-exported `ZapClientCore`. The core owns the Nostr collaborator, relays, logger, LNURL cache, invoice generation, subscription collection, receipt-filter construction, validation, statistics, and split helpers. Both public constructor shapes and existing method contracts remain intact; `ZapClient` gains additive receipt-query and statistics methods so the two public facades can expose the same behavior without private test seams. Receipt filters now share one builder and preserve explicit zero limits.
+
+## Implementation Evidence
+
+- `implement` session: `issue-135-session.md`
+- `tdd` used: yes
+- Red tests: `ZapClient` lacked the five receipt-query/statistics methods required to compare both public facades; focused compilation failed on those missing public methods
+- Green implementation: both facades reuse per-instance LNURL state, emit equivalent user/event/general receipt filters, preserve `limit: 0`, and calculate equivalent user/event statistics
+- Refactor: all behavior ownership remains private; no private shape or production test hook is used
+- Commands run: focused Jest/Bun public-client suites, NIP-57 Jest regression suite, strict TypeScript, ESLint, and diff checks; full-suite and packaging gates follow independent review
+
+## Review Instructions
+
+Review only issue #135 unless a severe cross-slice regression appears. Keep standards and spec axes separate. Verify instance-local cache ownership, absence of short-lived internal client allocations, constructor and method compatibility, subscription/EOSE/timeout behavior, filter parity including zero-valued options, statistics parity, additive API safety, export compatibility, logger propagation, and tests through public facades only.
+
+## Reviewer Output
+
+```text
+STANDARDS_STATUS: pass
+STANDARDS_FINDINGS:
+- initial exported-JSDoc and targeted-filter compatibility findings fixed
+- golden filter shapes added; final targeted re-review found no remaining findings
+
+SPEC_STATUS: pass
+SPEC_FINDINGS:
+- all acceptance criteria met; zero findings
+
+CODERABBIT_STATUS: pending
+CODERABBIT_FINDINGS:
+- pending
+```

--- a/docs/agents/runs/issue-135-session.md
+++ b/docs/agents/runs/issue-135-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `25e055d`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
 - Commit: `0909227`; review fixes: `1b12872`
-- Status: all local review and verification complete; ready for hosted review
+- Status: hosted CodeRabbit finding fixed and fully verified; hosted rerun pending
 
 ## Inputs
 
@@ -28,16 +28,16 @@
 
 - Review fixed point: `25e055d`
 - Design findings: Grok mapped the short-lived `ZapClient` allocations, duplicated filter and statistics logic, cache ownership, subscription semantics, and export asymmetry; a targeted follow-up confirmed that five additive `ZapClient` receipt/statistics delegates are required to satisfy the literal public-facade equivalence criterion
-- Standards findings: initial pass found exported adapter JSDoc drift, facade-only filter comparisons without golden shapes, and a compatibility drift where targeted user queries inherited the general `events` filter; all were fixed and the targeted re-review passed with zero findings; Grok also passed the subsequent CodeRabbit-driven delta with zero findings
+- Standards findings: initial pass found exported adapter JSDoc drift, facade-only filter comparisons without golden shapes, and a compatibility drift where targeted user queries inherited the general `events` filter; all were fixed and the targeted re-review passed with zero findings; Grok also passed both subsequent CodeRabbit-driven deltas with zero findings
 - Spec findings: passed every acceptance criterion with zero findings
-- Worthy fixes applied: one instance-owned private core, persistent per-facade LNURL state, shared receipt filter and statistics implementations, explicit zero-limit preservation, public `ZapClient` receipt/statistics delegates, exported adapter JSDoc, golden filter assertions that protect targeted-query compatibility, valid ephemeral-key anonymous signatures, URL-aware bounded LNURL caching, a bounded invoice callback, and successful-response invoice validation
-- Findings ignored with reasons: additional duplicate subscription-lifecycle tests through `ZapClient` were optional because both adapters delegate to the same private collector and the parity tests exercise the new facade routes; the private core remains in the existing client module to avoid a circular or overly fragmented NIP-57 implementation; final local CodeRabbit review completed with zero findings
+- Worthy fixes applied: one instance-owned private core, persistent per-facade LNURL state, shared receipt filter and statistics implementations, explicit zero-limit preservation, public `ZapClient` receipt/statistics delegates, exported adapter JSDoc, golden filter assertions that protect targeted-query compatibility, valid ephemeral-key anonymous signatures, URL-aware bounded LNURL caching, a bounded invoice callback, successful-response invoice validation, and canonical empty statistics when all receipts are invalid
+- Findings ignored with reasons: additional duplicate subscription-lifecycle tests through `ZapClient` were optional because both adapters delegate to the same private collector and the parity tests exercise the new facade routes; the private core remains in the existing client module to avoid a circular or overly fragmented NIP-57 implementation; the hosted generic docstring-percentage warning conflicts with the actual exported JSDoc and produced no missing-docstring code finding; final local CodeRabbit review completed with zero findings
 
 ## Verification
 
-- Focused: Jest/Bun public-client suite 22/22; NIP-57 regression 4/4 suites and 40/40 tests
-- Full Jest: 83/83 suites and 1081/1081 tests
-- Full Bun: 83 files and 1081/1081 tests
+- Focused: Jest/Bun public-client suite 23/23; NIP-57 regression 4/4 suites and 41/41 tests
+- Full Jest: 83/83 suites and 1082/1082 tests
+- Full Bun: 83 files and 1082/1082 tests
 - Repository gates: commands and package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, pack verification, and diff checks all green
 
 ## Risks

--- a/docs/agents/runs/issue-135-session.md
+++ b/docs/agents/runs/issue-135-session.md
@@ -5,8 +5,8 @@
 - Issue: #135
 - Fixed point before session: `25e055d`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
-- Commit: `0909227`; review-fix commit pending
-- Status: all four initial CodeRabbit findings fixed and fully verified; committed-diff re-review pending
+- Commit: `0909227`; review fixes: `1b12872`
+- Status: all local review and verification complete; ready for hosted review
 
 ## Inputs
 
@@ -31,7 +31,7 @@
 - Standards findings: initial pass found exported adapter JSDoc drift, facade-only filter comparisons without golden shapes, and a compatibility drift where targeted user queries inherited the general `events` filter; all were fixed and the targeted re-review passed with zero findings; Grok also passed the subsequent CodeRabbit-driven delta with zero findings
 - Spec findings: passed every acceptance criterion with zero findings
 - Worthy fixes applied: one instance-owned private core, persistent per-facade LNURL state, shared receipt filter and statistics implementations, explicit zero-limit preservation, public `ZapClient` receipt/statistics delegates, exported adapter JSDoc, golden filter assertions that protect targeted-query compatibility, valid ephemeral-key anonymous signatures, URL-aware bounded LNURL caching, a bounded invoice callback, and successful-response invoice validation
-- Findings ignored with reasons: additional duplicate subscription-lifecycle tests through `ZapClient` were optional because both adapters delegate to the same private collector and the parity tests exercise the new facade routes; the private core remains in the existing client module to avoid a circular or overly fragmented NIP-57 implementation
+- Findings ignored with reasons: additional duplicate subscription-lifecycle tests through `ZapClient` were optional because both adapters delegate to the same private collector and the parity tests exercise the new facade routes; the private core remains in the existing client module to avoid a circular or overly fragmented NIP-57 implementation; final local CodeRabbit review completed with zero findings
 
 ## Verification
 

--- a/docs/agents/runs/issue-135-session.md
+++ b/docs/agents/runs/issue-135-session.md
@@ -1,0 +1,46 @@
+# Issue Session: #135 NIP-57 Client Consolidation
+
+## Issue
+
+- Issue: #135
+- Fixed point before session: `25e055d`
+- Worker session: current Codex orchestrator; Grok 4.5 High reviewers
+- Commit: pending
+- Status: independent standards/spec review and all local verification complete; committed-diff review pending
+
+## Inputs
+
+- Spec issue: #130
+- Ticket: #135
+- Relevant glossary terms: Nostr Event, Relay, Subscription Filter, NIP-57
+- Relevant ADRs: none
+- Prototype answer and source branch, if any: none
+
+## Implementation
+
+- Public interface used: existing `NostrZapClient` and `ZapClient` facades
+- Behaviors covered: persistent LNURL cache and collaborators, equivalent filters and statistics, explicit zero limits, and 0.x-compatible exports and methods
+- `tdd` used: yes; public-facade tests cover persistent and isolated cache state, equivalent receipt filters and statistics, and explicit zero limits
+- Commands run during implementation: focused Jest and Bun public-facade suites, NIP-57 Jest regression suite, strict TypeScript, ESLint, and diff checks
+- Full suite command: `npm test -- --runInBand --coverage=false`; `bun test ./tests --max-concurrency 1 --timeout 30000`; repository policy, lint, type, build, example, and pack gates
+
+## Review
+
+- Review fixed point: `25e055d`
+- Design findings: Grok mapped the short-lived `ZapClient` allocations, duplicated filter and statistics logic, cache ownership, subscription semantics, and export asymmetry; a targeted follow-up confirmed that five additive `ZapClient` receipt/statistics delegates are required to satisfy the literal public-facade equivalence criterion
+- Standards findings: initial pass found exported adapter JSDoc drift, facade-only filter comparisons without golden shapes, and a compatibility drift where targeted user queries inherited the general `events` filter; all were fixed and the targeted re-review passed with zero findings
+- Spec findings: passed every acceptance criterion with zero findings
+- Worthy fixes applied: one instance-owned private core, persistent per-facade LNURL state, shared receipt filter and statistics implementations, explicit zero-limit preservation, public `ZapClient` receipt/statistics delegates, exported adapter JSDoc, and golden filter assertions that protect targeted-query compatibility
+- Findings ignored with reasons: additional duplicate subscription-lifecycle tests through `ZapClient` were optional because both adapters delegate to the same private collector and the parity tests exercise the new facade routes; the private core remains in the existing client module to avoid a circular or overly fragmented NIP-57 implementation
+
+## Verification
+
+- Focused: Jest public-client suite 18/18; NIP-57 regression 4/4 suites and 36/36 tests; Bun public-client suite 18/18
+- Full Jest: 83/83 suites and 1077/1077 tests
+- Full Bun: 83 files and 1077/1077 tests
+- Repository gates: commands and package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, pack verification, and diff checks all green
+
+## Risks
+
+- Consolidation must preserve both public constructor shapes and return values while removing duplicated behavior ownership.
+- A shared persistent implementation must not share cache state between distinct public client instances.

--- a/docs/agents/runs/issue-135-session.md
+++ b/docs/agents/runs/issue-135-session.md
@@ -5,8 +5,8 @@
 - Issue: #135
 - Fixed point before session: `25e055d`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
-- Commit: pending
-- Status: independent standards/spec review and all local verification complete; committed-diff review pending
+- Commit: `0909227`; review-fix commit pending
+- Status: all four initial CodeRabbit findings fixed and fully verified; committed-diff re-review pending
 
 ## Inputs
 
@@ -20,7 +20,7 @@
 
 - Public interface used: existing `NostrZapClient` and `ZapClient` facades
 - Behaviors covered: persistent LNURL cache and collaborators, equivalent filters and statistics, explicit zero limits, and 0.x-compatible exports and methods
-- `tdd` used: yes; public-facade tests cover persistent and isolated cache state, equivalent receipt filters and statistics, and explicit zero limits
+- `tdd` used: yes; public-facade tests cover persistent, isolated, URL-aware, and bounded cache state; equivalent receipt filters and statistics; explicit zero limits; valid anonymous signing; invoice response validation; and callback timeout cleanup
 - Commands run during implementation: focused Jest and Bun public-facade suites, NIP-57 Jest regression suite, strict TypeScript, ESLint, and diff checks
 - Full suite command: `npm test -- --runInBand --coverage=false`; `bun test ./tests --max-concurrency 1 --timeout 30000`; repository policy, lint, type, build, example, and pack gates
 
@@ -28,16 +28,16 @@
 
 - Review fixed point: `25e055d`
 - Design findings: Grok mapped the short-lived `ZapClient` allocations, duplicated filter and statistics logic, cache ownership, subscription semantics, and export asymmetry; a targeted follow-up confirmed that five additive `ZapClient` receipt/statistics delegates are required to satisfy the literal public-facade equivalence criterion
-- Standards findings: initial pass found exported adapter JSDoc drift, facade-only filter comparisons without golden shapes, and a compatibility drift where targeted user queries inherited the general `events` filter; all were fixed and the targeted re-review passed with zero findings
+- Standards findings: initial pass found exported adapter JSDoc drift, facade-only filter comparisons without golden shapes, and a compatibility drift where targeted user queries inherited the general `events` filter; all were fixed and the targeted re-review passed with zero findings; Grok also passed the subsequent CodeRabbit-driven delta with zero findings
 - Spec findings: passed every acceptance criterion with zero findings
-- Worthy fixes applied: one instance-owned private core, persistent per-facade LNURL state, shared receipt filter and statistics implementations, explicit zero-limit preservation, public `ZapClient` receipt/statistics delegates, exported adapter JSDoc, and golden filter assertions that protect targeted-query compatibility
+- Worthy fixes applied: one instance-owned private core, persistent per-facade LNURL state, shared receipt filter and statistics implementations, explicit zero-limit preservation, public `ZapClient` receipt/statistics delegates, exported adapter JSDoc, golden filter assertions that protect targeted-query compatibility, valid ephemeral-key anonymous signatures, URL-aware bounded LNURL caching, a bounded invoice callback, and successful-response invoice validation
 - Findings ignored with reasons: additional duplicate subscription-lifecycle tests through `ZapClient` were optional because both adapters delegate to the same private collector and the parity tests exercise the new facade routes; the private core remains in the existing client module to avoid a circular or overly fragmented NIP-57 implementation
 
 ## Verification
 
-- Focused: Jest public-client suite 18/18; NIP-57 regression 4/4 suites and 36/36 tests; Bun public-client suite 18/18
-- Full Jest: 83/83 suites and 1077/1077 tests
-- Full Bun: 83 files and 1077/1077 tests
+- Focused: Jest/Bun public-client suite 22/22; NIP-57 regression 4/4 suites and 40/40 tests
+- Full Jest: 83/83 suites and 1081/1081 tests
+- Full Bun: 83 files and 1081/1081 tests
 - Repository gates: commands and package-manager policy, ESLint, strict TypeScript, CJS/ESM builds, examples, pack verification, and diff checks all green
 
 ## Risks

--- a/src/nip57/client.ts
+++ b/src/nip57/client.ts
@@ -14,6 +14,7 @@ import { LnurlSuccessAction, LnurlInvoiceResponse } from "./types";
 import { Nostr } from "../nip01/nostr";
 import { createSignedEvent } from "../nip01/event";
 import { getUnixTime } from "../utils/time";
+import { getPublicKey } from "../utils/crypto";
 import {
   createZapRequest,
   validateZapReceipt,
@@ -30,6 +31,9 @@ import {
 import { Logger } from "../utils/logger";
 import type { DiagnosticLogger } from "../utils/logger";
 import { reportNIP57Diagnostic } from "./diagnostics";
+
+const LNURL_CACHE_CAPACITY = 256;
+const LNURL_CALLBACK_TIMEOUT_MS = 10_000;
 
 /**
  * Options for the ZapClient
@@ -134,6 +138,21 @@ class ZapClientCore {
     this.client = options.nostrClient;
     this.defaultRelays = options.defaultRelays || [];
     this.logger = options.logger ?? new Logger({ silent: true });
+  }
+
+  private rememberLnurlResult(
+    pubkey: string,
+    lnurl: string,
+    supportsZaps: boolean,
+  ): void {
+    this.lnurlCache.delete(pubkey);
+    this.lnurlCache.set(pubkey, { pubkey, lnurl, supportsZaps });
+
+    while (this.lnurlCache.size > LNURL_CACHE_CAPACITY) {
+      const oldestPubkey = this.lnurlCache.keys().next().value;
+      if (oldestPubkey === undefined) break;
+      this.lnurlCache.delete(oldestPubkey);
+    }
   }
 
   /** Collect matching zap receipts until the first EOSE or the legacy timeout. */
@@ -244,7 +263,9 @@ class ZapClientCore {
   async canReceiveZaps(pubkey: string, lnurl?: string): Promise<boolean> {
     try {
       const cached = this.lnurlCache.get(pubkey);
-      if (cached) {
+      if (cached && (!lnurl || cached.lnurl === lnurl)) {
+        this.lnurlCache.delete(pubkey);
+        this.lnurlCache.set(pubkey, cached);
         return cached.supportsZaps;
       }
 
@@ -254,12 +275,12 @@ class ZapClientCore {
 
       const metadata = await fetchLnurlPayMetadata(lnurl, this.logger);
       if (!metadata) {
-        this.lnurlCache.set(pubkey, { pubkey, lnurl, supportsZaps: false });
+        this.rememberLnurlResult(pubkey, lnurl, false);
         return false;
       }
 
       const supportsZaps = supportsNostrZaps(metadata);
-      this.lnurlCache.set(pubkey, { pubkey, lnurl, supportsZaps });
+      this.rememberLnurlResult(pubkey, lnurl, supportsZaps);
       return supportsZaps;
     } catch (error) {
       reportNIP57Diagnostic(
@@ -341,20 +362,19 @@ class ZapClientCore {
         zapRequestOptions.senderPubkey = senderPubkey;
       }
 
+      const signingPubkey = options.anonymousZap
+        ? getPublicKey(privateKey)
+        : senderPubkey || "";
       const requestTemplate = createZapRequest(
         zapRequestOptions,
-        options.anonymousZap
-          ? "0000000000000000000000000000000000000000000000000000000000000000"
-          : senderPubkey || "",
+        signingPubkey,
       );
 
       const signedZapRequest = await createSignedEvent(
         {
           ...requestTemplate,
           tags: requestTemplate.tags || [],
-          pubkey: options.anonymousZap
-            ? "0000000000000000000000000000000000000000000000000000000000000000"
-            : senderPubkey || "",
+          pubkey: signingPubkey,
           created_at: getUnixTime(),
         },
         privateKey,
@@ -365,15 +385,46 @@ class ZapClientCore {
         JSON.stringify(signedZapRequest),
         options.amount,
       );
-      const invoiceResponse = await fetch(callbackUrl);
-      const invoiceData =
-        (await invoiceResponse.json()) as LnurlInvoiceResponse;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        LNURL_CALLBACK_TIMEOUT_MS,
+      );
+      let invoiceData: LnurlInvoiceResponse;
+      try {
+        const invoiceResponse = await fetch(callbackUrl, {
+          signal: controller.signal,
+        });
+        invoiceData = (await invoiceResponse.json()) as LnurlInvoiceResponse;
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return {
+            invoice: "",
+            zapRequest: signedZapRequest,
+            error: "LNURL callback timed out",
+          };
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeoutId);
+      }
 
       if (invoiceData.status === "ERROR") {
         return {
           invoice: "",
           zapRequest: signedZapRequest,
           error: invoiceData.reason || "LNURL error",
+        };
+      }
+
+      if (
+        typeof invoiceData.pr !== "string" ||
+        invoiceData.pr.trim().length === 0
+      ) {
+        return {
+          invoice: "",
+          zapRequest: signedZapRequest,
+          error: "LNURL server returned an invalid invoice response",
         };
       }
 

--- a/src/nip57/client.ts
+++ b/src/nip57/client.ts
@@ -692,15 +692,9 @@ class ZapClientCore {
       stats.latestAt = Math.max(stats.latestAt ?? 0, zap.created_at);
     }
 
-    if (stats.count > 0) {
-      stats.average = Math.floor(stats.total / stats.count);
-    }
-    if (stats.smallest === Number.MAX_SAFE_INTEGER) {
-      stats.smallest = undefined;
-    }
-    if (stats.firstAt === Number.MAX_SAFE_INTEGER) {
-      stats.firstAt = undefined;
-    }
+    if (stats.count === 0) return { total: 0, count: 0 };
+
+    stats.average = Math.floor(stats.total / stats.count);
 
     return stats;
   }

--- a/src/nip57/client.ts
+++ b/src/nip57/client.ts
@@ -117,26 +117,21 @@ export interface ZapStats {
  * This client provides high-level methods for sending zaps,
  * fetching zap receipts, and calculating zap statistics.
  */
-export class NostrZapClient {
+class ZapClientCore {
   private client: Nostr;
   private defaultRelays: string[];
   private logger: DiagnosticLogger;
+  private lnurlCache: Map<
+    string,
+    { pubkey: string; lnurl: string; supportsZaps: boolean }
+  > = new Map();
 
   /**
    * Create a new zap client
    * @param options Options for configuring the client
    */
-  constructor(options: {
-    /** The Nostr client instance to use */
-    client: Nostr;
-
-    /** Default relay URLs to use when not specified explicitly */
-    defaultRelays?: string[];
-
-    /** Receives NIP-57 diagnostics. Quiet by default. */
-    logger?: DiagnosticLogger;
-  }) {
-    this.client = options.client;
+  constructor(options: ZapClientOptions) {
+    this.client = options.nostrClient;
     this.defaultRelays = options.defaultRelays || [];
     this.logger = options.logger ?? new Logger({ silent: true });
   }
@@ -247,12 +242,157 @@ export class NostrZapClient {
    * @returns Whether the user can receive zaps
    */
   async canReceiveZaps(pubkey: string, lnurl?: string): Promise<boolean> {
-    const zapClient = new ZapClient({
-      nostrClient: this.client,
-      defaultRelays: this.defaultRelays,
-      logger: this.logger,
-    });
-    return zapClient.canReceiveZaps(pubkey, lnurl);
+    try {
+      const cached = this.lnurlCache.get(pubkey);
+      if (cached) {
+        return cached.supportsZaps;
+      }
+
+      if (!lnurl) {
+        return false;
+      }
+
+      const metadata = await fetchLnurlPayMetadata(lnurl, this.logger);
+      if (!metadata) {
+        this.lnurlCache.set(pubkey, { pubkey, lnurl, supportsZaps: false });
+        return false;
+      }
+
+      const supportsZaps = supportsNostrZaps(metadata);
+      this.lnurlCache.set(pubkey, { pubkey, lnurl, supportsZaps });
+      return supportsZaps;
+    } catch (error) {
+      reportNIP57Diagnostic(
+        this.logger,
+        "error",
+        "Failed to check zap support",
+        { error },
+      );
+      return false;
+    }
+  }
+
+  async getZapInvoice(
+    options: {
+      recipientPubkey: string;
+      lnurl: string;
+      amount: number;
+      comment?: string;
+      eventId?: string;
+      aTag?: string;
+      relays?: string[];
+      anonymousZap?: boolean;
+    },
+    privateKey: string,
+  ): Promise<ZapInvoiceResult> {
+    try {
+      const senderPubkey = this.client.getPublicKey();
+      if (!senderPubkey && !options.anonymousZap) {
+        return {
+          invoice: "",
+          zapRequest: {} as NostrEvent,
+          error: "No public key available and not anonymous zap",
+        };
+      }
+
+      const metadata = await fetchLnurlPayMetadata(options.lnurl, this.logger);
+      if (!metadata) {
+        return {
+          invoice: "",
+          zapRequest: {} as NostrEvent,
+          error: "Invalid LNURL or failed to fetch metadata",
+        };
+      }
+
+      if (!supportsNostrZaps(metadata)) {
+        return {
+          invoice: "",
+          zapRequest: {} as NostrEvent,
+          error: "LNURL does not support Nostr zaps",
+        };
+      }
+
+      if (
+        options.amount < metadata.minSendable ||
+        options.amount > metadata.maxSendable
+      ) {
+        return {
+          invoice: "",
+          zapRequest: {} as NostrEvent,
+          error: `Amount out of range (${metadata.minSendable}-${metadata.maxSendable} millisats)`,
+        };
+      }
+
+      const zapRequestOptions: ZapRequestOptions = {
+        recipientPubkey: options.recipientPubkey,
+        amount: options.amount,
+        relays: options.relays || this.defaultRelays,
+        content: options.comment || "",
+        lnurl: options.lnurl,
+      };
+
+      if (options.eventId) {
+        zapRequestOptions.eventId = options.eventId;
+      }
+      if (options.aTag) {
+        zapRequestOptions.aTag = options.aTag;
+      }
+      if (options.anonymousZap && senderPubkey) {
+        zapRequestOptions.senderPubkey = senderPubkey;
+      }
+
+      const requestTemplate = createZapRequest(
+        zapRequestOptions,
+        options.anonymousZap
+          ? "0000000000000000000000000000000000000000000000000000000000000000"
+          : senderPubkey || "",
+      );
+
+      const signedZapRequest = await createSignedEvent(
+        {
+          ...requestTemplate,
+          tags: requestTemplate.tags || [],
+          pubkey: options.anonymousZap
+            ? "0000000000000000000000000000000000000000000000000000000000000000"
+            : senderPubkey || "",
+          created_at: getUnixTime(),
+        },
+        privateKey,
+      );
+
+      const callbackUrl = buildZapCallbackUrl(
+        metadata.callback,
+        JSON.stringify(signedZapRequest),
+        options.amount,
+      );
+      const invoiceResponse = await fetch(callbackUrl);
+      const invoiceData =
+        (await invoiceResponse.json()) as LnurlInvoiceResponse;
+
+      if (invoiceData.status === "ERROR") {
+        return {
+          invoice: "",
+          zapRequest: signedZapRequest,
+          error: invoiceData.reason || "LNURL error",
+        };
+      }
+
+      return {
+        invoice: invoiceData.pr,
+        zapRequest: signedZapRequest,
+        paymentHash: invoiceData.payment_hash,
+        successAction: invoiceData.successAction,
+      };
+    } catch (error) {
+      reportNIP57Diagnostic(this.logger, "error", "Failed to get zap invoice", {
+        error,
+      });
+      return {
+        invoice: "",
+        zapRequest: {} as NostrEvent,
+        error: `Error: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
   }
 
   /**
@@ -302,14 +442,8 @@ export class NostrZapClient {
     invoice?: string;
     error?: string;
   }> {
-    const zapClient = new ZapClient({
-      nostrClient: this.client,
-      defaultRelays: this.defaultRelays,
-      logger: this.logger,
-    });
-
     // Get the invoice
-    const result = await zapClient.getZapInvoice(options, privateKey);
+    const result = await this.getZapInvoice(options, privateKey);
 
     if (result.error) {
       return {
@@ -328,6 +462,40 @@ export class NostrZapClient {
     // 2. Return the payment success/failure
   }
 
+  private buildReceiptFilter(
+    options: ZapFilterOptions,
+    target: { recipientPubkey?: string; eventId?: string } = {},
+  ): Filter {
+    const filter: Filter = {
+      kinds: [9735],
+      limit: options.limit ?? 20,
+    };
+
+    if (target.recipientPubkey) {
+      filter["#p"] = [target.recipientPubkey];
+    }
+    if (target.eventId) {
+      filter["#e"] = [target.eventId];
+    } else if (
+      !target.recipientPubkey &&
+      options.events &&
+      options.events.length > 0
+    ) {
+      filter["#e"] = options.events;
+    }
+    if (options.since !== undefined) {
+      filter.since = options.since;
+    }
+    if (options.until !== undefined) {
+      filter.until = options.until;
+    }
+    if (options.authors && options.authors.length > 0) {
+      filter.authors = options.authors;
+    }
+
+    return filter;
+  }
+
   /**
    * Fetch zaps received by a user
    *
@@ -339,25 +507,9 @@ export class NostrZapClient {
     pubkey: string,
     options: ZapFilterOptions = {},
   ): Promise<NostrEvent[]> {
-    const filter: Filter = {
-      kinds: [9735],
-      "#p": [pubkey] as string[],
-      limit: options.limit || 20,
-    };
-
-    if (options.since) {
-      filter.since = options.since;
-    }
-
-    if (options.until) {
-      filter.until = options.until;
-    }
-
-    if (options.authors && options.authors.length > 0) {
-      filter.authors = options.authors;
-    }
-
-    return this.collectZapReceipts(filter);
+    return this.collectZapReceipts(
+      this.buildReceiptFilter(options, { recipientPubkey: pubkey }),
+    );
   }
 
   /**
@@ -415,25 +567,9 @@ export class NostrZapClient {
     eventId: string,
     options: ZapFilterOptions = {},
   ): Promise<NostrEvent[]> {
-    const filter: Filter = {
-      kinds: [9735],
-      "#e": [eventId] as string[],
-      limit: options.limit || 20,
-    };
-
-    if (options.since) {
-      filter.since = options.since;
-    }
-
-    if (options.until) {
-      filter.until = options.until;
-    }
-
-    if (options.authors && options.authors.length > 0) {
-      filter.authors = options.authors;
-    }
-
-    return this.collectZapReceipts(filter);
+    return this.collectZapReceipts(
+      this.buildReceiptFilter(options, { eventId }),
+    );
   }
 
   /**
@@ -445,28 +581,7 @@ export class NostrZapClient {
   async fetchZapReceipts(
     options: ZapFilterOptions = {},
   ): Promise<NostrEvent[]> {
-    const filter: Filter = {
-      kinds: [9735],
-      limit: options.limit || 20,
-    };
-
-    if (options.since) {
-      filter.since = options.since;
-    }
-
-    if (options.until) {
-      filter.until = options.until;
-    }
-
-    if (options.authors && options.authors.length > 0) {
-      filter.authors = options.authors;
-    }
-
-    if (options.events && options.events.length > 0) {
-      filter["#e"] = options.events as string[];
-    }
-
-    return this.collectZapReceipts(filter);
+    return this.collectZapReceipts(this.buildReceiptFilter(options));
   }
 
   /**
@@ -493,6 +608,52 @@ export class NostrZapClient {
     );
   }
 
+  private calculateZapStats(zaps: NostrEvent[]): ZapStats {
+    if (zaps.length === 0) {
+      return { total: 0, count: 0 };
+    }
+
+    const stats: ZapStats = {
+      total: 0,
+      count: 0,
+      largest: 0,
+      smallest: Number.MAX_SAFE_INTEGER,
+      average: 0,
+      firstAt: Number.MAX_SAFE_INTEGER,
+      latestAt: 0,
+    };
+
+    for (const zap of zaps) {
+      const validation = this.validateZapReceipt(zap);
+      if (!validation.valid || !validation.amount) continue;
+
+      stats.total += validation.amount;
+      stats.count++;
+      stats.largest = Math.max(stats.largest ?? 0, validation.amount);
+      stats.smallest = Math.min(
+        stats.smallest ?? Number.MAX_SAFE_INTEGER,
+        validation.amount,
+      );
+      stats.firstAt = Math.min(
+        stats.firstAt ?? Number.MAX_SAFE_INTEGER,
+        zap.created_at,
+      );
+      stats.latestAt = Math.max(stats.latestAt ?? 0, zap.created_at);
+    }
+
+    if (stats.count > 0) {
+      stats.average = Math.floor(stats.total / stats.count);
+    }
+    if (stats.smallest === Number.MAX_SAFE_INTEGER) {
+      stats.smallest = undefined;
+    }
+    if (stats.firstAt === Number.MAX_SAFE_INTEGER) {
+      stats.firstAt = undefined;
+    }
+
+    return stats;
+  }
+
   /**
    * Calculate total zaps received by a user
    *
@@ -505,66 +666,7 @@ export class NostrZapClient {
     options: ZapFilterOptions = {},
   ): Promise<ZapStats> {
     const zaps = await this.fetchUserReceivedZaps(pubkey, options);
-
-    if (zaps.length === 0) {
-      return { total: 0, count: 0 };
-    }
-
-    // Initialize stats
-    const stats: ZapStats = {
-      total: 0,
-      count: 0,
-      largest: 0,
-      smallest: Number.MAX_SAFE_INTEGER,
-      average: 0,
-      firstAt: Number.MAX_SAFE_INTEGER,
-      latestAt: 0,
-    };
-
-    // Process each zap
-    for (const zap of zaps) {
-      const validation = this.validateZapReceipt(zap);
-
-      if (validation.valid && validation.amount) {
-        stats.total += validation.amount;
-        stats.count++;
-
-        // Update largest/smallest
-        if (validation.amount > (stats.largest || 0)) {
-          stats.largest = validation.amount;
-        }
-
-        if (validation.amount < (stats.smallest || Number.MAX_SAFE_INTEGER)) {
-          stats.smallest = validation.amount;
-        }
-
-        // Update timestamps
-        if (zap.created_at < stats.firstAt!) {
-          stats.firstAt = zap.created_at;
-        }
-
-        if (zap.created_at > stats.latestAt!) {
-          stats.latestAt = zap.created_at;
-        }
-      }
-    }
-
-    // Calculate average
-    if (stats.count > 0) {
-      stats.average = Math.floor(stats.total / stats.count);
-    }
-
-    // Reset smallest if no valid zaps were found
-    if (stats.smallest === Number.MAX_SAFE_INTEGER) {
-      stats.smallest = undefined;
-    }
-
-    // Reset timestamps if no valid zaps were found
-    if (stats.firstAt === Number.MAX_SAFE_INTEGER) {
-      stats.firstAt = undefined;
-    }
-
-    return stats;
+    return this.calculateZapStats(zaps);
   }
 
   /**
@@ -579,66 +681,7 @@ export class NostrZapClient {
     options: ZapFilterOptions = {},
   ): Promise<ZapStats> {
     const zaps = await this.fetchEventZaps(eventId, options);
-
-    if (zaps.length === 0) {
-      return { total: 0, count: 0 };
-    }
-
-    // Initialize stats
-    const stats: ZapStats = {
-      total: 0,
-      count: 0,
-      largest: 0,
-      smallest: Number.MAX_SAFE_INTEGER,
-      average: 0,
-      firstAt: Number.MAX_SAFE_INTEGER,
-      latestAt: 0,
-    };
-
-    // Process each zap
-    for (const zap of zaps) {
-      const validation = this.validateZapReceipt(zap);
-
-      if (validation.valid && validation.amount) {
-        stats.total += validation.amount;
-        stats.count++;
-
-        // Update largest/smallest
-        if (validation.amount > (stats.largest || 0)) {
-          stats.largest = validation.amount;
-        }
-
-        if (validation.amount < (stats.smallest || Number.MAX_SAFE_INTEGER)) {
-          stats.smallest = validation.amount;
-        }
-
-        // Update timestamps
-        if (zap.created_at < stats.firstAt!) {
-          stats.firstAt = zap.created_at;
-        }
-
-        if (zap.created_at > stats.latestAt!) {
-          stats.latestAt = zap.created_at;
-        }
-      }
-    }
-
-    // Calculate average
-    if (stats.count > 0) {
-      stats.average = Math.floor(stats.total / stats.count);
-    }
-
-    // Reset smallest if no valid zaps were found
-    if (stats.smallest === Number.MAX_SAFE_INTEGER) {
-      stats.smallest = undefined;
-    }
-
-    // Reset timestamps if no valid zaps were found
-    if (stats.firstAt === Number.MAX_SAFE_INTEGER) {
-      stats.firstAt = undefined;
-    }
-
-    return stats;
+    return this.calculateZapStats(zaps);
   }
 
   /**
@@ -666,26 +709,129 @@ export class NostrZapClient {
   }
 }
 
+/** Comprehensive public NIP-57 facade retained for 0.x compatibility. */
+export class NostrZapClient {
+  private core: ZapClientCore;
+
+  /** Create a comprehensive NIP-57 client around an existing Nostr client. */
+  constructor(options: {
+    /** The Nostr client instance to use. */
+    client: Nostr;
+    /** Default relay URLs to use when not specified explicitly. */
+    defaultRelays?: string[];
+    /** Receives NIP-57 diagnostics. Quiet by default. */
+    logger?: DiagnosticLogger;
+  }) {
+    this.core = new ZapClientCore({
+      nostrClient: options.client,
+      defaultRelays: options.defaultRelays,
+      logger: options.logger,
+    });
+  }
+
+  /** Check whether a user LNURL supports Nostr zaps. */
+  async canReceiveZaps(pubkey: string, lnurl?: string): Promise<boolean> {
+    return this.core.canReceiveZaps(pubkey, lnurl);
+  }
+
+  /** Build a zap request and return the invoice needed to send the zap. */
+  async sendZap(
+    options: {
+      recipientPubkey: string;
+      lnurl: string;
+      amount: number;
+      comment?: string;
+      eventId?: string;
+      aTag?: string;
+      relays?: string[];
+      anonymousZap?: boolean;
+    },
+    privateKey: string,
+  ): Promise<{ success: boolean; invoice?: string; error?: string }> {
+    return this.core.sendZap(options, privateKey);
+  }
+
+  /** Fetch zap receipts received by a user. */
+  async fetchUserReceivedZaps(
+    pubkey: string,
+    options: ZapFilterOptions = {},
+  ): Promise<NostrEvent[]> {
+    return this.core.fetchUserReceivedZaps(pubkey, options);
+  }
+
+  /** Fetch zap receipts sent by a user. */
+  async fetchUserSentZaps(
+    pubkey: string,
+    options: ZapFilterOptions = {},
+  ): Promise<NostrEvent[]> {
+    return this.core.fetchUserSentZaps(pubkey, options);
+  }
+
+  /** Fetch zap receipts associated with an event. */
+  async fetchEventZaps(
+    eventId: string,
+    options: ZapFilterOptions = {},
+  ): Promise<NostrEvent[]> {
+    return this.core.fetchEventZaps(eventId, options);
+  }
+
+  /** Fetch all zap receipts matching the supplied filter options. */
+  async fetchZapReceipts(
+    options: ZapFilterOptions = {},
+  ): Promise<NostrEvent[]> {
+    return this.core.fetchZapReceipts(options);
+  }
+
+  /** Validate a zap receipt and extract its amount when valid. */
+  validateZapReceipt(
+    zapReceipt: NostrEvent,
+    lnurlPubkey?: string,
+  ): ZapValidationResult {
+    return this.core.validateZapReceipt(zapReceipt, lnurlPubkey);
+  }
+
+  /** Calculate aggregate zap statistics for a user. */
+  async getTotalZapsReceived(
+    pubkey: string,
+    options: ZapFilterOptions = {},
+  ): Promise<ZapStats> {
+    return this.core.getTotalZapsReceived(pubkey, options);
+  }
+
+  /** Calculate aggregate zap statistics for an event. */
+  async getTotalZapsForEvent(
+    eventId: string,
+    options: ZapFilterOptions = {},
+  ): Promise<ZapStats> {
+    return this.core.getTotalZapsForEvent(eventId, options);
+  }
+
+  /** Parse zap split recipients and weights from an event. */
+  parseZapSplit(event: NostrEvent) {
+    return this.core.parseZapSplit(event);
+  }
+
+  /** Calculate recipient amounts for parsed zap split information. */
+  calculateZapSplitAmounts(
+    totalAmount: number,
+    splitInfo: ReturnType<typeof parseZapSplit>,
+  ) {
+    return this.core.calculateZapSplitAmounts(totalAmount, splitInfo);
+  }
+}
+
 /**
  * Client for working with NIP-57 Zaps
  */
 export class ZapClient {
-  private nostrClient: Nostr;
-  private defaultRelays: string[];
-  private logger: DiagnosticLogger;
-  private lnurlCache: Map<
-    string,
-    { pubkey: string; lnurl: string; supportsZaps: boolean }
-  > = new Map();
+  private core: ZapClientCore;
 
   /**
    * Create a new ZapClient
    * @param options Options for the client
    */
   constructor(options: ZapClientOptions) {
-    this.nostrClient = options.nostrClient;
-    this.defaultRelays = options.defaultRelays || [];
-    this.logger = options.logger ?? new Logger({ silent: true });
+    this.core = new ZapClientCore(options);
   }
 
   /**
@@ -698,44 +844,7 @@ export class ZapClient {
     pubkey: string,
     lnurlFromProfile?: string,
   ): Promise<boolean> {
-    try {
-      // Check cache first
-      const cached = this.lnurlCache.get(pubkey);
-      if (cached) {
-        return cached.supportsZaps;
-      }
-
-      // Use provided LNURL or fetch from profile
-      const lnurl = lnurlFromProfile;
-      if (!lnurl) {
-        // In a real implementation, we would fetch the user's profile to get their LNURL
-        // For now, return false as we don't have profile fetching implemented
-        return false;
-      }
-
-      // Fetch and validate LNURL metadata
-      const metadata = await fetchLnurlPayMetadata(lnurl, this.logger);
-      if (!metadata) {
-        this.lnurlCache.set(pubkey, { pubkey, lnurl, supportsZaps: false });
-        return false;
-      }
-
-      // Check if it supports zaps
-      const supportsZaps = supportsNostrZaps(metadata);
-
-      // Cache the result
-      this.lnurlCache.set(pubkey, { pubkey, lnurl, supportsZaps });
-
-      return supportsZaps;
-    } catch (error) {
-      reportNIP57Diagnostic(
-        this.logger,
-        "error",
-        "Failed to check zap support",
-        { error },
-      );
-      return false;
-    }
+    return this.core.canReceiveZaps(pubkey, lnurlFromProfile);
   }
 
   /**
@@ -757,126 +866,7 @@ export class ZapClient {
     },
     privateKey: string,
   ): Promise<ZapInvoiceResult> {
-    try {
-      const senderPubkey = this.nostrClient.getPublicKey();
-      if (!senderPubkey && !options.anonymousZap) {
-        return {
-          invoice: "",
-          zapRequest: {} as NostrEvent,
-          error: "No public key available and not anonymous zap",
-        };
-      }
-
-      // Fetch LNURL metadata
-      const metadata = await fetchLnurlPayMetadata(options.lnurl, this.logger);
-      if (!metadata) {
-        return {
-          invoice: "",
-          zapRequest: {} as NostrEvent,
-          error: "Invalid LNURL or failed to fetch metadata",
-        };
-      }
-
-      // Check if LNURL supports zaps
-      if (!supportsNostrZaps(metadata)) {
-        return {
-          invoice: "",
-          zapRequest: {} as NostrEvent,
-          error: "LNURL does not support Nostr zaps",
-        };
-      }
-
-      // Check amount limits
-      if (
-        options.amount < metadata.minSendable ||
-        options.amount > metadata.maxSendable
-      ) {
-        return {
-          invoice: "",
-          zapRequest: {} as NostrEvent,
-          error: `Amount out of range (${metadata.minSendable}-${metadata.maxSendable} millisats)`,
-        };
-      }
-
-      // Create zap request
-      const zapRequestOptions: ZapRequestOptions = {
-        recipientPubkey: options.recipientPubkey,
-        amount: options.amount,
-        relays: options.relays || this.defaultRelays,
-        content: options.comment || "",
-        lnurl: options.lnurl,
-      };
-
-      // Add optional parameters
-      if (options.eventId) {
-        zapRequestOptions.eventId = options.eventId;
-      }
-
-      if (options.aTag) {
-        zapRequestOptions.aTag = options.aTag;
-      }
-
-      // For anonymous zaps
-      if (options.anonymousZap && senderPubkey) {
-        zapRequestOptions.senderPubkey = senderPubkey;
-      }
-
-      // Create and sign zap request
-      const requestTemplate = createZapRequest(
-        zapRequestOptions,
-        options.anonymousZap
-          ? "00000000000000000000000000000000000000000000000000000000000000"
-          : senderPubkey || "",
-      );
-
-      const signedZapRequest = await createSignedEvent(
-        {
-          ...requestTemplate,
-          tags: requestTemplate.tags || [],
-          pubkey: options.anonymousZap
-            ? "00000000000000000000000000000000000000000000000000000000000000"
-            : senderPubkey || "",
-          created_at: getUnixTime(),
-        },
-        privateKey,
-      );
-
-      // Build callback URL with the zap request
-      const callbackUrl = buildZapCallbackUrl(
-        metadata.callback,
-        JSON.stringify(signedZapRequest),
-        options.amount,
-      );
-
-      // Fetch invoice from LNURL
-      const invoiceResponse = await fetch(callbackUrl);
-      const invoiceData =
-        (await invoiceResponse.json()) as LnurlInvoiceResponse;
-
-      if (invoiceData.status === "ERROR") {
-        return {
-          invoice: "",
-          zapRequest: signedZapRequest,
-          error: invoiceData.reason || "LNURL error",
-        };
-      }
-
-      return {
-        invoice: invoiceData.pr,
-        zapRequest: signedZapRequest,
-        paymentHash: invoiceData.payment_hash,
-        successAction: invoiceData.successAction,
-      };
-    } catch (error) {
-      reportNIP57Diagnostic(this.logger, "error", "Failed to get zap invoice", {
-        error,
-      });
-      return {
-        invoice: "",
-        zapRequest: {} as NostrEvent,
-        error: `Error: ${error instanceof Error ? error.message : String(error)}`,
-      };
-    }
+    return this.core.getZapInvoice(options, privateKey);
   }
 
   /**
@@ -889,7 +879,7 @@ export class ZapClient {
     zapReceipt: NostrEvent,
     lnurlPubkey: string,
   ): ZapValidationResult {
-    return validateZapReceipt(zapReceipt, lnurlPubkey, this.logger);
+    return this.core.validateZapReceipt(zapReceipt, lnurlPubkey);
   }
 
   /**
@@ -899,7 +889,46 @@ export class ZapClient {
    * @returns Split information for each recipient
    */
   getZapSplitAmounts(event: NostrEvent, totalAmount: number) {
-    const splitInfo = parseZapSplit(event);
-    return calculateZapSplitAmounts(totalAmount, splitInfo);
+    const splitInfo = this.core.parseZapSplit(event);
+    return this.core.calculateZapSplitAmounts(totalAmount, splitInfo);
+  }
+
+  /** Fetch all zap receipts matching the filter criteria. */
+  async fetchZapReceipts(
+    options: ZapFilterOptions = {},
+  ): Promise<NostrEvent[]> {
+    return this.core.fetchZapReceipts(options);
+  }
+
+  /** Fetch zap receipts received by a user. */
+  async fetchUserReceivedZaps(
+    pubkey: string,
+    options: ZapFilterOptions = {},
+  ): Promise<NostrEvent[]> {
+    return this.core.fetchUserReceivedZaps(pubkey, options);
+  }
+
+  /** Fetch zap receipts for an event. */
+  async fetchEventZaps(
+    eventId: string,
+    options: ZapFilterOptions = {},
+  ): Promise<NostrEvent[]> {
+    return this.core.fetchEventZaps(eventId, options);
+  }
+
+  /** Calculate zap statistics for a user. */
+  async getTotalZapsReceived(
+    pubkey: string,
+    options: ZapFilterOptions = {},
+  ): Promise<ZapStats> {
+    return this.core.getTotalZapsReceived(pubkey, options);
+  }
+
+  /** Calculate zap statistics for an event. */
+  async getTotalZapsForEvent(
+    eventId: string,
+    options: ZapFilterOptions = {},
+  ): Promise<ZapStats> {
+    return this.core.getTotalZapsForEvent(eventId, options);
   }
 }

--- a/tests/nip57/client.test.ts
+++ b/tests/nip57/client.test.ts
@@ -917,5 +917,31 @@ describe("NIP-57 public clients", () => {
         runEventStats(new ZapClient({ nostrClient: zapEvent }), zapEvent),
       ).resolves.toEqual(expected);
     });
+
+    test("both facades normalize all-invalid receipts to empty statistics", async () => {
+      jest.spyOn(nip57, "validateZapReceipt").mockReturnValue({
+        valid: false,
+        message: "invalid receipt",
+      });
+
+      const runStatistics = async (
+        facade: NostrZapClient | ZapClient,
+        nostr: ScriptedNostr,
+      ) => {
+        const statistics = facade.getTotalZapsReceived("a".repeat(64));
+        nostr.emitEvent(RECEIPT);
+        nostr.emitEOSE();
+        return statistics;
+      };
+      const nostrClient = new ScriptedNostr();
+      const zapClient = new ScriptedNostr();
+
+      await expect(
+        runStatistics(new NostrZapClient({ client: nostrClient }), nostrClient),
+      ).resolves.toEqual({ total: 0, count: 0 });
+      await expect(
+        runStatistics(new ZapClient({ nostrClient: zapClient }), zapClient),
+      ).resolves.toEqual({ total: 0, count: 0 });
+    });
   });
 });

--- a/tests/nip57/client.test.ts
+++ b/tests/nip57/client.test.ts
@@ -12,6 +12,7 @@ import {
 import { createSignedEvent } from "../../src/nip01/event";
 import { NostrRelay } from "../../src/testing";
 import type { DiagnosticLogger } from "../../src/utils/logger";
+import * as nip57 from "../../src/nip57";
 
 function createDiagnosticLogger(): DiagnosticLogger & {
   error: jest.Mock;
@@ -30,6 +31,7 @@ class ScriptedNostr extends Nostr {
   public returnedSubscriptionIds: unknown = ["relay-one", "relay-two"];
   public readonly activeSubscriptionIds = new Set<string>();
   public readonly releasedSubscriptionIds: string[][] = [];
+  public readonly subscribedFilters: Filter[][] = [];
   public subscribeError: Error | null = null;
   public readonly unsubscribeErrors = new Map<string, Error>();
   public reachesEoseSynchronously = false;
@@ -40,13 +42,14 @@ class ScriptedNostr extends Nostr {
   private eoseCallback: (() => void) | null = null;
 
   override subscribe(
-    _filters: Filter[],
+    filters: Filter[],
     onEvent: (event: NostrEvent, relay: string) => void,
     onEOSE?: () => void,
     _options: SubscriptionOptions = {},
   ): string[] {
     if (this.subscribeError) throw this.subscribeError;
 
+    this.subscribedFilters.push(filters);
     this.eventCallback = onEvent;
     this.eoseCallback = onEOSE ?? null;
     if (Array.isArray(this.returnedSubscriptionIds)) {
@@ -483,8 +486,9 @@ describe("NIP-57 public clients", () => {
     });
 
     test("preserves fallback behavior when an injected diagnostic logger throws", async () => {
-      spyOnGlobalFetch()
-        .mockRejectedValue(new Error("LNURL endpoint unavailable"));
+      spyOnGlobalFetch().mockRejectedValue(
+        new Error("LNURL endpoint unavailable"),
+      );
       const logger = createDiagnosticLogger();
       logger.error.mockImplementation(() => {
         throw new Error("logger unavailable");
@@ -533,6 +537,218 @@ describe("NIP-57 public clients", () => {
       expect(logger.error).toHaveBeenCalledWith("Failed to get zap invoice", {
         error: callbackError,
       });
+    });
+  });
+
+  describe("shared facade behavior", () => {
+    let installedFetchForTest = false;
+
+    const spyOnGlobalFetch = () => {
+      if (typeof globalThis.fetch !== "function") {
+        Object.defineProperty(globalThis, "fetch", {
+          configurable: true,
+          writable: true,
+          value: jest.fn(),
+        });
+        installedFetchForTest = true;
+      }
+
+      return jest.spyOn(globalThis, "fetch");
+    };
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+      if (installedFetchForTest) {
+        delete (globalThis as { fetch?: typeof fetch }).fetch;
+        installedFetchForTest = false;
+      }
+    });
+
+    test("reuses LNURL state per facade instance without sharing it between instances", async () => {
+      const fetchSpy = spyOnGlobalFetch().mockResolvedValue({
+        json: jest.fn().mockResolvedValue({
+          callback: "https://lnurl.test/callback",
+          maxSendable: 10_000,
+          minSendable: 1,
+          metadata: "[]",
+          tag: "payRequest",
+          allowsNostr: true,
+          nostrPubkey: "8".repeat(64),
+        }),
+      } as unknown as Response);
+      const pubkey = "7".repeat(64);
+      const lnurl = "https://lnurl.test/metadata";
+
+      const nostrFacade = new NostrZapClient({ client: new Nostr() });
+      await expect(nostrFacade.canReceiveZaps(pubkey, lnurl)).resolves.toBe(
+        true,
+      );
+      await expect(nostrFacade.canReceiveZaps(pubkey, lnurl)).resolves.toBe(
+        true,
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      fetchSpy.mockClear();
+      const zapFacade = new ZapClient({ nostrClient: new Nostr() });
+      await expect(zapFacade.canReceiveZaps(pubkey, lnurl)).resolves.toBe(true);
+      await expect(zapFacade.canReceiveZaps(pubkey, lnurl)).resolves.toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      fetchSpy.mockClear();
+      const first = new NostrZapClient({ client: new Nostr() });
+      const second = new NostrZapClient({ client: new Nostr() });
+      await expect(first.canReceiveZaps(pubkey, lnurl)).resolves.toBe(true);
+      await expect(second.canReceiveZaps(pubkey, lnurl)).resolves.toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test("both facades produce equivalent receipt filters", async () => {
+      jest.useFakeTimers();
+      const nostrForNostrFacade = new ScriptedNostr();
+      const nostrForZapFacade = new ScriptedNostr();
+      nostrForNostrFacade.reachesEoseSynchronously = true;
+      nostrForZapFacade.reachesEoseSynchronously = true;
+      const nostrFacade = new NostrZapClient({ client: nostrForNostrFacade });
+      const zapFacade = new ZapClient({ nostrClient: nostrForZapFacade });
+      const pubkey = "a".repeat(64);
+      const eventId = "b".repeat(64);
+      const generalEventId = "d".repeat(64);
+      const authors = ["c".repeat(64)];
+      const options = {
+        limit: 7,
+        since: 100,
+        until: 200,
+        authors,
+        events: [generalEventId],
+      };
+
+      await nostrFacade.fetchUserReceivedZaps(pubkey, options);
+      await zapFacade.fetchUserReceivedZaps(pubkey, options);
+      await nostrFacade.fetchEventZaps(eventId, options);
+      await zapFacade.fetchEventZaps(eventId, options);
+      await nostrFacade.fetchZapReceipts(options);
+      await zapFacade.fetchZapReceipts(options);
+
+      expect(nostrForZapFacade.subscribedFilters).toEqual(
+        nostrForNostrFacade.subscribedFilters,
+      );
+      expect(nostrForNostrFacade.subscribedFilters).toEqual([
+        [
+          {
+            kinds: [9735],
+            limit: 7,
+            "#p": [pubkey],
+            since: 100,
+            until: 200,
+            authors,
+          },
+        ],
+        [
+          {
+            kinds: [9735],
+            limit: 7,
+            "#e": [eventId],
+            since: 100,
+            until: 200,
+            authors,
+          },
+        ],
+        [
+          {
+            kinds: [9735],
+            limit: 7,
+            "#e": [generalEventId],
+            since: 100,
+            until: 200,
+            authors,
+          },
+        ],
+      ]);
+    });
+
+    test("both facades preserve an explicit zero limit for every receipt filter", async () => {
+      jest.useFakeTimers();
+      const nostrForNostrFacade = new ScriptedNostr();
+      const nostrForZapFacade = new ScriptedNostr();
+      nostrForNostrFacade.reachesEoseSynchronously = true;
+      nostrForZapFacade.reachesEoseSynchronously = true;
+      const nostrFacade = new NostrZapClient({ client: nostrForNostrFacade });
+      const zapFacade = new ZapClient({ nostrClient: nostrForZapFacade });
+
+      await nostrFacade.fetchUserReceivedZaps("a".repeat(64), { limit: 0 });
+      await zapFacade.fetchUserReceivedZaps("a".repeat(64), { limit: 0 });
+      await nostrFacade.fetchEventZaps("b".repeat(64), { limit: 0 });
+      await zapFacade.fetchEventZaps("b".repeat(64), { limit: 0 });
+      await nostrFacade.fetchZapReceipts({ limit: 0 });
+      await zapFacade.fetchZapReceipts({ limit: 0 });
+
+      expect(
+        nostrForNostrFacade.subscribedFilters.map(([filter]) => filter.limit),
+      ).toEqual([0, 0, 0]);
+      expect(nostrForZapFacade.subscribedFilters).toEqual(
+        nostrForNostrFacade.subscribedFilters,
+      );
+    });
+
+    test("both facades calculate equivalent user and event statistics", async () => {
+      jest.spyOn(nip57, "validateZapReceipt").mockImplementation((receipt) => ({
+        valid: true,
+        amount: receipt.id === RECEIPT.id ? 1_000 : 3_000,
+      }));
+      const secondReceipt = {
+        ...RECEIPT,
+        id: "4".repeat(64),
+        created_at: 3,
+      };
+      const expected = {
+        total: 4_000,
+        count: 2,
+        largest: 3_000,
+        smallest: 1_000,
+        average: 2_000,
+        firstAt: 1,
+        latestAt: 3,
+      };
+
+      const runUserStats = async (
+        facade: NostrZapClient | ZapClient,
+        nostr: ScriptedNostr,
+      ) => {
+        const statistics = facade.getTotalZapsReceived("a".repeat(64));
+        nostr.emitEvent(RECEIPT);
+        nostr.emitEvent(secondReceipt);
+        nostr.emitEOSE();
+        return statistics;
+      };
+      const runEventStats = async (
+        facade: NostrZapClient | ZapClient,
+        nostr: ScriptedNostr,
+      ) => {
+        const statistics = facade.getTotalZapsForEvent("b".repeat(64));
+        nostr.emitEvent(RECEIPT);
+        nostr.emitEvent(secondReceipt);
+        nostr.emitEOSE();
+        return statistics;
+      };
+
+      const nostrUser = new ScriptedNostr();
+      const zapUser = new ScriptedNostr();
+      await expect(
+        runUserStats(new NostrZapClient({ client: nostrUser }), nostrUser),
+      ).resolves.toEqual(expected);
+      await expect(
+        runUserStats(new ZapClient({ nostrClient: zapUser }), zapUser),
+      ).resolves.toEqual(expected);
+
+      const nostrEvent = new ScriptedNostr();
+      const zapEvent = new ScriptedNostr();
+      await expect(
+        runEventStats(new NostrZapClient({ client: nostrEvent }), nostrEvent),
+      ).resolves.toEqual(expected);
+      await expect(
+        runEventStats(new ZapClient({ nostrClient: zapEvent }), zapEvent),
+      ).resolves.toEqual(expected);
     });
   });
 });

--- a/tests/nip57/client.test.ts
+++ b/tests/nip57/client.test.ts
@@ -8,6 +8,7 @@ import {
   NostrZapClient,
   SubscriptionOptions,
   ZapClient,
+  verifySignature,
 } from "../../src";
 import { createSignedEvent } from "../../src/nip01/event";
 import { NostrRelay } from "../../src/testing";
@@ -450,6 +451,7 @@ describe("NIP-57 public clients", () => {
     };
 
     afterEach(() => {
+      jest.useRealTimers();
       jest.restoreAllMocks();
       if (installedFetchForTest) {
         delete (globalThis as { fetch?: typeof fetch }).fetch;
@@ -538,6 +540,137 @@ describe("NIP-57 public clients", () => {
         error: callbackError,
       });
     });
+
+    test("signs anonymous requests with the supplied ephemeral key", async () => {
+      const realPrivateKey = "8".repeat(64);
+      const ephemeralPrivateKey = "9".repeat(64);
+      const nostr = new Nostr();
+      nostr.setPrivateKey(realPrivateKey);
+      spyOnGlobalFetch()
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            callback: "https://lnurl.test/callback",
+            maxSendable: 10_000,
+            minSendable: 1,
+            metadata: "[]",
+            tag: "payRequest",
+            allowsNostr: true,
+            nostrPubkey: "7".repeat(64),
+          }),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({ pr: "lnbc-valid-invoice" }),
+        } as unknown as Response);
+      const client = new ZapClient({ nostrClient: nostr });
+
+      const result = await client.getZapInvoice(
+        {
+          recipientPubkey: "a".repeat(64),
+          lnurl: "https://lnurl.test/metadata",
+          amount: 1_000,
+          anonymousZap: true,
+        },
+        ephemeralPrivateKey,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.zapRequest.pubkey).toBe(getPublicKey(ephemeralPrivateKey));
+      expect(result.zapRequest.tags).toContainEqual([
+        "P",
+        getPublicKey(realPrivateKey),
+      ]);
+      await expect(
+        verifySignature(
+          result.zapRequest.id,
+          result.zapRequest.sig,
+          result.zapRequest.pubkey,
+        ),
+      ).resolves.toBe(true);
+    });
+
+    test("rejects a successful callback response without a usable invoice", async () => {
+      const privateKey = "9".repeat(64);
+      const nostr = new Nostr();
+      nostr.setPrivateKey(privateKey);
+      spyOnGlobalFetch()
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            callback: "https://lnurl.test/callback",
+            maxSendable: 10_000,
+            minSendable: 1,
+            metadata: "[]",
+            tag: "payRequest",
+            allowsNostr: true,
+            nostrPubkey: "8".repeat(64),
+          }),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({ status: "OK" }),
+        } as unknown as Response);
+      const client = new ZapClient({ nostrClient: nostr });
+
+      await expect(
+        client.getZapInvoice(
+          {
+            recipientPubkey: "a".repeat(64),
+            lnurl: "https://lnurl.test/metadata",
+            amount: 1_000,
+          },
+          privateKey,
+        ),
+      ).resolves.toMatchObject({
+        invoice: "",
+        error: "LNURL server returned an invalid invoice response",
+      });
+    });
+
+    test("bounds a stalled LNURL invoice callback", async () => {
+      const nativeSetTimeout = globalThis.setTimeout;
+      const timeoutSpy = jest
+        .spyOn(globalThis, "setTimeout")
+        .mockImplementation(((callback: () => void) =>
+          nativeSetTimeout(callback, 0)) as typeof setTimeout);
+      const privateKey = "9".repeat(64);
+      const nostr = new Nostr();
+      nostr.setPrivateKey(privateKey);
+      spyOnGlobalFetch()
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            callback: "https://lnurl.test/callback",
+            maxSendable: 10_000,
+            minSendable: 1,
+            metadata: "[]",
+            tag: "payRequest",
+            allowsNostr: true,
+            nostrPubkey: "8".repeat(64),
+          }),
+        } as unknown as Response)
+        .mockImplementationOnce(
+          (_url, init) =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener("abort", () => {
+                const error = new Error("aborted");
+                error.name = "AbortError";
+                reject(error);
+              });
+            }),
+        );
+      const client = new ZapClient({ nostrClient: nostr });
+      await expect(
+        client.getZapInvoice(
+          {
+            recipientPubkey: "a".repeat(64),
+            lnurl: "https://lnurl.test/metadata",
+            amount: 1_000,
+          },
+          privateKey,
+        ),
+      ).resolves.toMatchObject({
+        invoice: "",
+        error: "LNURL callback timed out",
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10_000);
+    });
   });
 
   describe("shared facade behavior", () => {
@@ -588,12 +721,20 @@ describe("NIP-57 public clients", () => {
         true,
       );
       expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await expect(
+        nostrFacade.canReceiveZaps(pubkey, `${lnurl}/changed`),
+      ).resolves.toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
 
       fetchSpy.mockClear();
       const zapFacade = new ZapClient({ nostrClient: new Nostr() });
       await expect(zapFacade.canReceiveZaps(pubkey, lnurl)).resolves.toBe(true);
       await expect(zapFacade.canReceiveZaps(pubkey, lnurl)).resolves.toBe(true);
       expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await expect(
+        zapFacade.canReceiveZaps(pubkey, `${lnurl}/changed`),
+      ).resolves.toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
 
       fetchSpy.mockClear();
       const first = new NostrZapClient({ client: new Nostr() });
@@ -601,6 +742,32 @@ describe("NIP-57 public clients", () => {
       await expect(first.canReceiveZaps(pubkey, lnurl)).resolves.toBe(true);
       await expect(second.canReceiveZaps(pubkey, lnurl)).resolves.toBe(true);
       expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test("bounds persistent LNURL state with observable eviction", async () => {
+      const fetchSpy = spyOnGlobalFetch().mockResolvedValue({
+        json: jest.fn().mockResolvedValue({
+          callback: "https://lnurl.test/callback",
+          maxSendable: 10_000,
+          minSendable: 1,
+          metadata: "[]",
+          tag: "payRequest",
+          allowsNostr: true,
+          nostrPubkey: "8".repeat(64),
+        }),
+      } as unknown as Response);
+      const client = new ZapClient({ nostrClient: new Nostr() });
+      const cacheCapacity = 256;
+
+      for (let index = 0; index <= cacheCapacity; index += 1) {
+        await client.canReceiveZaps(
+          index.toString(16).padStart(64, "0"),
+          `https://lnurl.test/${index}`,
+        );
+      }
+      await client.canReceiveZaps("0".repeat(64), "https://lnurl.test/0");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(cacheCapacity + 2);
     });
 
     test("both facades produce equivalent receipt filters", async () => {


### PR DESCRIPTION
Closes #135

## Summary
- route NostrZapClient and ZapClient through one persistent private core
- unify receipt filters and zap statistics while preserving explicit limit zero and 0.x facade compatibility
- harden anonymous signing, LNURL cache eviction, and invoice callback validation/timeouts
- cover both public facades without private test seams

## Verification
- Grok standards/spec and review-fix passes: clean
- CodeRabbit committed-diff review: 0 findings
- NIP-57 Jest: 40/40
- full Jest and Bun: 1081/1081 each
- policies, lint, strict types, CJS/ESM builds, examples, and pack verification: green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved NIP-57 zap client reliability with persistent, bounded LNURL caching and callback timeouts.
  * Anonymous zap requests now use securely derived signing keys.
  * Receipt filtering and aggregated zap statistics are consistent across supported client interfaces, preserving explicit `limit: 0`.
* **Bug Fixes**
  * Rejects invalid LNURL callback responses more reliably.
  * Terminates stalled LNURL requests within a defined timeout.
  * Normalizes all-invalid receipts to empty statistics.
* **Documentation**
  * Added review, verification, and issue session records for NIP-57 client updates.
* **Tests**
  * Expanded automated coverage for signature behavior, caching isolation/eviction, filter/statistics equivalence, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->