### PR TITLE
docs: prepare 0.6.0 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A supported `snstr/testing` subpath now owns the Node-only `NostrRelay` test Relay and framework-neutral Relay test-double types without leaking Jest into published application declarations.
+- Canonical NIP-01 client and Relay wire-message tuple types now provide one authoritative protocol definition.
+- Repository tooling now enforces npm 9.8.1 as the release package manager, Bun as a pinned compatibility runner, and explicit routine, slow, and complete test lanes.
+
+### Changed
+- Relay event storage, Nostr Relay registry management, NIP-47 protocol codecs and dispatch, NIP-46 request machinery, NIP-57 client behavior, and ephemeral Relay transport/session/filter responsibilities now live behind smaller internal modules while preserving their public 0.x facades.
+- Production diagnostics now use one compatible logger policy across Nostr, Relay, RelayPool, NIP-46, NIP-47, NIP-57, and stateless protocol helpers.
+- Structural regression tests now prefer public behavior and owned testing seams over private implementation shapes.
+
+### Fixed
+- NIP-44 decryption now rejects unsupported legacy payload versions and malformed v2 nonce sizes through the public decrypt path.
+- NIP-47 service initialization is idempotent, concurrent-safe, and restartable after disconnect.
+- NIP-57 client flows share cache, filter, invoice, and statistics behavior while preserving explicit limit values, including zero.
+- Ephemeral Relay shutdown now retains runtime error handling, releases transports when session cleanup rejects, and stops session polling without stale routes.
+
+### Security
+- NIP-46 connection secrets, private keys, decrypted payloads, and untrusted error text are excluded from diagnostic output.
+- Generic key, wire-format, and resource-limit validation now has canonical ownership so NIP-specific policies cannot silently drift.
+
 ## [0.5.0] - 2026-07-18
 
 ### Added

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,8 +25,12 @@ npm publish --access public
 gh release create "v$(node -p 'require("./package.json").version')" --generate-notes
 ```
 
-The cleanup release is backward-compatible and adds browser/React Native
-exports, so its expected version bump is **minor** (`0.3.4` → `0.4.0`).
+The current cleanup candidate is backward-compatible and adds supported public
+testing and protocol surfaces, so its expected version bump is **minor**
+(`0.5.0` → `0.6.0`). Keep the package at the currently published version while
+the candidate remains on `staging`. After promotion, create the version commit
+from a clean `main` checkout and move the populated `Unreleased` changelog
+entries under the dated `0.6.0` heading before publishing.
 
 ## Pre-release Checklist
 

--- a/docs/agents/runs/cleanup-1-9-ledger.md
+++ b/docs/agents/runs/cleanup-1-9-ledger.md
@@ -25,8 +25,8 @@ Complete cleanup items 1–9 from the staging audit end to end, branch by branch
 - Tickets: #131–#139
 - Ticket sessions: created as each ticket starts
 - Agent briefs: Grok 4.5 is the exclusive delegated sidecar; Cursor exposes the highest available tier as `cursor-grok-4.5-high`, which is used for all standards/spec passes
-- Review packets: `issue-131-review-packet.md` through `issue-137-review-packet.md`; created per later ticket
-- Local CodeRabbit report: `issue-131-coderabbit-local.md` through `issue-136-coderabbit-local.md`; created per later ticket
+- Review packets: `issue-131-review-packet.md` through `issue-137-review-packet.md`, plus `issue-139-review-packet.md`; issue #138 keeps its review evidence in `issue-138-session.md`
+- Local CodeRabbit reports: `issue-131-coderabbit-local.md` through `issue-136-coderabbit-local.md`, plus `issue-139-coderabbit-local.md`; issues #137 and #138 keep their CodeRabbit evidence in their review packet and session record respectively
 - PR URL: #140 merged for issue #131; #141 merged for issue #132; #142 merged for issue #133; #143 merged for issue #134; #144 merged for issue #135; #145 merged for issue #136; #146 merged for issue #137; #147 merged for issue #138; #148 merged for issue #139; all were non-draft and targeted `staging`
 
 ## Commands

--- a/docs/agents/runs/feature-cleanup-1-3-ledger.md
+++ b/docs/agents/runs/feature-cleanup-1-3-ledger.md
@@ -9,7 +9,7 @@
 - Feature branch: `feature/cleanup-logging-web-build`
 - Human owner: plebdev
 - Started: 2026-07-11
-- Current status: PR open; checks and review complete
+- Current status: checks and review complete; hosted gates passed; PR #92 merged into `staging`
 - Skill setup status: present and verified
 
 ## Goal
@@ -26,7 +26,7 @@ Implement cleanup items 1–3 from the repository scan end to end:
 - ADRs: none; choices are reversible and follow existing logger/build conventions
 - Prototype source branch, if any: none
 - Spec issue: #88 — https://github.com/AustinKelsay/snstr/issues/88
-- Tickets: #89, #90, #91 — implemented; ready-for-review
+- Tickets: #89, #90, #91 — implemented and merged through PR #92
 - Ticket sessions: `issue-89-session.md`, `issue-90-session.md`, `issue-91-session.md`
 - Agent briefs: not applicable; current orchestrator implemented the slices
 - Review packets: `issue-89-review-packet.md`, `issue-90-review-packet.md`, `issue-91-review-packet.md`

--- a/docs/agents/runs/feature-cleanup-1-8-ledger.md
+++ b/docs/agents/runs/feature-cleanup-1-8-ledger.md
@@ -9,7 +9,7 @@
 - Feature branch: `feature/cleanup-logging-web-build`
 - Human owner: plebdev
 - Started: 2026-07-13
-- Current status: items 1–8 complete locally; final review fixes verified and ready for PR CI refresh
+- Current status: items 1–8 complete; final review fixes and hosted gates passed; PR #92 merged into `staging`
 - Skill setup status: present and verified
 
 ## Goal
@@ -63,7 +63,7 @@ Complete all eight cleanup items from the repository scan end to end, optimizing
 
 | Issue | Fixed point | Worker session | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
-| Items 1–3 (#89–#91) | `staging` | completed prior sessions + final review fixes | `934a2d5`, `1543c6a`, `62ba743`, `d4fb538`, `2f3126e`, `932a787` | pass/pass | lint, typecheck, 879 tests, builds, pack, CI refresh pending |
+| Items 1–3 (#89–#91) | `staging` | completed prior sessions + final review fixes | `934a2d5`, `1543c6a`, `62ba743`, `d4fb538`, `2f3126e`, `932a787` | pass/pass | lint, typecheck, 879 tests, builds, pack; hosted gates passed |
 | Item 4 (#94) | `1334370` | Luna-high worker + orchestrator | `e77c49c` | pass/pass | coverage 66/879; 23 nested indexes measured |
 | Item 5 (#95) | `2f6a6f4` | orchestrator | `3daf6ad` | pass/pass after wording fix | five targeted scripts; integrated 66/879 |
 | Item 6 (#96) | `e77c49c` | orchestrator | `40f01c9` | pass/pass | lockfiles, 56 focused tests, builds, pack |

--- a/docs/agents/runs/feature-cleanup-runtime-debt-ledger.md
+++ b/docs/agents/runs/feature-cleanup-runtime-debt-ledger.md
@@ -9,7 +9,7 @@
 - Feature branch: `feature/cleanup-runtime-debt`
 - Human owner: plebdev
 - Started: 2026-07-14
-- Current status: implementation, integrated verification, and local final review complete; non-draft staging PR #108 open for hosted review
+- Current status: implementation and integrated verification complete; hosted gates passed; PR #108 merged into `staging`
 - Skill setup status: present and verified (`AGENTS.md`, GitHub issue tracker, triage labels, single-context domain docs)
 
 ## Goal

--- a/docs/agents/runs/feature-collapse-event-validation-ledger.md
+++ b/docs/agents/runs/feature-collapse-event-validation-ledger.md
@@ -9,7 +9,7 @@
 - Feature branch: `feature/collapse-event-validation`
 - Human owner: plebdev
 - Started: 2026-07-06T13:30:37Z
-- Current status: PR opened
+- Current status: hosted gates passed; PR #86 merged into `staging`
 - Skill setup status: created `docs/agents/*`; GitHub triage labels confirmed/created
 
 ## Goal

--- a/docs/agents/runs/issue-113-review-packet.md
+++ b/docs/agents/runs/issue-113-review-packet.md
@@ -43,7 +43,7 @@
 - Jest: 74 suites, 1013/1013
 - Bun: 1013/1013
 - Commands, lint, root/examples typechecks, CJS/ESM build, examples build, and pack verification: pass
-- Local CodeRabbit: 4/4 findings fixed; hosted review pending
+- Local CodeRabbit: 4/4 findings fixed; hosted review passed before PR #122 merged into `staging`
 
 ## Known Tooling Limitation
 

--- a/docs/agents/runs/issue-114-session.md
+++ b/docs/agents/runs/issue-114-session.md
@@ -15,7 +15,7 @@
 | Client and service delegate pure protocol work | client delegates URL/response codecs; service delegates request parsing and dispatch |
 | Exhaustive compatible dispatch | `src/nip47/requestDispatcher.ts` plus direct tests |
 | Preserve lifecycle and encryption negotiation | existing public NIP-47 and NIP-44 integration suites |
-| Full verification | post-hosted-review focused 71/71; pre-hosted-review full Jest/Bun 1021/1021; commands, types, builds, pack; hosted rerun pending |
+| Full verification | post-hosted-review focused 71/71; full Jest/Bun 1021/1021; commands, types, builds, pack; hosted CodeRabbit and Bun/Node 16/18/20 checks green |
 
 ## Decisions
 

--- a/docs/agents/runs/issue-131-session.md
+++ b/docs/agents/runs/issue-131-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `f4bda34`
 - Worker session: current Codex orchestrator; Grok 4.5 High standards/spec reviewers
 - Commit: `7ed8433`, `00104cc`, `21b4ad9`, `426c17b`
-- Status: local and hosted review complete; PR #140 open against `staging`; all hosted gates passed for `4ea5fbc`
+- Status: local and hosted review complete; PR #140 merged into `staging` as `cf705f0`; all hosted gates passed
 
 ## Inputs
 
@@ -46,4 +46,4 @@
 
 ## Risks
 
-- No code or hosted-gate risks remain open; `4ea5fbc` is ready to merge into `staging`.
+- No code or hosted-gate risks remained when PR #140 merged into `staging`.

--- a/docs/agents/runs/issue-133-coderabbit-local.md
+++ b/docs/agents/runs/issue-133-coderabbit-local.md
@@ -5,7 +5,7 @@
 - Command: `coderabbit review --agent --type committed --base staging -c AGENTS.md`
 - Reviewed commit: `b238461`
 - Initial result: four major findings
-- Re-review: pending
+- Re-review: complete; hosted follow-up findings were fixed and the final Grok standards/spec pass found no remaining issues
 
 ## Findings and Resolutions
 

--- a/docs/agents/runs/issue-136-review-packet.md
+++ b/docs/agents/runs/issue-136-review-packet.md
@@ -37,7 +37,7 @@ SPEC_STATUS: pass
 SPEC_FINDINGS:
 - all acceptance criteria met; zero remaining findings
 
-CODERABBIT_STATUS: local pass; final hosted rerun pending
+CODERABBIT_STATUS: local and hosted pass; PR #145 merged into `staging`
 CODERABBIT_FINDINGS:
 - initial six issues fixed: envelope schemas, duplicate IDs, validation order, lifecycle serialization, publish deadline, browser-safe process access
 - two follow-up test issues addressed with timeout/cancel coverage and deterministic synthetic keypairs

--- a/docs/agents/runs/issue-136-session.md
+++ b/docs/agents/runs/issue-136-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `ed9fa4a`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
 - Commits: `cf3819b`, `baa2bf2`, `03a6652`, `7b5a7d0`, `2d4fc6f`, `d983bae`, `bc342cd`, `9e029be`, `1c38f2c`
-- Status: PR #145 open; follow-up hosted and local findings fixed; all local gates green; final hosted rerun pending
+- Status: PR #145 merged into `staging` as `8b970e4`; follow-up hosted and local findings fixed; all local and hosted gates green
 
 ## Inputs
 

--- a/docs/agents/runs/issue-137-review-packet.md
+++ b/docs/agents/runs/issue-137-review-packet.md
@@ -38,7 +38,7 @@ SPEC_STATUS: pass
 SPEC_FINDINGS:
 - none; final pinned-Bun Grok follow-up passed standards and spec
 
-CODERABBIT_STATUS: compatibility implementation clean; final wording fix committed, zero-finding retry pending after CLI cooldown
+CODERABBIT_STATUS: clean committed rerun with zero findings; all hosted findings fixed and verified
 CODERABBIT_FINDINGS:
 - major: include Jest-compatible .spec.* files in canonical discovery — fixed with a red/green regression test
 - minor: assert routine and complete coverage wiring — fixed

--- a/docs/agents/runs/issue-137-session.md
+++ b/docs/agents/runs/issue-137-session.md
@@ -6,7 +6,7 @@
 - Fixed point before session: `8b970e4`
 - Worker session: current Codex orchestrator; Grok 4.5 High reviewers
 - Implementation commits: `0de11d9`, `91ffafa`, `295d114`, `d8de419`; supporting review records continue through the current branch HEAD
-- Status: implementation, Grok review, and final local gates green; clean CodeRabbit retry pending after cooldown on PR #146
+- Status: complete; implementation, final Grok review, clean CodeRabbit rerun, local gates, and hosted CI are green; PR #146 merged
 
 ## Inputs
 

--- a/docs/agents/runs/issue-138-session.md
+++ b/docs/agents/runs/issue-138-session.md
@@ -27,7 +27,7 @@ Remove the shared `Nostr` and `Relay` private-shape adapters, rewrite tests arou
 
 ## Status
 
-- Local implementation and review are complete; the non-draft PR to `staging` is pending.
+- Local implementation and review completed; all hosted gates passed and PR #147 merged into `staging` as `3c1e905`.
 
 ## Implementation Result
 


### PR DESCRIPTION
## Summary

- populate the Unreleased changelog for the completed cleanup programs
- align release instructions with the current 0.5.0 package and expected 0.6.0 release
- synchronize stale run-ledger and review statuses with their merged PRs and passing hosted gates

## Verification

- git diff --check
- npm run package-manager:verify
- npm run commands:verify
- npm publish --dry-run (snstr@0.5.0; no publish performed)
- full Jest/Bun routine and slow suites, lint, strict TypeScript, CJS/ESM builds, examples, and package verification passed on this branch before the documentation-only status follow-up
- Grok standards and specification reviews approved the release-prep diff with no findings

## Release hold

This PR only prepares staging. It does not merge staging into main, bump the package version, create a tag or GitHub release, or publish to npm.