### PR TITLE
docs: finalize cleanup run ledger

### DIFF
--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -9,7 +9,7 @@
 - Feature branches: one branch per approved ticket, created from the latest integrated `staging`
 - Human owner: plebdev
 - Started: 2026-07-18
-- Current status: items 1–8 / issues #131–#138 merged into `staging`; item 9 / issue #139 is open as PR #148 into `staging`; one hosted Node 20 rerun pending after an isolated loaded-suite timeout
+- Current status: complete; items 1–9 / issues #131–#139 merged into `staging` through PRs #140–#148; parent spec #130 closed
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, domain docs, ADRs, CI, CodeRabbit)
 
 ## Goal
@@ -27,7 +27,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
 - Review packets: `issue-131-review-packet.md` through `issue-137-review-packet.md`; created per later ticket
 - Local CodeRabbit report: `issue-131-coderabbit-local.md` through `issue-136-coderabbit-local.md`; created per later ticket
-- PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; #143 merged for issue #134; #144 merged for issue #135; #145 merged for issue #136; #146 merged for issue #137; #147 merged for issue #138; #148 open for issue #139; always non-draft and targeting `staging`
+- PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; #143 merged for issue #134; #144 merged for issue #135; #145 merged for issue #136; #146 merged for issue #137; #147 merged for issue #138; #148 merged for issue #139; all were non-draft and targeted `staging`
 
 ## Commands
 
@@ -49,7 +49,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #136 NIP-46 protocol core         | AFK  | merged      | `feature/nip46-protocol-core`           | Grok and CodeRabbit local/hosted clean after fixes       | Jest/Bun 1096/1096; hosted CI green  |
 | #137 default test feedback loop   | AFK  | merged      | `feature/fast-default-test-loop`        | Grok pass; CodeRabbit hosted finding fixed and confirmed | routine 1063; slow 40; coverage 1103 |
 | #138 public behavior test seams   | AFK  | merged      | `feature/public-behavior-test-seams`    | Grok approved; CodeRabbit local/hosted findings resolved | Jest/Bun 1061; hosted CI green       |
-| #139 ephemeral Relay internals    | AFK  | PR #148 open | `feature/ephemeral-relay-internals`     | Grok standards/spec approved; CodeRabbit findings resolved/triaged | Jest/Bun 1,109; local gates green; hosted rerun pending |
+| #139 ephemeral Relay internals    | AFK  | merged      | `feature/ephemeral-relay-internals`     | Grok approved; local CodeRabbit findings resolved; hosted timeout fallback documented | routine 1074; slow 35; coverage 1109; hosted CI green |
 
 ## Parked HITL Slices
 
@@ -69,7 +69,7 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 | #136  | `ed9fa4a`   | current Codex orchestrator; Grok 4.5 High reviewers | PR #145 through merge `8b970e4`            | Grok and CodeRabbit local/hosted clean after fixes                                                       | NIP-46 185/185; Jest/Bun 1096/1096; all local and hosted gates green                                    |
 | #137  | `8b970e4`   | current Codex orchestrator; Grok 4.5 High reviewers | PR #146 through merge `b33f31f`            | Grok standards/spec passed after Bun 1.3.9 fix; CodeRabbit hosted finding fixed and explicitly confirmed | baseline 85/1096/58.793s; routine 84/1063/32.356s; slow 2/40/43.154s; coverage 86/1103; hosted CI green |
 | #138  | `b33f31f`   | current Codex orchestrator; Grok 4.5 High reviewers | PR #147 through merge `3c1e905`            | Grok approved; CodeRabbit local clean; two hosted nits fixed and false positive withdrawn                | routine Jest/Bun 1061; slow Jest/Bun 35; coverage 1096; all local gates and four hosted lanes green     |
-| #139  | `3c1e905`   | current Codex orchestrator; Grok 4.5 High reviewers | PR #148 through current head | Grok standards/spec approved with 0 findings; CodeRabbit in-scope findings fixed, scope changes rejected | focused 50/50; Jest/Bun 1,109/1,109; policies, lint, types, builds, examples, web, pack green |
+| #139  | `3c1e905`   | current Codex orchestrator; Grok 4.5 High reviewers | PR #148 through merge `9c9e14c` | Grok standards/spec approved with 0 findings; local CodeRabbit actionable findings fixed; hosted review timed out after 20 minutes without findings | focused 50/50; routine Jest/Bun 1074; slow Jest/Bun 35; coverage 1109; all local gates and four hosted lanes green |
 
 ## Alignment Decisions
 

--- a/docs/agents/runs/issue-139-review-packet.md
+++ b/docs/agents/runs/issue-139-review-packet.md
@@ -30,6 +30,8 @@
 - Routine lanes: Jest/Bun 1,074 tests each.
 - Slow lanes: Jest/Bun 35 tests each.
 - Complete Jest coverage inventory: 1,109 tests.
+- Hosted CI: Bun and Node 16/18/20 all passed on final head `d5b7cf5`.
+- Integration: PR #148 merged into `staging` as `9c9e14c`; issue #139 closed.
 - Green: command policy, package-manager policy, ESLint, strict TypeScript, CJS/ESM build, web entry checks, examples, and packed-consumer verification.
 - Pack result: 19 referenced targets, 376 packed files, 55 web modules, 3 guarded Node fallbacks.
 - CodeRabbit: all actionable in-scope findings fixed; final incremental review clean.

--- a/docs/agents/runs/issue-139-session.md
+++ b/docs/agents/runs/issue-139-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `3c1e905` (`staging` merge of PR #147)
 - Worker session: current Codex orchestrator; Grok 4.5 High is the exclusive delegated read-only reviewer
 - Commits: `d6504f6`, `7a48586`, `f8e9aac`, `96dd79f` plus review artifacts
-- Status: PR #148 open into `staging`; hosted rerun pending after one loaded Node 20 NIP-46 timeout
+- Status: complete; PR #148 merged into `staging` as `9c9e14c`; issue #139 and parent spec #130 closed
 
 ## Inputs
 
@@ -53,5 +53,8 @@
 - Routine Jest/Bun: 1,074/1,074 each.
 - Slow Jest/Bun: 35/35 each.
 - Complete Jest coverage inventory: 1,109/1,109.
+- Hosted verification: Bun and Node 16/18/20 all green on the final head. An earlier Node 20 run had one isolated loaded-suite NIP-46 timeout while the same inventory passed on Node 16/18 and locally; the clean rerun passed unchanged production code.
+- Hosted CodeRabbit: remained pending for the full 20-minute Feature Dev window without posting findings. The documented fallback was applied after two full local passes, one zero-finding incremental pass, final Grok approval, and four green hosted CI jobs.
+- Integrated: PR #148 merged into `staging` at `9c9e14c` on 2026-07-19.
 - Policy, lint, strict types, CJS/ESM and examples builds, web exports, and pack verification: green.
 - Pack verification: 19 referenced targets, 376 packed files, 55 web modules, 3 guarded Node fallbacks.


### PR DESCRIPTION
## Summary

- mark cleanup items 1–9 and issues #130–#139 complete
- record PR #148 merge commit and final hosted CI evidence
- document the hosted CodeRabbit timeout fallback already recorded on PR #148

## Verification

- `git diff --check`
- documentation-only reconciliation; no production or test code changed